### PR TITLE
change --safe checkpoints to tags for rewrite recovery (were branches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Options:
 - `--after <N|bottom|top|last|all>`: 'drop' the first N PR groups; rebase the remaining commits onto `--base`
   - `0` or `bottom`: restack all groups (moves everything after merge-base)
   - `top` or `last` or `all`: skip all PRs; ignored commits (pr:ignore blocks) are preserved, so the branch may remain ahead of base
-- `--safe`: create a local backup branch at current `HEAD` before rebasing
+- `--safe`: create a local backup tag at current `HEAD` before rebasing
 
 Behavior:
 
@@ -142,7 +142,7 @@ Behavior:
   - Ignored commits attached to dropped groups are kept before the remaining stack
   - Ignored commits attached to kept groups move with those groups
 - Updates the current branch to the rebuilt tip
-- With `--safe`, a backup branch named like `backup/restack/<current-branch>-<short-sha>` is created first
+- With `--safe`, a backup tag named like `backup/restack/<current-branch>-<short-sha>` is created first
 - Conflict handling is controlled by `restack_conflict` in config.
 - `rollback` (default) aborts the restack and attempts to clean up the temp restack worktree and branch (cleanup failures may require manual cleanup).
 - `halt` stops on conflict, leaves the temp restack worktree and branch in place, and prints manual rollback/continue instructions.
@@ -190,7 +190,7 @@ Aliases:
 - `spr move A..B --after C`: move PRs A..B to come after PR C (requires A < B and C ∉ [A..B]; C ∈ [0..N])
   - `--after bottom` is the same as `--after 0`
   - `--after top` is the same as `--after N`
-- `--safe`: create a local backup branch at current `HEAD` before rewriting
+- `--safe`: create a local backup tag at current `HEAD` before rewriting
  - Ignore blocks (`pr:ignore`) stay attached to the preceding PR group and move with it
 
 Prints an explicit plan, e.g.: `2..3→4: [1,2,3,4,5,6] → [1,4,2,3,5,6]`.
@@ -267,7 +267,7 @@ spr fix-pr 1 --tail 2
 Behavior:
 
 - Rewrites local history to move the tail M commits after PR N’s tail commit
-- `--safe`: create a local backup branch at current `HEAD` before executing
+- `--safe`: create a local backup tag at current `HEAD` before executing
 - Ignore blocks (`pr:ignore`) are preserved and cannot be moved; the command aborts if the tail intersects an ignore block
 
 ### spr cleanup
@@ -335,7 +335,7 @@ spr restack --after 0
 # Restack everything above the first 2 PRs ('drops' the first 2 PRs)
 spr restack --after 2
 
-# Restack safely (creates a backup branch before rebase)
+# Restack safely (creates a backup tag before rebase)
 spr restack --after 2 --safe
 
 # Land top PR only using config default mode (flatten by default)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,7 @@ pub enum Cmd {
         #[arg(long, value_name = "N|bottom|top|last")]
         after: String,
 
-        /// Create a local backup branch at current HEAD before rebasing
+        /// Create a local backup tag at current HEAD before rebasing
         #[arg(long)]
         safe: bool,
     },
@@ -116,7 +116,7 @@ pub enum Cmd {
         /// Number of top commits to move to PR N's tail
         #[arg(short = 't', long = "tail", default_value_t = 1)]
         tail: usize,
-        /// Create a local backup branch at current HEAD before rewriting
+        /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
     },
@@ -129,7 +129,7 @@ pub enum Cmd {
         /// Target PR position to come after: number (0..=N), or one of: bottom, top. Must not be in [A..B]
         #[arg(long, value_name = "C|bottom|top")]
         after: String,
-        /// Create a local backup branch at current HEAD before rewriting
+        /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
     },

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -4,11 +4,11 @@
 //! `fix-pr`: naming temporary branches/worktrees, creating safety backups, and
 //! resetting the current branch to a rebuilt tip.
 //!
-//! A subtle but important invariant is that backup branch names include the
+//! A subtle but important invariant is that backup tag names include the
 //! short SHA of `HEAD`. When a rewrite command fails before `HEAD` changes, a
-//! second attempt would otherwise try to create the same backup branch again
-//! and fail with "branch already exists". To keep `--safe` re-runnable after a
-//! failure, `create_backup_branch` force-updates the backup ref in place.
+//! second attempt would otherwise try to create the same backup tag again and
+//! fail with "tag already exists". To keep `--safe` re-runnable after a
+//! failure, `create_backup_tag` force-updates the backup ref in place.
 //!
 //! Temporary worktrees and their branches follow the same naming scheme. A
 //! failed rewrite can therefore leave behind a temp branch that will collide
@@ -17,8 +17,8 @@
 //! and uses `git worktree add -B` as a final safeguard when cleanup is skipped
 //! in dry-run mode.
 //!
-//! Backup branches are local-only and are intended as an escape hatch for a
-//! single user; callers should not rely on them being immutable.
+//! Backup tags are local-only and are intended as an escape hatch for a single
+//! user; callers should not rely on them being immutable.
 
 use anyhow::{Context, Result};
 use std::collections::HashSet;
