### PR TITLE
Make spr restack --after all|top|last effectively 'sync' the branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Restack the local stack by rebasing commits after the bottom N PR groups onto th
 
 Options:
 
-- `--after <N|bottom|top|last>`: 'drop' the first N PR groups; rebase the remaining commits onto `--base`
+- `--after <N|bottom|top|last|all>`: 'drop' the first N PR groups; rebase the remaining commits onto `--base`
   - `0` or `bottom`: restack all groups (moves everything after merge-base)
-  - `top` or `last`: skip all PRs
+  - `top` or `last` or `all`: skip all PRs; current branch is synced to the base tip after `git fetch`
  - `--safe`: create a local backup branch at current `HEAD` before rebasing
 
 Behavior:

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
             let (base, _) = resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone());
             let after_num: usize = match after.to_lowercase().as_str() {
                 "bottom" => 0,
-                "top" | "last" => usize::MAX,
+                "top" | "last" | "all" => usize::MAX,
                 s => s.parse::<usize>().map_err(|_| {
                     anyhow::anyhow!(
                         "Invalid value for --after: {} (expected number or bottom|top|last)",


### PR DESCRIPTION
<!-- spr-stack:start -->
**Stack**:
-   #71
- ➡ #70

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->