### PR TITLE
update: block recent branch reuse after closed or merged PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +340,12 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -485,6 +506,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "time",
  "tracing",
  "tracing-subscriber",
 ]
@@ -526,6 +548,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 indicatif = "0.17"
+time = { version = "0.3", features = ["parsing"] }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ list_order: recent_on_bottom
 
 # How `spr restack` behaves on cherry-pick conflicts: "rollback" (default) or "halt"
 restack_conflict: rollback
+
+# Blocks PR recreation when the same head branch had a recently merged
+# or closed PR within the configured window. Set to 0 to disable the guard.
+branch_reuse_guard_days: 180
 ```
 
 Precedence for defaults:
@@ -112,6 +116,7 @@ Key options:
 - `--from <REF>`: commit range upper bound when parsing tags (default `HEAD`) (untested)
 - `--no-pr`: only (re)create branches; skip PR creation/updates (untested)
 - `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
+- `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
 - Extent (optional subcommand):
   - `pr --n <N>`: limit to first N PRs from the bottom
   - `commits --n <N>`: limit to first N commits (untested)
@@ -120,6 +125,8 @@ Behavior:
 
 - Parses `pr:<tag>` markers from `merge-base(base, from)..from` (commits between `pr:ignore` and the next `pr:<tag>` are ignored)
 - Creates/updates per-PR branches and GitHub PRs
+- Before creating a PR for a branch head without an open PR, checks whether the same branch name
+  had a recently merged or closed PR and halts within `branch_reuse_guard_days`
 - Updates PR bodies with a visualized stack block and correct `baseRefName`
   - When `pr_description_mode` is `stack_only`, only the stack block (between markers) is updated; the rest of the body is preserved
   - May temporarily set existing PR bases to the repo base while pushing, then re-chain them to match the local stack

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,11 @@ pub enum Cmd {
         #[arg(long, value_enum)]
         pr_description_mode: Option<crate::config::PrDescriptionMode>,
 
+        /// Bypass the recent branch-name reuse guard and allow creating a new PR even when the
+        /// same branch name had a recently closed or merged PR.
+        #[arg(long)]
+        allow_branch_reuse: bool,
+
         /// Limit how much to update (optional sub-mode)
         #[command(subcommand)]
         extent: Option<Extent>,

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,7 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashMap;
 use std::time::Duration;
+use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tracing::info;
 
 use crate::commands::common;
@@ -9,7 +10,7 @@ use crate::config::{ListOrder, PrDescriptionMode};
 use crate::git::{get_remote_branches_sha, gh_rw, git_is_ancestor, git_rw, sanitize_gh_base_ref};
 use crate::github::{
     fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape, list_open_prs_for_heads,
-    upsert_pr_cached,
+    list_terminal_prs_for_heads, upsert_pr_cached, TerminalPrState,
 };
 use crate::limit::{apply_limit_groups, Limit};
 use crate::parsing::{derive_groups_between, Group};
@@ -36,6 +37,109 @@ fn update_stack_block(body: &str, new_block: &str) -> String {
         new_block.to_string()
     } else {
         format!("{}\n\n{}", body, new_block)
+    }
+}
+
+/// Parse a GitHub GraphQL RFC3339 timestamp string.
+fn parse_github_timestamp_rfc3339(s: &str) -> Result<OffsetDateTime> {
+    OffsetDateTime::parse(s, &Rfc3339)
+        .with_context(|| format!("Failed to parse GitHub RFC3339 timestamp: {}", s))
+}
+
+/// Compute precise elapsed time since a terminal PR event.
+///
+/// Callers should use this typed duration for both comparisons and display conversion so the
+/// same source value drives the guard decision and the error message.
+fn recent_pr_age(terminal_at: OffsetDateTime, now: OffsetDateTime) -> TimeDuration {
+    now - terminal_at
+}
+
+/// Return the typed duration threshold used by the branch reuse guard.
+fn branch_reuse_guard_window(guard_days: u32) -> TimeDuration {
+    TimeDuration::days(i64::from(guard_days))
+}
+
+/// Return true when a terminal PR age falls within the configured guard window.
+///
+/// The comparison uses precise typed durations and does not round/truncate before comparing.
+fn recent_pr_age_blocks_recreation(age: TimeDuration, guard_window: TimeDuration) -> bool {
+    age <= guard_window
+}
+
+/// Convert a duration to fractional days for user-facing error messages.
+///
+/// This is display-only and intentionally preserves sub-day precision so the error text matches
+/// the same non-rounded comparison used by `merged_pr_age_blocks_recreation`.
+fn duration_days_precise(duration: TimeDuration) -> f64 {
+    duration.as_seconds_f64() / 86_400.0
+}
+
+/// Return the user-facing verb for a terminal PR event.
+fn terminal_pr_action(state: TerminalPrState) -> &'static str {
+    if state == TerminalPrState::Merged {
+        "merged"
+    } else {
+        "closed"
+    }
+}
+
+/// Fail `spr update` early when branch-name reuse matches a recently closed or merged PR.
+///
+/// The guard only runs when PR creation is enabled, the CLI override is not set, and the
+/// threshold is non-zero. It reuses the caller-provided `prs_by_head` map so only heads without
+/// open PRs are queried for terminal history; querying all heads would duplicate the open-PR
+/// lookup and could produce misleading results when a branch has both open and historical PRs.
+///
+/// # Errors
+///
+/// Returns an error when the terminal-PR lookup fails, when GitHub timestamps cannot be parsed,
+/// or when a recent closed or merged PR is found within the configured threshold.
+fn enforce_branch_reuse_guard(
+    no_pr: bool,
+    allow_branch_reuse: bool,
+    branch_reuse_guard_days: u32,
+    heads: &[String],
+    prs_by_head: &HashMap<String, u64>,
+) -> Result<()> {
+    if no_pr || allow_branch_reuse || branch_reuse_guard_days == 0 {
+        Ok(())
+    } else {
+        let heads_without_open_prs: Vec<String> = heads
+            .iter()
+            .filter(|head| !prs_by_head.contains_key(head.as_str()))
+            .cloned()
+            .collect();
+        if heads_without_open_prs.is_empty() {
+            Ok(())
+        } else {
+            let terminal_prs = list_terminal_prs_for_heads(&heads_without_open_prs)?;
+            let now = OffsetDateTime::now_utc();
+            let guard_window = branch_reuse_guard_window(branch_reuse_guard_days);
+            for terminal_pr in terminal_prs {
+                let terminal_at = parse_github_timestamp_rfc3339(&terminal_pr.terminal_at)
+                    .with_context(|| {
+                        format!(
+                            "Failed to parse terminal timestamp for PR #{} ({})",
+                            terminal_pr.number, terminal_pr.url
+                        )
+                    })?;
+                let age = recent_pr_age(terminal_at, now);
+                if recent_pr_age_blocks_recreation(age, guard_window) {
+                    let age_days = duration_days_precise(age);
+                    let action = terminal_pr_action(terminal_pr.state);
+                    return Err(anyhow!(
+                        "Refusing to recreate a PR for branch {} because PR #{} ({}) on that branch was {} {:.3} day(s) ago, within the configured guard window (branch_reuse_guard_days={}). You probably meant spr restack. If branch-name reuse is intentional, rerun with --allow-branch-reuse.",
+                        terminal_pr.head,
+                        terminal_pr.number,
+                        terminal_pr.url,
+                        action,
+                        age_days,
+                        branch_reuse_guard_days
+                    ));
+                }
+            }
+            Ok(())
+        }
     }
 }
 
@@ -194,6 +298,8 @@ pub fn build_from_groups(
     limit: Option<Limit>,
     mut groups: Vec<Group>,
     list_order: ListOrder,
+    allow_branch_reuse: bool,
+    branch_reuse_guard_days: u32,
 ) -> Result<()> {
     if groups.is_empty() {
         info!("No groups discovered; nothing to do.");
@@ -220,6 +326,13 @@ pub fn build_from_groups(
         prs_by_head.insert(p.head.clone(), p.number);
         current_base_by_number.insert(p.number, p.base);
     }
+    enforce_branch_reuse_guard(
+        no_pr,
+        allow_branch_reuse,
+        branch_reuse_guard_days,
+        &heads,
+        &prs_by_head,
+    )?;
     // Allow force-push within the selected scope when branch diverged from remote
 
     // Batch fetch remote SHAs for all target branches
@@ -629,5 +742,93 @@ pub fn build_from_tags(
         limit,
         groups,
         list_order,
+        true,
+        0,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        branch_reuse_guard_window, parse_github_timestamp_rfc3339, recent_pr_age,
+        recent_pr_age_blocks_recreation, terminal_pr_action,
+    };
+    use crate::github::TerminalPrState;
+    use time::{Duration as TimeDuration, OffsetDateTime};
+
+    fn fixed_now() -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(1_800_000_000).unwrap()
+    }
+
+    #[test]
+    // Verifies: recent terminal PRs well inside the threshold block PR recreation.
+    // Catches: regressions that invert the recent-age comparison for ordinary cases.
+    fn recent_pr_age_blocks_when_recent() {
+        let now = fixed_now();
+        let merged_at = now - TimeDuration::days(10);
+        let age = recent_pr_age(merged_at, now);
+        let guard_window = branch_reuse_guard_window(180);
+        assert!(recent_pr_age_blocks_recreation(age, guard_window));
+    }
+
+    #[test]
+    // Verifies: older terminal PRs outside the threshold do not block PR recreation.
+    // Catches: regressions that use a too-large threshold or reverse the allow path.
+    fn recent_pr_age_allows_when_old() {
+        let now = fixed_now();
+        let merged_at = now - TimeDuration::days(181);
+        let age = recent_pr_age(merged_at, now);
+        let guard_window = branch_reuse_guard_window(180);
+        assert!(!recent_pr_age_blocks_recreation(age, guard_window));
+    }
+
+    #[test]
+    // Verifies: a zero-day threshold allows historical terminal PRs with any positive elapsed age.
+    // Catches: regressions where the disabled threshold still blocks normal historical closures.
+    fn recent_pr_age_zero_threshold_allows_positive_age() {
+        let now = fixed_now();
+        let merged_at = now - TimeDuration::seconds(1);
+        let age = recent_pr_age(merged_at, now);
+        let guard_window = branch_reuse_guard_window(0);
+        assert!(!recent_pr_age_blocks_recreation(age, guard_window));
+    }
+
+    #[test]
+    // Verifies: the threshold comparison blocks values just under the day cutoff without rounding.
+    // Catches: regressions that round fractional days before comparing to the integer threshold.
+    fn recent_pr_age_just_under_threshold_blocks_without_rounding() {
+        let now = fixed_now();
+        let merged_at = now - TimeDuration::days(180) + TimeDuration::minutes(1);
+        let age = recent_pr_age(merged_at, now);
+        let guard_window = branch_reuse_guard_window(180);
+        assert!(recent_pr_age_blocks_recreation(age, guard_window));
+    }
+
+    #[test]
+    // Verifies: the threshold comparison allows values just over the day cutoff without rounding.
+    // Catches: regressions that floor or ceil fractional-day ages before threshold comparison.
+    fn recent_pr_age_just_over_threshold_allows_without_rounding() {
+        let now = fixed_now();
+        let merged_at = now - TimeDuration::days(180) - TimeDuration::minutes(1);
+        let age = recent_pr_age(merged_at, now);
+        let guard_window = branch_reuse_guard_window(180);
+        assert!(!recent_pr_age_blocks_recreation(age, guard_window));
+    }
+
+    #[test]
+    // Verifies: the guard error wording distinguishes merged and closed terminal PR events.
+    // Catches: regressions where closed PR blocks still claim the branch was merged.
+    fn terminal_pr_action_describes_terminal_state() {
+        assert_eq!(terminal_pr_action(TerminalPrState::Merged), "merged");
+        assert_eq!(terminal_pr_action(TerminalPrState::Closed), "closed");
+    }
+
+    #[test]
+    // Verifies: GitHub RFC3339 timestamps parse into the expected UTC instant.
+    // Catches: regressions in timestamp parsing format or timezone handling.
+    fn parse_github_timestamp_rfc3339_parses_valid_timestamp() {
+        let parsed = parse_github_timestamp_rfc3339("2026-02-20T12:34:56Z").unwrap();
+        let expected = OffsetDateTime::from_unix_timestamp(1_771_590_896).unwrap();
+        assert_eq!(parsed, expected);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,11 @@ pub struct FileConfig {
     /// - `rollback` (default): abort and clean up temp restack state
     /// - `halt`: stop and leave the temp worktree for manual resolution
     pub restack_conflict: Option<RestackConflictPolicy>,
+    /// Block `spr update` from recreating a PR when the same branch name had a recently merged
+    /// or closed PR within this many days.
+    ///
+    /// `0` effectively disables the guard for past terminal PRs.
+    pub branch_reuse_guard_days: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +111,11 @@ pub struct Config {
     pub list_order: ListOrder,
     /// Behavior when `spr restack` encounters a cherry-pick conflict.
     pub restack_conflict: RestackConflictPolicy,
+    /// Threshold in days for blocking `spr update` from recreating a PR on a branch name that
+    /// already had a recently merged or closed PR.
+    ///
+    /// `0` effectively disables the guard for past terminal PRs.
+    pub branch_reuse_guard_days: u32,
 }
 
 fn read_config_file(path: &PathBuf) -> Result<Option<FileConfig>> {
@@ -129,6 +139,7 @@ fn default_config() -> Config {
         pr_description_mode: PrDescriptionMode::Overwrite,
         list_order: ListOrder::RecentOnTop,
         restack_conflict: RestackConflictPolicy::Rollback,
+        branch_reuse_guard_days: 180,
     }
 }
 
@@ -154,6 +165,9 @@ fn apply_overrides(config: &Config, overrides: FileConfig) -> Config {
     }
     if let Some(restack_conflict) = overrides.restack_conflict {
         merged.restack_conflict = restack_conflict;
+    }
+    if let Some(branch_reuse_guard_days) = overrides.branch_reuse_guard_days {
+        merged.branch_reuse_guard_days = branch_reuse_guard_days;
     }
     merged
 }
@@ -193,7 +207,7 @@ pub fn load_config() -> Result<Config> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_config_file, PrDescriptionMode};
+    use super::{apply_overrides, default_config, read_config_file, FileConfig, PrDescriptionMode};
     use std::fs;
     use tempfile::tempdir;
 
@@ -242,5 +256,40 @@ overwrite_pr_description: false
             err_msg.contains(path.to_string_lossy().as_ref()),
             "error should include config path: {err_msg}"
         );
+    }
+
+    #[test]
+    // Verifies: YAML config parsing accepts an integer value for branch_reuse_guard_days.
+    // Catches: regressions where the new config key is rejected or parsed with the wrong type.
+    fn read_config_file_parses_branch_reuse_guard_days_integer() {
+        let dir = tempdir().unwrap();
+        let mut path = dir.path().to_path_buf();
+        path.push(".spr_multicommit_cfg.yml");
+        fs::write(&path, "branch_reuse_guard_days: 0\n").unwrap();
+
+        let cfg = read_config_file(&path).unwrap().unwrap();
+        assert_eq!(cfg.branch_reuse_guard_days, Some(0));
+    }
+
+    #[test]
+    // Verifies: file-config overrides replace the default branch reuse guard threshold.
+    // Catches: regressions where the new config key is ignored during config merge.
+    fn apply_overrides_updates_branch_reuse_guard_days() {
+        let base = default_config();
+        let merged = apply_overrides(
+            &base,
+            FileConfig {
+                base: None,
+                prefix: None,
+                land: None,
+                ignore_tag: None,
+                pr_description_mode: None,
+                list_order: None,
+                restack_conflict: None,
+                branch_reuse_guard_days: Some(30),
+            },
+        );
+
+        assert_eq!(merged.branch_reuse_guard_days, 30);
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,11 +3,14 @@
 //! This module centralizes read/write calls to GitHub so command modules can operate on
 //! typed results instead of raw JSON. The status-list path relies on branch-name lookups:
 //! for each local stack head, we resolve either the currently open PR or (if none is open)
-//! the latest merged PR for that same head ref.
+//! the latest merged PR for that same head ref. The update preflight also looks up the latest
+//! terminal PR event for a head ref so branch-name reuse can be blocked after recent merges or
+//! closes.
 
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::{info, warn};
 
 use crate::git::{gh_ro, gh_rw, git_ro};
@@ -38,6 +41,38 @@ pub struct PrInfoWithState {
     pub head: String,
     pub state: PrState,
 }
+
+/// Terminal state for a branch-name reuse guard lookup.
+///
+/// `Merged` and `Closed` are intentionally distinct because the update preflight needs to
+/// report whether a recent terminal event came from a merge or a manual close.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalPrState {
+    /// The prior PR on this head branch was merged.
+    Merged,
+    /// The prior PR on this head branch was closed without merging.
+    Closed,
+}
+
+/// Latest terminal PR metadata for a specific head branch.
+///
+/// The `head` is the exact GitHub head ref name that matched the query. `terminal_at` is the
+/// GitHub RFC3339 timestamp string for the event that matters to the branch-name reuse guard:
+/// `mergedAt` for merged PRs and `closedAt` for closed PRs.
+#[derive(Debug, Clone)]
+pub struct TerminalPrInfo {
+    pub number: u64,
+    pub head: String,
+    pub state: TerminalPrState,
+    pub terminal_at: String,
+    pub url: String,
+}
+
+/// Number of terminal PR candidates fetched per head before client-side time selection.
+///
+/// GitHub's pull request connection for this query can only order by created/update time, so we
+/// fetch a bounded recent window and then choose the newest terminal timestamp locally.
+const TERMINAL_PRS_PER_HEAD_QUERY_LIMIT: usize = 10;
 
 #[derive(Clone)]
 pub struct PrBodyInfo {
@@ -269,6 +304,190 @@ pub fn list_open_prs_for_heads(heads: &[String]) -> Result<Vec<PrInfo>> {
     Ok(out)
 }
 
+/// Parse a GitHub GraphQL `DateTime` string and attach head-specific error context.
+fn parse_github_datetime_rfc3339(s: &str, context: &str) -> Result<OffsetDateTime> {
+    OffsetDateTime::parse(s, &Rfc3339).map_err(|e| {
+        anyhow!(
+            "Failed to parse GitHub DateTime for {}: {} ({})",
+            context,
+            s,
+            e
+        )
+    })
+}
+
+fn parse_terminal_pr_state(
+    node: &serde_json::Value,
+    requested_head: &str,
+    number: u64,
+) -> Result<TerminalPrState> {
+    let state = node["state"].as_str().ok_or_else(|| {
+        anyhow!(
+            "Terminal PR #{} missing state for {}",
+            number,
+            requested_head
+        )
+    })?;
+    if state == "MERGED" {
+        Ok(TerminalPrState::Merged)
+    } else if state == "CLOSED" {
+        Ok(TerminalPrState::Closed)
+    } else {
+        Err(anyhow!(
+            "Terminal PR #{} has unsupported state {} for {}",
+            number,
+            state,
+            requested_head
+        ))
+    }
+}
+
+fn parse_terminal_pr_timestamp(
+    node: &serde_json::Value,
+    requested_head: &str,
+    number: u64,
+    state: TerminalPrState,
+) -> Result<String> {
+    if state == TerminalPrState::Merged {
+        node["mergedAt"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Merged PR #{} missing mergedAt for {}",
+                    number,
+                    requested_head
+                )
+            })
+    } else {
+        node["closedAt"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Closed PR #{} missing closedAt for {}",
+                    number,
+                    requested_head
+                )
+            })
+    }
+}
+
+/// Parse one terminal-PR GraphQL node into typed metadata used by the update guard.
+///
+/// The caller still parses `terminal_at` separately for ordering so this function can preserve
+/// the original timestamp text for user-facing errors.
+fn parse_terminal_pr_node(
+    node: &serde_json::Value,
+    requested_head: &str,
+) -> Result<TerminalPrInfo> {
+    let number = node["number"]
+        .as_u64()
+        .ok_or_else(|| anyhow!("Terminal PR result missing number for {}", requested_head))?;
+    let head = node["headRefName"].as_str().ok_or_else(|| {
+        anyhow!(
+            "Terminal PR result missing headRefName for {}",
+            requested_head
+        )
+    })?;
+    let state = parse_terminal_pr_state(node, requested_head, number)?;
+    let terminal_at = parse_terminal_pr_timestamp(node, requested_head, number, state)?;
+    let url = node["url"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Terminal PR #{} missing url for {}", number, requested_head))?;
+
+    Ok(TerminalPrInfo {
+        number,
+        head: head.to_string(),
+        state,
+        terminal_at,
+        url: url.to_string(),
+    })
+}
+
+/// Select the newest terminal PR by its terminal timestamp from a bounded set of PR nodes.
+///
+/// GitHub returns nodes ordered by `UPDATED_AT`, which can differ from close or merge time when
+/// older PRs receive later comments or edits. Picking the max terminal timestamp avoids basing
+/// the update guard on a stale terminal PR.
+fn select_latest_terminal_pr(
+    nodes: &[serde_json::Value],
+    requested_head: &str,
+) -> Result<Option<TerminalPrInfo>> {
+    let mut latest: Option<(OffsetDateTime, TerminalPrInfo)> = None;
+    for node in nodes {
+        let info = parse_terminal_pr_node(node, requested_head)?;
+        let terminal_at = parse_github_datetime_rfc3339(&info.terminal_at, requested_head)?;
+        if latest
+            .as_ref()
+            .map(|(current, _)| terminal_at > *current)
+            .unwrap_or(true)
+        {
+            latest = Some((terminal_at, info));
+        }
+    }
+
+    if let Some((_, info)) = latest {
+        Ok(Some(info))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Fetches the latest closed-or-merged PR for each requested head branch (exact match).
+///
+/// Heads with no closed or merged PR are omitted from the result. Callers that already know the
+/// set of heads with open PRs can use this to look up only the remaining candidates when
+/// enforcing branch-name reuse guardrails. GitHub does not expose a close-or-merge-time ordering
+/// field for this connection, so this function fetches a small recent window per head and picks
+/// the newest terminal PR client-side.
+pub fn list_terminal_prs_for_heads(heads: &[String]) -> Result<Vec<TerminalPrInfo>> {
+    let mut out: Vec<TerminalPrInfo> = Vec::new();
+    if heads.is_empty() {
+        return Ok(out);
+    }
+    let (owner, name) = get_repo_owner_name()?;
+
+    let mut q =
+        String::from("query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ ");
+    for (i, head) in heads.iter().enumerate() {
+        q.push_str(&format!(
+            "pr{}: pullRequests(headRefName:\"{}\", states:[CLOSED,MERGED], first:{}, orderBy:{{field:UPDATED_AT,direction:DESC}}) {{ nodes {{ number headRefName state mergedAt closedAt url }} }} ",
+            i,
+            graphql_escape(head),
+            TERMINAL_PRS_PER_HEAD_QUERY_LIMIT
+        ));
+    }
+    q.push_str("} }");
+
+    let json = gh_ro(
+        [
+            "api",
+            "graphql",
+            "-f",
+            &format!("query={}", q),
+            "-F",
+            &format!("owner={}", owner),
+            "-F",
+            &format!("name={}", name),
+        ]
+        .as_slice(),
+    )?;
+
+    let v: serde_json::Value = serde_json::from_str(&json)?;
+    let repo = &v["data"]["repository"];
+    for (i, requested_head) in heads.iter().enumerate() {
+        let key = format!("pr{}", i);
+        if let Some(nodes) = repo[&key]["nodes"].as_array() {
+            if let Some(info) = select_latest_terminal_pr(nodes, requested_head)? {
+                out.push(info);
+            }
+        }
+    }
+
+    Ok(out)
+}
+
 /// Fetches one status-bearing PR per requested head branch.
 ///
 /// For each entry in `heads`, this function first checks for an open PR and falls back to
@@ -484,4 +703,42 @@ pub fn append_warning_to_pr(number: u64, warning: &str, dry: bool) -> Result<()>
         info!("Appended warning to PR #{}", number);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{select_latest_terminal_pr, TerminalPrState};
+    use serde_json::json;
+
+    #[test]
+    // Verifies: terminal PR selection uses the most recent close-or-merge timestamp across states.
+    // Catches: regressions that trust UPDATED_AT ordering or ignore closed PRs in the reuse guard.
+    fn select_latest_terminal_pr_uses_max_terminal_timestamp_across_states() {
+        let nodes = vec![
+            json!({
+                "number": 11,
+                "headRefName": "dank-spr/example",
+                "state": "MERGED",
+                "mergedAt": "2026-02-01T00:00:00Z",
+                "closedAt": "2026-02-01T00:00:00Z",
+                "url": "https://github.com/o/r/pull/11"
+            }),
+            json!({
+                "number": 22,
+                "headRefName": "dank-spr/example",
+                "state": "CLOSED",
+                "mergedAt": null,
+                "closedAt": "2026-02-10T00:00:00Z",
+                "url": "https://github.com/o/r/pull/22"
+            }),
+        ];
+
+        let selected = select_latest_terminal_pr(&nodes, "dank-spr/example")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(selected.number, 22);
+        assert_eq!(selected.state, TerminalPrState::Closed);
+        assert_eq!(selected.terminal_at, "2026-02-10T00:00:00Z");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ fn main() -> Result<()> {
     let pr_description_mode = cfg.pr_description_mode;
     let restack_conflict_policy = cfg.restack_conflict;
     let list_order = cfg.list_order;
+    let branch_reuse_guard_days = cfg.branch_reuse_guard_days;
     match cli.cmd {
         crate::cli::Cmd::Update {
             from,
@@ -92,6 +93,7 @@ fn main() -> Result<()> {
             restack,
             assume_existing_prs,
             pr_description_mode: pr_description_mode_override,
+            allow_branch_reuse,
             extent,
         } => {
             set_dry_run_env(cli.dry_run, assume_existing_prs);
@@ -123,6 +125,8 @@ fn main() -> Result<()> {
                     limit,
                     groups,
                     list_order,
+                    allow_branch_reuse,
+                    branch_reuse_guard_days,
                 )?;
             }
         }


### PR DESCRIPTION
# Problem Solved

`spr update` could recreate a PR after a stack PR was merged or manually closed when the user accidentally ran `update` instead of `restack`, because the preflight lookup only considered open PRs and treated the branch name as reusable. This change broadens the preflight guard to recent terminal PR events on the same head branch and renames the public controls to `branch_reuse_guard_days` and `--allow-branch-reuse` so the configuration matches the behavior.

# Mental model

Before `spr update` creates PRs, it resolves open PRs by head branch as before, then checks only heads without an open PR for recent terminal PR history. If the newest closed or merged PR for that head happened within `branch_reuse_guard_days`, the command fails with an explicit error and suggests `spr restack`; users can bypass the guard with `--allow-branch-reuse`. The age comparison uses precise elapsed time against an integer-day threshold without rounding. A threshold of `0` short-circuits the guard and skips the terminal-PR GitHub query entirely.

# Non-goals

- Reusing or changing the existing open-PR lookup and PR upsert flow.
- Blocking branch updates when the head already has an open PR.
- Automatically restacking or rewriting branches when the guard triggers.

# Tradeoffs

- Keeps the extra `time` dependency to parse GitHub RFC3339 timestamps and compare precise durations.
- Adds terminal-PR preflight queries for heads without open PRs.
- GitHub GraphQL does not support ordering pull requests by close-or-merge time, so the implementation fetches a bounded recent window (`first:10`) ordered by `UPDATED_AT` and selects the max terminal timestamp client-side.

# Architecture

- `src/cli.rs` renames the override to `spr update --allow-branch-reuse`.
- `src/config.rs` renames the threshold key to `branch_reuse_guard_days` (default `180`) and merges YAML overrides.
- `src/main.rs` threads the renamed config threshold and CLI override into the update command path.
- `src/github.rs` replaces merged-only metadata lookup with terminal PR metadata lookup (`state`, `mergedAt`, `closedAt`, `url`) plus client-side latest-by-terminal-time selection.
- `src/commands/update.rs` enforces the broader guard, reuses precise age comparison for both closed and merged PRs, and updates the user-facing error with the renamed config key and override flag.
- `README.md` documents the broader guard behavior and renamed public controls.

# Observability

When the guard blocks PR creation, the error includes the branch name, PR number, PR URL, whether the prior PR was closed or merged, the computed age in days, the configured threshold, `You probably meant spr restack`, and the override flag to allow intentional branch-name reuse.

# Tests

Test scope is the unit tests covering the guardrail change and its rename. Coverage includes precise age-threshold comparisons (including just-under and just-over cases), the `0` threshold behavior, RFC3339 timestamp parsing, config parsing for the renamed key, terminal-PR selection across merged and closed states, and terminal-state wording in the guard error path. Intent annotations remain on the touched tests in this commit boundary.

<!-- spr-stack:start -->
**Stack**:
-   #109
-   #108
- ➡ #107

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->