@@ -32,7 +32,7 @@ use crate::parsing::Group;
 /// Returns the current branch name and the short SHA of `HEAD`.
 ///
 /// This is primarily used to derive stable, human-readable names for backup
-/// branches and temporary worktree branches. If `HEAD` is detached, the branch
+/// tags and temporary worktree branches. If `HEAD` is detached, the branch
 /// component will be reported as `HEAD`, which can lead to less useful backup
 /// names.
 pub fn get_current_branch_and_short() -> Result<(String, String)> {
@@ -45,32 +45,27 @@ pub fn get_current_branch_and_short() -> Result<(String, String)> {
     Ok((cur_branch, short))
 }
 
-/// Creates or updates a local backup branch pointing at the current `HEAD`.
+/// Creates or updates a local backup tag pointing at the current `HEAD`.
 ///
 /// The backup name is derived from `(kind, cur_branch, short)` and is therefore
 /// stable for a given `HEAD`. This stability is desirable for operator clarity,
 /// but it means repeat runs at the same `HEAD` will collide. We force-update
-/// the branch (`git branch -f`) so that `spr restack --safe` remains runnable
-/// after a failed attempt that left the backup branch behind.
+/// the tag (`git tag -f`) so that `spr restack --safe` remains runnable after a
+/// failed attempt that left the backup tag behind.
 ///
-/// The existence check is only used to drive the log message; the branch is
+/// The existence check is only used to drive the log message; the tag is
 /// always updated to point at `HEAD`.
-pub fn create_backup_branch(
-    dry: bool,
-    kind: &str,
-    cur_branch: &str,
-    short: &str,
-) -> Result<String> {
+pub fn create_backup_tag(dry: bool, kind: &str, cur_branch: &str, short: &str) -> Result<String> {
     let backup = format!("backup/{}/{}-{}", kind, cur_branch, short);
-    let exists = git_ro(["branch", "--list", &backup].as_slice())?;
+    let exists = git_ro(["tag", "--list", &backup].as_slice())?;
     if exists.trim().is_empty() {
-        info!("Creating backup branch at HEAD: {}", backup);
+        info!("Creating backup tag at HEAD: {}", backup);
     } else {
-        info!("Backup branch exists; overwriting at HEAD: {}", backup);
+        info!("Backup tag exists; overwriting at HEAD: {}", backup);
     }
     // Use `-f` to make backup creation idempotent. When the name already
     // exists, we explicitly move it to the current HEAD.
-    let _ = git_rw(dry, ["branch", "-f", &backup, "HEAD"].as_slice())?;
+    let _ = git_rw(dry, ["tag", "-f", &backup, "HEAD"].as_slice())?;
     Ok(backup)
 }
 
@@ -260,7 +255,7 @@ pub fn build_head_base_chain(base: &str, groups: &[Group], prefix: &str) -> Vec<
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_temp_worktree, create_backup_branch, create_temp_worktree,
+        cleanup_temp_worktree, create_backup_tag, create_temp_worktree,
         get_current_branch_and_short,
     };
     use std::env;
@@ -321,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn create_backup_branch_overwrites_existing() {
+    fn create_backup_tag_overwrites_existing() {
         let _lock = CWD_LOCK.lock().expect("lock cwd");
         let dir = init_repo();
         let repo = dir.path().to_path_buf();
@@ -331,15 +326,21 @@ mod tests {
             get_current_branch_and_short().expect("get current branch and short sha");
 
         let backup =
-            create_backup_branch(false, "restack", &cur_branch, &short).expect("create backup");
+            create_backup_tag(false, "restack", &cur_branch, &short).expect("create backup");
         let backup_again =
-            create_backup_branch(false, "restack", &cur_branch, &short).expect("overwrite backup");
+            create_backup_tag(false, "restack", &cur_branch, &short).expect("overwrite backup");
 
         assert_eq!(backup, backup_again, "backup name should be stable");
 
         let head = git(&repo, ["rev-parse", "HEAD"].as_slice());
-        let backup_head = git(&repo, ["rev-parse", backup.as_str()].as_slice());
+        let backup_ref = format!("refs/tags/{}", backup);
+        let backup_head = git(&repo, ["rev-parse", backup_ref.as_str()].as_slice());
         assert_eq!(head.trim(), backup_head.trim(), "backup should match HEAD");
+        let branch_out = git(&repo, ["branch", "--list", backup.as_str()].as_slice());
+        assert!(
+            branch_out.trim().is_empty(),
+            "backup should be a tag, not a branch"
+        );
     }
 
     #[test]

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -134,10 +134,10 @@ pub fn fix_pr_tail(
         new_order.extend(all_commits[insert_pos + 1..].iter().cloned());
     }
 
-    // Optionally create a backup branch at current HEAD (safety)
+    // Optionally create a backup tag at current HEAD (safety)
     let (cur_branch, short) = common::get_current_branch_and_short()?;
     if safe {
-        let _ = common::create_backup_branch(dry, "fix-pr", &cur_branch, &short)?;
+        let _ = common::create_backup_tag(dry, "fix-pr", &cur_branch, &short)?;
     }
 
     // Build the new history in a temporary worktree off merge-base

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -153,10 +153,10 @@ pub fn move_groups_after(
         return Ok(());
     }
 
-    // Optionally create a backup branch at current HEAD
+    // Optionally create a backup tag at current HEAD
     let (cur_branch, short) = common::get_current_branch_and_short()?;
     if safe {
-        let _ = common::create_backup_branch(dry, "move", &cur_branch, &short)?;
+        let _ = common::create_backup_tag(dry, "move", &cur_branch, &short)?;
     }
 
     // Build the new history in a temporary worktree off merge-base

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -147,7 +147,7 @@ fn build_cherry_pick_plan(kept_ignored: &[String], remaining: &[Group]) -> Vec<C
 /// not affect the halted cherry-pick sequence.
 fn emit_halt_instructions(
     cur_branch: &str,
-    backup_branch: Option<&str>,
+    backup_tag: Option<&str>,
     base: &str,
     tmp_path: &str,
     tmp_branch: &str,
@@ -166,9 +166,9 @@ fn emit_halt_instructions(
     info!("  git worktree remove -f {}", tmp_path);
     info!("  git branch -D {}", tmp_branch);
     info!("  git checkout {}", cur_branch);
-    if let Some(backup) = backup_branch {
-        info!("  # Optional: restore the backup created by --safe");
-        info!("  git checkout {}", backup);
+    if let Some(backup) = backup_tag {
+        info!("  # Optional: restore the --safe backup tag onto your current branch");
+        info!("  git reset --hard refs/tags/{}", backup);
     }
 
     info!("To resolve and continue the restack manually:");
@@ -240,7 +240,7 @@ pub fn restack_after(
     if remaining.is_empty() && kept_ignored.is_empty() {
         // Nothing to move; sync current branch to base
         if safe {
-            let _ = common::create_backup_branch(dry, "restack", &cur_branch, &short)?;
+            let _ = common::create_backup_tag(dry, "restack", &cur_branch, &short)?;
         }
         info!(
             "Skipping all {} PR(s); syncing current branch {} to {}",
@@ -252,9 +252,9 @@ pub fn restack_after(
         return Ok(());
     }
 
-    // Create a local backup branch pointing to current HEAD before rewriting
-    let backup_branch = if safe {
-        Some(common::create_backup_branch(
+    // Create a local backup tag pointing to current HEAD before rewriting
+    let backup_tag = if safe {
+        Some(common::create_backup_tag(
             dry,
             "restack",
             &cur_branch,
@@ -272,7 +272,7 @@ pub fn restack_after(
             if conflict && conflict_policy == RestackConflictPolicy::Halt {
                 emit_halt_instructions(
                     &cur_branch,
-                    backup_branch.as_deref(),
+                    backup_tag.as_deref(),
                     base,
                     &tmp_path,
                     &tmp_branch,


### PR DESCRIPTION
Tag name pattern (the pattern is unchanged, but restating it here) is:

`  backup/<kind>/<current-branch>-<short-head-sha>`

  So today with --safe:

  - restack uses kind = restack
  - move uses kind = move
  - fix-pr uses kind = fix-pr

# Problem Solved
- `--safe` in `restack`, `move`, and `fix-pr` previously created `backup/...` branches.
- These refs are safety checkpoints/snapshots, not active integration lines.
- Branch semantics implied ongoing workflow and cluttered branch-oriented listings.

# Mental model
- Treat `backup/<kind>/<current-branch>-<short-sha>` as a local bookmark of pre-rewrite `HEAD`.
- The name stays stable for the same `HEAD`, and reruns force-update the same tag for idempotency.
- Recovery means resetting your current branch to `refs/tags/<backup-tag>`.

# Non-goals
- Do not change remote PR branch creation or update behavior.
- Do not change temporary worktree branch lifecycle.
- Do not make backup refs immutable archives; they remain force-updatable local safety refs.

# Tradeoffs
- Force-updating tags keeps `--safe` rerunnable but intentionally does not preserve previous points for the same name.
- Users who looked for backups under branch listings must now inspect tags instead.
- The change removes semantic ambiguity between "checkpoint" and "work branch".

# Architecture
- Replace `create_backup_branch` with `create_backup_tag` and switch from `git branch -f` to `git tag -f`.
- Update safe rewrite call sites in `restack`, `move`, and `fix-pr` to use the shared tag helper.
- Update halt-path recovery instructions to reset from `refs/tags/<tag>`.
- Keep backup naming unchanged so operator-facing identifiers remain familiar.
- Update unit coverage to assert backup refs resolve via `refs/tags/*` and are not local branches.

# Observability
- Logs now explicitly state "Creating backup tag..." or "Backup tag exists; overwriting...".
- Halt instructions show the exact restore command using the tag ref path.

# Tests
- Test scope: existing unit tests touched by this change boundary.
- `commands::common::tests::create_backup_tag_overwrites_existing` verifies the backup ref points to `HEAD` as a tag and is absent from branch listings.
- Full validation run for this change set: `cargo fmt`, `cargo clippy`, and `cargo test`.

<!-- spr-stack:start -->
**Stack**:
- ➡ #100

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->