### PR TITLE
Add `land flatten` option, which squash merges all prs as single commit.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,7 +99,7 @@ pub enum Cmd {
         prefix: Option<String>,
     },
 
-    /// Land PRs from the bottom of the stack
+    /// Land PRs (merge variants)
     Land {
         /// Base branch to locate the root of the stack
         #[arg(short = 'b', long)]
@@ -109,13 +109,16 @@ pub enum Cmd {
         #[arg(long)]
         prefix: Option<String>,
 
-        /// Land the first N PRs (bottom-up). Use 0 for all
-        #[arg(long, value_name = "N")]
-        until: usize,
-
         /// Print state-changing commands instead of executing
         #[arg(long)]
         dry_run: bool,
+
+        /// Target PR index. For `flatten`, 0 means the top PR. For `per-pr`, 0 means all
+        #[arg(long, value_name = "N")]
+        until: usize,
+
+        #[command(subcommand)]
+        which: Option<LandCmd>,
     },
 
     /// Fix PR base connectivity to match local commit stack
@@ -132,6 +135,14 @@ pub enum Cmd {
         #[arg(long)]
         dry_run: bool,
     },
+}
+
+#[derive(Subcommand, Debug, Clone, Copy)]
+pub enum LandCmd {
+    /// Flatten PRs from the bottom up to N (0 means all): set base to actual base then squash-merge each
+    Flatten,
+    /// Prior behavior: rebase-merge Nth and close previous with comments
+    PerPr,
 }
 
 #[derive(Parser, Debug)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,7 +6,7 @@ pub mod restack;
 pub mod update;
 
 pub use fix_chain::fix_chain;
-pub use land::land_prs_until;
+pub use land::{land_flatten_until, land_per_pr_until};
 pub use list::list_prs_display;
 pub use prep::prep_squash;
 pub use restack::restack_existing;

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 pub struct FileConfig {
     pub base: Option<String>,
     pub prefix: Option<String>,
+    pub land: Option<String>,
 }
 
 fn read_config_file(path: &PathBuf) -> Result<Option<FileConfig>> {
@@ -31,6 +32,9 @@ pub fn load_config() -> Result<FileConfig> {
             if let Some(pfx) = home_cfg.prefix {
                 merged.prefix = Some(pfx);
             }
+            if let Some(mode) = home_cfg.land {
+                merged.land = Some(mode);
+            }
         }
     }
 
@@ -44,6 +48,9 @@ pub fn load_config() -> Result<FileConfig> {
             }
             if repo_cfg.prefix.is_some() {
                 merged.prefix = repo_cfg.prefix;
+            }
+            if repo_cfg.land.is_some() {
+                merged.land = repo_cfg.land;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,12 +133,28 @@ fn main() -> Result<()> {
         crate::cli::Cmd::Land {
             base,
             prefix,
-            until,
             dry_run,
+            until,
+            which,
         } => {
             set_dry_run_env(dry_run, false);
             let (base, prefix) = resolve_base_prefix(&cfg, base, prefix);
-            crate::commands::land_prs_until(&base, &prefix, until, dry_run)?;
+            let mode = which
+                .or(match cfg.land.as_deref() {
+                    Some("per-pr") | Some("perpr") | Some("per_pr") => {
+                        Some(crate::cli::LandCmd::PerPr)
+                    }
+                    _ => Some(crate::cli::LandCmd::Flatten),
+                })
+                .unwrap_or(crate::cli::LandCmd::Flatten);
+            match mode {
+                crate::cli::LandCmd::Flatten => {
+                    crate::commands::land_flatten_until(&base, &prefix, until, dry_run)?
+                }
+                crate::cli::LandCmd::PerPr => {
+                    crate::commands::land_per_pr_until(&base, &prefix, until, dry_run)?
+                }
+            }
         }
         crate::cli::Cmd::FixChain {
             base,


### PR DESCRIPTION
<!-- spr-stack:start -->
**Stack**:
-   #41
-   #40
-   #39
-   #38
-   #37
-   #36
-   #35
- ➡ #34

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->