### PR TITLE
Preserve PR bodies while refreshing stack block

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,14 @@ land: flatten
 # Commit with pr:ignore_tag starts ignore mode until the next pr:<tag>
 ignore_tag: ignore
 
-# Whether `spr update` overwrites PR descriptions from commit messages
-# When false, only the stack block is managed; the rest is preserved
-overwrite_pr_description: true
+# How `spr update` manages PR descriptions from commit messages
+pr_description_mode: overwrite | stack_only
 ```
 
 Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > built-in defaults
-- Built-in defaults: `base = origin/oai-main`, `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `overwrite_pr_description = true`
+- Built-in defaults: `base = origin/oai-main`, `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`
 
 Global flags
 ------------
@@ -103,7 +102,7 @@ Key options:
 
 - `--from <REF>`: commit range upper bound when parsing tags (default `HEAD`) (untested)
 - `--no-pr`: only (re)create branches; skip PR creation/updates (untested)
-- `--update-pr-body`: force PR description rewrites (overrides `overwrite_pr_description`)
+- `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
 - Extent (optional subcommand):
   - `pr --n <N>`: limit to first N PRs from the bottom
   - `commits --n <N>`: limit to first N commits (untested)
@@ -113,7 +112,7 @@ Behavior:
 - Parses `pr:<tag>` markers from `merge-base(base, from)..from` (commits between `pr:ignore` and the next `pr:<tag>` are ignored)
 - Creates/updates per-PR branches and GitHub PRs
 - Updates PR bodies with a visualized stack block and correct `baseRefName`
-  - When `overwrite_pr_description` is false, only the stack block (between markers) is updated; the rest of the body is preserved
+  - When `pr_description_mode` is `stack_only`, only the stack block (between markers) is updated; the rest of the body is preserved
   - May temporarily set existing PR bases to the repo base while pushing, then re-chain them to match the local stack
 
 ### spr restack

--- a/README.md
+++ b/README.md
@@ -67,12 +67,16 @@ land: flatten
 # Tag used to ignore commits between PR groups
 # Commit with pr:ignore_tag starts ignore mode until the next pr:<tag>
 ignore_tag: ignore
+
+# Whether `spr update` overwrites PR descriptions from commit messages
+# When false, only the stack block is managed; the rest is preserved
+overwrite_pr_description: true
 ```
 
 Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > built-in defaults
