### PR TITLE
Add configurable list order for stack output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ ignore_tag: ignore
 # How `spr update` manages PR descriptions from commit messages
 pr_description_mode: overwrite | stack_only
 
+# Order for printing PR/commit lists
+# one of: "recent_on_bottom" (default) or "recent_on_top"
+list_order: recent_on_bottom
+
 # How `spr restack` behaves on cherry-pick conflicts: "rollback" (default) or "halt"
 restack_conflict: rollback
 ```
@@ -80,7 +84,7 @@ Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > git discovery (`origin/HEAD`)
 - Base has no built-in fallback; if discovery fails, set `base` explicitly
-- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `restack_conflict = rollback`
+- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `restack_conflict = rollback`
 
 Global flags
 ------------
@@ -146,7 +150,7 @@ Behavior:
 
 ### spr list pr
 
-Lists PRs in the current stack (bottom → top) for the configured prefix.
+Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top.
 
 Aliases:
 
@@ -164,7 +168,7 @@ Alias for `spr list pr`.
 
 ### spr list commit
 
-Lists commits in the current stack (bottom → top), grouped by local PR. Each group header shows the local PR number and branch (and remote PR number when available). Within each group, each line shows the bottom-up commit index (1-based) and the short SHA.
+Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top.
 
 Aliases:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,10 +17,10 @@ pub enum PrepSelection {
 
 #[derive(Subcommand, Debug, Clone, Copy)]
 pub enum ListWhat {
-    /// List PRs in the stack (bottom-up)
+    /// List PRs in the stack (order via list_order config)
     #[command(alias = "p")]
     Pr,
-    /// List commits in the stack (bottom-up)
+    /// List commits in the stack (order via list_order config)
     #[command(alias = "c")]
     Commit,
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,10 +1,30 @@
+//! Display helpers for `spr list` output.
+//!
+//! The local stack order is derived bottom-up from commits and is the source of truth for
+//! local PR numbers and commit indices. `ListOrder` only affects which groups or commits
+//! are shown first; it does not change the underlying numbering.
+
 use anyhow::Result;
 use tracing::info;
 
+use crate::config::ListOrder;
 use crate::github::{fetch_pr_ci_review_status, list_open_prs_for_heads};
 use crate::parsing::derive_local_groups;
 
-pub fn list_prs_display(base: &str, prefix: &str, ignore_tag: &str) -> Result<()> {
+/// Print a per-PR summary for the current local stack.
+///
+/// The local stack order is derived bottom-up from commits, so local PR numbers are based
+/// on that ordering even when `list_order` reverses the display. If a caller assumes the
+/// first printed line is "LPR #1" in display order, the labels will be wrong under
+/// `RecentOnTop`.
+///
+/// Errors are returned when local groups or GitHub metadata cannot be loaded.
+pub fn list_prs_display(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    list_order: ListOrder,
+) -> Result<()> {
     // Derive stack from local commits (source of truth)
     let (_merge_base, groups) = derive_local_groups(base, ignore_tag)?;
     if groups.is_empty() {
@@ -32,7 +52,9 @@ pub fn list_prs_display(base: &str, prefix: &str, ignore_tag: &str) -> Result<()
     info!("┏━━{}CI status", crate::format::EM_SPACE);
     info!("┃┏━{}review status", crate::format::EM_SPACE);
 
-    for (i, g) in groups.iter().enumerate() {
+    let display_indices = list_order.display_indices(groups.len());
+    for group_idx in display_indices {
+        let g = &groups[group_idx];
         let head_branch = format!("{}{}", prefix, g.tag);
         let num = prs.iter().find(|p| p.head == head_branch).map(|p| p.number);
         let count = g.commits.len();
@@ -69,18 +91,28 @@ pub fn list_prs_display(base: &str, prefix: &str, ignore_tag: &str) -> Result<()
         } else {
             ("?", "?")
         };
+        let local_pr_num = group_idx + 1;
         info!(
             "{}{} LPR #{} - {} : {}{} - {} {}",
             ci_icon,
             rv_icon,
-            i + 1,
+            local_pr_num,
             short,
             head_branch,
             remote_pr_num_str,
             count,
             plural
         );
-        let first_subject = g.subjects.first().map(|s| s.as_str()).unwrap_or("");
+        let subject_idx = if list_order == ListOrder::RecentOnTop {
+            g.subjects.len().saturating_sub(1)
+        } else {
+            0
+        };
+        let first_subject = g
+            .subjects
+            .get(subject_idx)
+            .map(|s| s.as_str())
+            .unwrap_or("");
         info!(
             "{s}{s}{s}{s}{s}{subject}",
             s = crate::format::EM_SPACE,
@@ -90,7 +122,20 @@ pub fn list_prs_display(base: &str, prefix: &str, ignore_tag: &str) -> Result<()
     Ok(())
 }
 
-pub fn list_commits_display(base: &str, prefix: &str, ignore_tag: &str) -> Result<()> {
+/// Print commits grouped by local PR, keeping commit indices in bottom-up order.
+///
+/// The commit indices are global and tied to the local stack ordering. When `list_order`
+/// is `RecentOnTop`, commits are shown newest-first but their indices still count from the
+/// bottom. If a caller treats the visible order as the numbering order, the output will
+/// look inconsistent to users.
+///
+/// Errors are returned when local groups or PR metadata cannot be loaded.
+pub fn list_commits_display(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    list_order: ListOrder,
+) -> Result<()> {
     // Derive stack from local commits (source of truth)
     let (_merge_base, groups) = derive_local_groups(base, ignore_tag)?;
     if groups.is_empty() {
@@ -105,8 +150,17 @@ pub fn list_commits_display(base: &str, prefix: &str, ignore_tag: &str) -> Resul
         .collect();
     let prs = list_open_prs_for_heads(&heads)?; // may be empty; that's fine
 
-    let mut commit_counter: usize = 0; // global, bottom-up
-    for (i, g) in groups.iter().enumerate() {
+    // Precompute global commit numbering in bottom-up stack order.
+    let mut group_start_idx: Vec<usize> = Vec::with_capacity(groups.len());
+    let mut commit_counter: usize = 1; // 1-based, bottom-up
+    for g in &groups {
+        group_start_idx.push(commit_counter);
+        commit_counter += g.commits.len();
+    }
+
+    let display_indices = list_order.display_indices(groups.len());
+    for group_idx in display_indices {
+        let g = &groups[group_idx];
         let head_branch = format!("{}{}", prefix, g.tag);
         let num = prs.iter().find(|p| p.head == head_branch).map(|p| p.number);
         let remote_pr_num_str = match num {
@@ -117,16 +171,23 @@ pub fn list_commits_display(base: &str, prefix: &str, ignore_tag: &str) -> Resul
         // Group separator with local PR number
         info!(
             "===== Local PR #{}{} : {} =====",
-            i + 1,
+            group_idx + 1,
             remote_pr_num_str,
             head_branch
         );
 
-        for (j, sha) in g.commits.iter().enumerate() {
-            commit_counter += 1;
+        let start_idx = group_start_idx[group_idx];
+        let commit_indices: Vec<usize> = if list_order == ListOrder::RecentOnTop {
+            (0..g.commits.len()).rev().collect()
+        } else {
+            (0..g.commits.len()).collect()
+        };
+        for j in commit_indices {
+            let sha = &g.commits[j];
+            let commit_idx = start_idx + j;
             let short = if sha.len() >= 8 { &sha[..8] } else { sha };
             let subject = g.subjects.get(j).map(|s| s.as_str()).unwrap_or("");
-            info!("{:>4}  {} - {}", commit_counter, short, subject);
+            info!("{:>4}  {} - {}", commit_idx, short, subject);
         }
         // Blank line between groups for readability
         info!("");

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -7,11 +7,15 @@ use crate::limit::Limit;
 use crate::parsing::derive_local_groups;
 
 /// Squash PRs according to selection; operate locally then run update for the affected groups.
+///
+/// `list_order` is forwarded to the update step so progress output and PR lists use the
+/// same display order as `spr list`.
 pub fn prep_squash(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
     pr_description_mode: crate::config::PrDescriptionMode,
+    list_order: crate::config::ListOrder,
     selection: crate::cli::PrepSelection,
     dry: bool,
 ) -> Result<()> {
@@ -208,6 +212,7 @@ pub fn prep_squash(
         dry,
         pr_description_mode,
         limit,
+        list_order,
     )?;
 
     // Add a warning to the first PR not included in the push

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,6 @@ pub enum ListOrder {
     RecentOnBottom,
 }
 
-impl Default for ListOrder {
-    fn default() -> Self {
-        Self::RecentOnBottom
-    }
-}
-
 impl ListOrder {
     /// Return 0-based group indices in the configured display order.
     ///
@@ -130,7 +124,7 @@ fn default_config() -> Config {
         land: "flatten".to_string(),
         ignore_tag: "ignore".to_string(),
         pr_description_mode: PrDescriptionMode::Overwrite,
-        list_order: ListOrder::RecentOnBottom,
+        list_order: ListOrder::RecentOnTop,
         restack_conflict: RestackConflictPolicy::Rollback,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> Result<()> {
         resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone())?;
     let pr_description_mode = cfg.pr_description_mode;
     let restack_conflict_policy = cfg.restack_conflict;
+    let list_order = cfg.list_order;
     match cli.cmd {
         crate::cli::Cmd::Update {
             from,
@@ -121,6 +122,7 @@ fn main() -> Result<()> {
                     pr_description_mode,
                     limit,
                     groups,
+                    list_order,
                 )?;
             }
         }
@@ -166,6 +168,7 @@ fn main() -> Result<()> {
                 &prefix,
                 &ignore_tag,
                 pr_description_mode,
+                list_order,
                 selection,
                 cli.dry_run,
             )?;
@@ -173,16 +176,16 @@ fn main() -> Result<()> {
         crate::cli::Cmd::List { what } => {
             match what {
                 crate::cli::ListWhat::Pr => {
-                    crate::commands::list_prs_display(&base, &prefix, &ignore_tag)?
+                    crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?
                 }
                 crate::cli::ListWhat::Commit => {
-                    crate::commands::list_commits_display(&base, &prefix, &ignore_tag)?
+                    crate::commands::list_commits_display(&base, &prefix, &ignore_tag, list_order)?
                 }
             }
         }
         crate::cli::Cmd::Status {} => {
             // alias for `spr list pr`
-            crate::commands::list_prs_display(&base, &prefix, &ignore_tag)?
+            crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?
         }
         crate::cli::Cmd::Land {
             which,


### PR DESCRIPTION
# Problem
The list output always prints oldest commit/PR on top. This does not match git conventions (e.g. git log shows most recent commit on top). It does not match the stack block stanza that this tool adds to PR descriptions. It does not match a description of a physical-world stack, where the most recently placed item is on top.

We need a config-only way to change display order while keeping the underlying stack numbering stable.

# Mental model
The local stack order (bottom-up) remains the source of truth for local PR numbers and commit indices. A new `list_order` config controls only the presentation order of groups/commits and the progress/list output during updates.

# Non-goals
- No new CLI flags; configuration is YAML-only for now.
- No changes to how stacks are parsed, numbered, or chained.
- No behavioral changes to update/land/restack beyond display/progress ordering.

# Tradeoffs
- Reversing display order means local PR numbers and commit indices appear non-monotonic from top to bottom.
- Additional configuration surface area with limited validation (enum deserialization).

# Architecture
- Introduce `ListOrder` in config with a default of `recent_on_bottom`.
- Load `list_order` from home/repo config and pass it through main into list, update, and prep flows.
- List rendering uses `display_indices` to order groups/commits while preserving bottom-up numbering.

# Observability
- `spr list pr` and `spr list commit` now show ordering per `list_order`; local numbering remains bottom-up.
- `spr update` progress logs and the final printed PR list follow the same display order.

# Tests
- None added; behavior can be verified by toggling `list_order` and comparing list/update output.

<!-- spr-stack:start -->
**Stack**:
- ➡ #91

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->