### PR TITLE
allow origin's default branch to be discovered

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ spr reads configuration from YAML in two locations (repo overrides home):
 Supported keys:
 
 ```yaml
-# Default base branch used when not provided via CLI
-base: origin/oai-main  # example; use your repo's default (e.g., main)
+# Base branch used as the root of the stack
+# If omitted, spr discovers origin/HEAD and errors if discovery fails
+base: origin/main
 
 # Branch prefix used for per-PR branches
 # Trailing slashes are normalized to exactly one
@@ -77,8 +78,9 @@ restack_conflict: rollback
 
 Precedence for defaults:
 
-- CLI flag > repo YAML > home YAML > built-in defaults
-- Built-in defaults: `base = origin/oai-main`, `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `restack_conflict = rollback`
+- CLI flag > repo YAML > home YAML > git discovery (`origin/HEAD`)
+- Base has no built-in fallback; if discovery fails, set `base` explicitly
+- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `restack_conflict = rollback`
 
 Global flags
 ------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,11 @@ impl Default for RestackConflictPolicy {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct FileConfig {
+    /// Root base branch for the stack, e.g. `origin/main`.
+    ///
+    /// When this is `None` and the CLI does not supply `--base`, the caller
+    /// attempts to discover the base via `origin/HEAD` and will error loudly if
+    /// discovery fails.
     pub base: Option<String>,
     pub prefix: Option<String>,
     pub land: Option<String>,
@@ -79,7 +84,7 @@ fn read_config_file(path: &PathBuf) -> Result<Option<FileConfig>> {
 fn default_config() -> Config {
     let user = std::env::var("USER").unwrap_or_else(|_| "".to_string());
     Config {
-        base: "origin/oai-main".to_string(),
+        base: String::new(),
         prefix: format!("{}-spr/", user),
         land: "flatten".to_string(),
         ignore_tag: "ignore".to_string(),


### PR DESCRIPTION
# Problem

spr previously had a hardcoded base fallback, but we can do better

  ## Mental model

  Base resolution is now strict and explicit:

  1. Use CLI --base when provided.
  2. Otherwise use merged config base.
  3. Otherwise discover the default via git symbolic-ref --short refs/remotes/origin/HEAD.
  4. If discovery fails or is empty, error loudly with an actionable message.

  ## Non-goals

  - No change to prefix/land/ignore-tag defaults.
  - No attempt to support non-origin remotes in discovery.
  - No behavioral refactors beyond base resolution.

  ## Tradeoffs

  Failing loudly may break repos where origin/HEAD is unset, but it prevents silent mis-targeting and pushes users toward explicit configuration.

  ## Architecture

  - Added a single discovery helper in the git module.
  - Made base resolution return Result so discovery failures surface cleanly.
  - Documented the new contract at module/type/function and README levels.

<!-- spr-stack:start -->
**Stack**:
-   #89
- ➡ #88

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->