-- Built-in defaults: `base = origin/oai-main`, `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`
+- Built-in defaults: `base = origin/oai-main`, `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `overwrite_pr_description = true`
 
 Global flags
 ------------
@@ -99,7 +103,7 @@ Key options:
 
 - `--from <REF>`: commit range upper bound when parsing tags (default `HEAD`) (untested)
 - `--no-pr`: only (re)create branches; skip PR creation/updates (untested)
-- `--update-pr-body`: rewrite PR bodies even if content is unchanged
+- `--update-pr-body`: force PR description rewrites (overrides `overwrite_pr_description`)
 - Extent (optional subcommand):
   - `pr --n <N>`: limit to first N PRs from the bottom
   - `commits --n <N>`: limit to first N commits (untested)
@@ -109,6 +113,7 @@ Behavior:
 - Parses `pr:<tag>` markers from `merge-base(base, from)..from` (commits between `pr:ignore` and the next `pr:<tag>` are ignored)
 - Creates/updates per-PR branches and GitHub PRs
 - Updates PR bodies with a visualized stack block and correct `baseRefName`
+  - When `overwrite_pr_description` is false, only the stack block (between markers) is updated; the rest of the body is preserved
   - May temporarily set existing PR bases to the repo base while pushing, then re-chain them to match the local stack
 
 ### spr restack

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ pub enum Cmd {
         #[arg(long)]
         assume_existing_prs: bool,
 
-        /// Rewrite PR descriptions (bodies) even when content would be unchanged
+        /// Force PR description rewrites (overrides overwrite_pr_description config)
         #[arg(long, default_value_t = false)]
         update_pr_body: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,9 +46,9 @@ pub enum Cmd {
         #[arg(long)]
         assume_existing_prs: bool,
 
-        /// Force PR description rewrites (overrides overwrite_pr_description config)
-        #[arg(long, default_value_t = false)]
-        update_pr_body: bool,
+        /// How to manage PR descriptions (overrides pr_description_mode config)
+        #[arg(long, value_enum)]
+        pr_description_mode: Option<crate::config::PrDescriptionMode>,
 
         /// Limit how much to update (optional sub-mode)
         #[command(subcommand)]

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -11,6 +11,7 @@ pub fn prep_squash(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    overwrite_pr_description: bool,
     selection: crate::cli::PrepSelection,
     dry: bool,
 ) -> Result<()> {
@@ -197,9 +198,16 @@ pub fn prep_squash(
         crate::cli::PrepSelection::Exact(i) => (Some(Limit::ByPr(i)), Some(i)),
     };
 
-    // Push updates for the selected scope (do not force PR body rewrite by default)
+    // Push updates for the selected scope (respect PR body overwrite config)
     crate::commands::build_from_tags(
-        base, "HEAD", prefix, ignore_tag, false, dry, false, limit,
+        base,
+        "HEAD",
+        prefix,
+        ignore_tag,
+        false,
+        dry,
+        overwrite_pr_description,
+        limit,
     )?;
 
     // Add a warning to the first PR not included in the push
@@ -208,11 +216,18 @@ pub fn prep_squash(
             let next_branch = format!("{}{}", prefix, groups[next_idx].tag);
             let prs = list_open_prs_for_heads(std::slice::from_ref(&next_branch))?;
             if let Some(pr) = prs.iter().find(|p| p.head == next_branch) {
-                append_warning_to_pr(
-                    pr.number,
-                    "🚨🚨 parent PRs have changed, this PR may show extra diffs from parent PR 🚨🚨",
-                    dry,
-                )?;
+                if overwrite_pr_description {
+                    append_warning_to_pr(
+                        pr.number,
+                        "🚨🚨 parent PRs have changed, this PR may show extra diffs from parent PR 🚨🚨",
+                        dry,
+                    )?;
+                } else {
+                    info!(
+                        "PR description overwrites disabled; skipping warning on PR #{}",
+                        pr.number
+                    );
+                }
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ pub struct FileConfig {
     pub land: Option<String>,
     /// Optional `pr:<tag>` value that starts an ignore block during group parsing.
     pub ignore_tag: Option<String>,
+    /// Whether `spr update` should overwrite PR descriptions from commit messages.
+    pub overwrite_pr_description: Option<bool>,
 }
 
 fn read_config_file(path: &PathBuf) -> Result<Option<FileConfig>> {
@@ -40,6 +42,9 @@ pub fn load_config() -> Result<FileConfig> {
             if let Some(ignore_tag) = home_cfg.ignore_tag {
                 merged.ignore_tag = Some(ignore_tag);
             }
+            if let Some(overwrite_pr_description) = home_cfg.overwrite_pr_description {
+                merged.overwrite_pr_description = Some(overwrite_pr_description);
+            }
         }
     }
 
@@ -59,6 +64,9 @@ pub fn load_config() -> Result<FileConfig> {
             }
             if repo_cfg.ignore_tag.is_some() {
                 merged.ignore_tag = repo_cfg.ignore_tag;
+            }
+            if repo_cfg.overwrite_pr_description.is_some() {
+                merged.overwrite_pr_description = repo_cfg.overwrite_pr_description;
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,39 @@
 use anyhow::Result;
+use clap::ValueEnum;
 use serde::Deserialize;
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+#[value_enum(rename_all = "snake_case")]
+pub enum PrDescriptionMode {
+    /// Overwrite the entire PR body from commit messages + stack block.
+    Overwrite,
+    /// Only update the stack block; preserve the rest of the PR body.
+    StackOnly,
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct FileConfig {
     pub base: Option<String>,
     pub prefix: Option<String>,
     pub land: Option<String>,
     /// Optional `pr:<tag>` value that starts an ignore block during group parsing.
     pub ignore_tag: Option<String>,
-    /// Whether `spr update` should overwrite PR descriptions from commit messages.
-    pub overwrite_pr_description: Option<bool>,
+    /// How `spr update` should manage PR descriptions from commit messages.
+    pub pr_description_mode: Option<PrDescriptionMode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub base: String,
+    pub prefix: String,
+    pub land: String,
+    /// Optional `pr:<tag>` value that starts an ignore block during group parsing.
+    pub ignore_tag: String,
+    /// How `spr update` should manage PR descriptions from commit messages.
+    pub pr_description_mode: PrDescriptionMode,
 }
 
 fn read_config_file(path: &PathBuf) -> Result<Option<FileConfig>> {
@@ -23,28 +45,54 @@ fn read_config_file(path: &PathBuf) -> Result<Option<FileConfig>> {
     Ok(Some(cfg))
 }
 
-pub fn load_config() -> Result<FileConfig> {
+fn default_config() -> Config {
+    let user = std::env::var("USER").unwrap_or_else(|_| "".to_string());
+    Config {
+        base: "origin/oai-main".to_string(),
+        prefix: format!("{}-spr/", user),
+        land: "flatten".to_string(),
+        ignore_tag: "ignore".to_string(),
+        pr_description_mode: PrDescriptionMode::Overwrite,
+    }
+}
+
+fn apply_overrides(config: &Config, overrides: FileConfig) -> Config {
+    let mut merged = config.clone();
+    if let Some(base) = overrides.base {
+        merged.base = base;
+    }
+    if let Some(prefix) = overrides.prefix {
+        merged.prefix = prefix;
+    }
+    if let Some(land) = overrides.land {
+        merged.land = land;
+    }
+    if let Some(ignore_tag) = overrides.ignore_tag {
+        merged.ignore_tag = ignore_tag;
+    }
+    if let Some(pr_description_mode) = overrides.pr_description_mode {
+        merged.pr_description_mode = pr_description_mode;
+    }
+    merged
+}
+
+fn normalize_config(config: &mut Config) {
+    let mut prefix = config.prefix.trim_end_matches('/').to_string();
+    prefix.push('/');
+    config.prefix = prefix;
+    if config.ignore_tag.trim().is_empty() {
+        config.ignore_tag = "ignore".to_string();
+    }
+}
+
+pub fn load_config() -> Result<Config> {
     // Home config
-    let mut merged = FileConfig::default();
+    let mut merged = default_config();
     if let Some(home) = std::env::var_os("HOME") {
         let mut p = PathBuf::from(home);
         p.push(".spr_multicommit_cfg.yml");
         if let Some(home_cfg) = read_config_file(&p)? {
-            if let Some(b) = home_cfg.base {
-                merged.base = Some(b);
-            }
-            if let Some(pfx) = home_cfg.prefix {
-                merged.prefix = Some(pfx);
-            }
-            if let Some(mode) = home_cfg.land {
-                merged.land = Some(mode);
-            }
-            if let Some(ignore_tag) = home_cfg.ignore_tag {
-                merged.ignore_tag = Some(ignore_tag);
-            }
-            if let Some(overwrite_pr_description) = home_cfg.overwrite_pr_description {
-                merged.overwrite_pr_description = Some(overwrite_pr_description);
-            }
+            merged = apply_overrides(&merged, home_cfg);
         }
     }
 
@@ -53,23 +101,10 @@ pub fn load_config() -> Result<FileConfig> {
         let mut p = PathBuf::from(root);
         p.push(".spr_multicommit_cfg.yml");
         if let Some(repo_cfg) = read_config_file(&p)? {
-            if repo_cfg.base.is_some() {
-                merged.base = repo_cfg.base;
-            }
-            if repo_cfg.prefix.is_some() {
-                merged.prefix = repo_cfg.prefix;
-            }
-            if repo_cfg.land.is_some() {
-                merged.land = repo_cfg.land;
-            }
-            if repo_cfg.ignore_tag.is_some() {
-                merged.ignore_tag = repo_cfg.ignore_tag;
-            }
-            if repo_cfg.overwrite_pr_description.is_some() {
-                merged.overwrite_pr_description = repo_cfg.overwrite_pr_description;
-            }
+            merged = apply_overrides(&merged, repo_cfg);
         }
     }
 
+    normalize_config(&mut merged);
     Ok(merged)
 }


### PR DESCRIPTION
When overwrite_pr_description is false, spr update now rewrites only the managed stack block between markers, leaving the rest of the PR description untouched. Stack blocks are replaced if present or appended if missing; base refs still update as before.

Full overwrites remain the default and --update-pr-body still forces them. Docs updated to clarify stack-only behavior.

<!-- spr-stack:start -->
**Stack**:
-   #89
-   #88
-   #87
-   #86
-   #85
- ➡ #84

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->