### PR TITLE
Update the force‑push path in spr update to pass explicit per‑branch leases...

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -253,7 +253,7 @@ pub fn build_from_groups(
             // Fallback to default lease behavior if we couldn't resolve remote SHAs.
             argv.push("--force-with-lease".into());
         } else {
-            argv.extend(force_leases.clone());
+            argv.extend(force_leases);
         }
         argv.extend(force_refspecs.clone());
         let args: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();


### PR DESCRIPTION
Updated the force‑push path in spr update to pass explicit per‑branch leases using the remote SHA we already query, so --force-with-lease no longer depends on your local origin/spr/* tracking refs being fetched. This eliminates the “stale info” failure without needing an extra fetch.

# Problem

Every time I tried `spr update` it failed. The command was `push --force-with-lease <stuff>`. With this change, it works every time.

<!-- spr-stack:start -->
**Stack**:
-   #88
-   #87
-   #86
-   #85
-   #84
- ➡ #83

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->