### PR TITLE
Add stable pr <label> selectors for PR groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ spr list pr
 spr list commit
 ```
 
+`pr:<tag>` is the stable handle for a PR group. `LPR #N` is only the current
+local position in the outstanding stack and may renumber after lower groups
+land or are removed. Commands that target groups can use either form, for
+example `spr land flatten --until pr:beta` or `spr move pr:beta --after
+pr:gamma`.
+
 Configuration
 -------------
 
@@ -100,8 +106,8 @@ Global flags
  - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
 - `--dry-run` (alias: `--dr`): print state-changing commands instead of executing
-- `--until <N>`: target range used by `prep` and `land` (0 means all)
-- `--exact <I>`: used by `prep` to select exactly the I-th PR (1-based)
+- `--until <N|0|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
+- `--exact <I|pr:<label>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
 
 Commands
@@ -122,7 +128,9 @@ Key options:
 - `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
 - `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
 - Extent (optional subcommand):
-  - `pr --n <N>`: limit to first N PRs from the bottom
+  - `pr --to <N|pr:<label>>`: canonical selector for limiting updates to the first N PRs from the bottom
+  - `pr --n <N>`: legacy numeric-only form
+  - `pr <N>`: backward-compatible positional numeric form
   - `commits --n <N>`: limit to first N commits (untested)
 
 Behavior:
@@ -144,9 +152,10 @@ Restack the local stack by rebuilding commits after the bottom N PR groups onto 
 
 Options:
 
-- `--after <N|bottom|top|last|all>`: 'drop' the first N PR groups; rebase the remaining commits onto `--base`
+- `--after <N|0|bottom|top|last|all|pr:<label>>`: keep groups through this selector in place, then rebase only the groups above it onto `--base`
   - `0` or `bottom`: restack all groups (moves everything after merge-base)
   - `top` or `last` or `all`: skip all PRs; ignored commits (pr:ignore blocks) are preserved, so the branch may remain ahead of base
+  - `pr:<label>`: keep that stable group and everything below it in place even if local PR numbers renumber
 - `--safe`: create a local backup tag at current `HEAD` before rebasing
 
 Behavior:
@@ -164,7 +173,7 @@ Behavior:
 
 ### spr list pr
 
-Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top.
+Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top, but the output now shows both the current `LPR #N` and the stable `pr:<label>` handle for each group.
 
 Aliases:
 
@@ -176,6 +185,12 @@ Legend:
 - Review ✓/✗/◐ indicates passing/failing/pending review status when available.
 - `⑃M` indicates the PR is already merged (open PRs take precedence when a branch has both open and historical merged PRs).
 
+Example summary line:
+
+```text
+✓✓ LPR #2 / pr:beta - abcdef12 : dank-spr/beta (#17) - 3 commits
+```
+
 ### spr status
 
 Aliases:
@@ -186,7 +201,7 @@ Alias for `spr list pr`.
 
 ### spr list commit
 
-Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top.
+Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top, and each group header also shows its stable `pr:<label>` handle.
 
 Aliases:
 
@@ -202,10 +217,12 @@ Aliases:
 
 - `spr move A --after C`: move PR at position A to come after PR C (C ∈ [0..N])
 - `spr move A..B --after C`: move PRs A..B to come after PR C (requires A < B and C ∉ [A..B]; C ∈ [0..N])
+- `spr move pr:beta --after pr:gamma`: move a stable group handle without caring what its current local PR number is
+- `spr move pr:beta..pr:gamma --after pr:delta`: stable-handle range form
   - `--after bottom` is the same as `--after 0`
   - `--after top` is the same as `--after N`
 - `--safe`: create a local backup tag at current `HEAD` before rewriting
- - Ignore blocks (`pr:ignore`) stay attached to the preceding PR group and move with it
+- Ignore blocks (`pr:ignore`) stay attached to the preceding PR group and move with it
 
 Prints an explicit plan, e.g.: `2..3→4: [1,2,3,4,5,6] → [1,4,2,3,5,6]`.
 
@@ -215,8 +232,8 @@ Land PRs using either flatten or per-pr strategy.
 
 Shared options (global):
 
-- `--until <N>`: land first N PRs bottom-up (0 means all)
- - `--no-restack`: do not automatically restack after landing
+- `--until <N|0|pr:<label>>`: land bottom-up through this local position or stable handle (`0` means all)
+- `--no-restack`: do not automatically restack after landing
 
 Safety checks:
 
@@ -230,7 +247,7 @@ Mode selection:
 
 Default follow-up behavior:
 
-- After a successful land, `spr` will automatically run `spr restack --after N` (using the same `N` from `--until`) to rebase the remaining commits onto the latest base. Pass `--no-restack` to skip this.
+- After a successful land, `spr` will automatically run `spr restack --after N` using the resolved group count from `--until`, so `spr land --until pr:beta` still restacks the correct remaining groups after `beta` disappears from the outstanding stack. Pass `--no-restack` to skip this.
 
 #### Mode: flatten
 
@@ -251,7 +268,7 @@ Default follow-up behavior:
 
 Prepare PRs for landing per-PR - squashes each PR's commits into a single commit.
 
-- Uses global `--until` / `--exact`
+- Uses global `--until <N|0|pr:<label>>` / `--exact <I|pr:<label>>`
 
 Behavior:
 
@@ -261,18 +278,22 @@ Behavior:
 
 ### spr fix-pr
 
-Move the tail M commits (top of stack) to the tail of PR N (1-based, bottom→top).
+Move the tail M commits (top of stack) to the tail of a PR group selected by local PR number or stable handle.
 
 Aliases:
 
 - `spr fix N -t M`
 - `spr fix N` (equivalent to `spr fix N -t 1`)
+- `spr fix-pr pr:beta --tail M`
 
 Usage:
 
 ```bash
 # Move the top commit to the tail of PR 3
 spr fix-pr 3
+
+# Move the top commit to the tail of the stable beta group
+spr fix-pr pr:beta
 
 # Move the last 2 commits to the tail of PR 1
 spr fix-pr 1 --tail 2
@@ -340,6 +361,15 @@ Examples
 # Build/refresh using defaults from config
 spr update
 
+# Update only through the stable beta group
+spr update pr --to pr:beta
+
+# Prep the stack through the stable beta group
+spr prep --until pr:beta
+
+# Prep exactly the stable gamma group
+spr prep --exact pr:gamma
+
 # Prep the first 3 PRs from the bottom
 spr prep --until 3
 
@@ -352,8 +382,14 @@ spr restack --after 2
 # Restack safely (creates a backup tag before rebase)
 spr restack --after 2 --safe
 
+# Restack only the groups above the stable beta group
+spr restack --after pr:beta
+
 # Land top PR only using config default mode (flatten by default)
 spr land --until 1
+
+# Land through the stable beta group
+spr land flatten --until pr:beta
 
 # Explicitly land first 2 PRs via flatten
 spr land flatten --until 2
@@ -363,6 +399,9 @@ spr land per-pr --until 2
 
 # Reorder local PR groups 2..3 to come after PR 4 (creates a backup if desired)
 spr move 2..3 --after 4 --safe
+
+# Reorder stable groups without depending on local PR renumbering
+spr move pr:beta..pr:gamma --after pr:delta
 
 # Fix PR base chain on GitHub to reflect local stack
 spr relink-prs

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ spr list pr
 spr list commit
 ```
 
-`pr:<tag>` is the stable handle for a PR group. `LPR #N` is only the current
-local position in the outstanding stack and may renumber after lower groups
-land or are removed. Commands that target groups can use either form, for
-example `spr land flatten --until pr:beta` or `spr move pr:beta --after
-pr:gamma`.
+`pr:<tag>` is the stable handle for a PR group, and `<tag>` must start with an
+ASCII letter. Commands that target groups accept either a bare label like
+`beta` or the explicit `pr:beta` form. `LPR #N` is only the current local
+position in the outstanding stack and may renumber after lower groups land or
+are removed. For example, `spr land flatten --until beta` and `spr move beta
+--after gamma` both target stable PR-group labels.
 
 Configuration
 -------------
@@ -73,6 +74,7 @@ land: flatten
 
 # Tag used to ignore commits between PR groups
 # Commit with pr:ignore_tag starts ignore mode until the next pr:<tag>
+# Must start with an ASCII letter
 ignore_tag: ignore
 
 # How `spr update` manages PR descriptions from commit messages
@@ -106,8 +108,8 @@ Global flags
  - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
 - `--dry-run` (alias: `--dr`): print state-changing commands instead of executing
-- `--until <N|0|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
-- `--exact <I|pr:<label>>`: used by `prep` to select exactly one PR group
+- `--until <N|0|label|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
+- `--exact <I|label|pr:<label>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
 
 Commands
@@ -128,7 +130,7 @@ Key options:
 - `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
 - `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
 - Extent (optional subcommand):
-  - `pr --to <N|pr:<label>>`: canonical selector for limiting updates to the first N PRs from the bottom
+  - `pr --to <N|label|pr:<label>>`: canonical selector for limiting updates to the first N PRs from the bottom
   - `pr --n <N>`: legacy numeric-only form
   - `pr <N>`: backward-compatible positional numeric form
   - `commits --n <N>`: limit to first N commits (untested)
@@ -152,10 +154,10 @@ Restack the local stack by rebuilding commits after the bottom N PR groups onto 
 
 Options:
 
-- `--after <N|0|bottom|top|last|all|pr:<label>>`: keep groups through this selector in place, then rebase only the groups above it onto `--base`
+- `--after <N|0|bottom|top|last|all|label|pr:<label>>`: keep groups through this selector in place, then rebase only the groups above it onto `--base`
   - `0` or `bottom`: restack all groups (moves everything after merge-base)
   - `top` or `last` or `all`: skip all PRs; ignored commits (pr:ignore blocks) are preserved, so the branch may remain ahead of base
-  - `pr:<label>`: keep that stable group and everything below it in place even if local PR numbers renumber
+  - `label` or `pr:<label>`: keep that stable group and everything below it in place even if local PR numbers renumber
 - `--safe`: create a local backup tag at current `HEAD` before rebasing
 
 Behavior:
@@ -217,8 +219,8 @@ Aliases:
 
 - `spr move A --after C`: move PR at position A to come after PR C (C ∈ [0..N])
 - `spr move A..B --after C`: move PRs A..B to come after PR C (requires A < B and C ∉ [A..B]; C ∈ [0..N])
-- `spr move pr:beta --after pr:gamma`: move a stable group handle without caring what its current local PR number is
-- `spr move pr:beta..pr:gamma --after pr:delta`: stable-handle range form
+- `spr move beta --after gamma`: move a stable group handle without caring what its current local PR number is
+- `spr move beta..gamma --after delta`: stable-handle range form
   - `--after bottom` is the same as `--after 0`
   - `--after top` is the same as `--after N`
 - `--safe`: create a local backup tag at current `HEAD` before rewriting
@@ -232,7 +234,7 @@ Land PRs using either flatten or per-pr strategy.
 
 Shared options (global):
 
-- `--until <N|0|pr:<label>>`: land bottom-up through this local position or stable handle (`0` means all)
+- `--until <N|0|label|pr:<label>>`: land bottom-up through this local position or stable handle (`0` means all)
 - `--no-restack`: do not automatically restack after landing
 
 Safety checks:
@@ -268,7 +270,7 @@ Default follow-up behavior:
 
 Prepare PRs for landing per-PR - squashes each PR's commits into a single commit.
 
-- Uses global `--until <N|0|pr:<label>>` / `--exact <I|pr:<label>>`
+- Uses global `--until <N|0|label|pr:<label>>` / `--exact <I|label|pr:<label>>`
 
 Behavior:
 
@@ -284,7 +286,7 @@ Aliases:
 
 - `spr fix N -t M`
 - `spr fix N` (equivalent to `spr fix N -t 1`)
-- `spr fix-pr pr:beta --tail M`
+- `spr fix-pr beta --tail M`
 
 Usage:
 
@@ -293,7 +295,7 @@ Usage:
 spr fix-pr 3
 
 # Move the top commit to the tail of the stable beta group
-spr fix-pr pr:beta
+spr fix-pr beta
 
 # Move the last 2 commits to the tail of PR 1
 spr fix-pr 1 --tail 2
@@ -362,13 +364,13 @@ Examples
 spr update
 
 # Update only through the stable beta group
-spr update pr --to pr:beta
+spr update pr --to beta
 
 # Prep the stack through the stable beta group
-spr prep --until pr:beta
+spr prep --until beta
 
 # Prep exactly the stable gamma group
-spr prep --exact pr:gamma
+spr prep --exact gamma
 
 # Prep the first 3 PRs from the bottom
 spr prep --until 3
@@ -383,13 +385,13 @@ spr restack --after 2
 spr restack --after 2 --safe
 
 # Restack only the groups above the stable beta group
-spr restack --after pr:beta
+spr restack --after beta
 
 # Land top PR only using config default mode (flatten by default)
 spr land --until 1
 
 # Land through the stable beta group
-spr land flatten --until pr:beta
+spr land flatten --until beta
 
 # Explicitly land first 2 PRs via flatten
 spr land flatten --until 2
@@ -401,7 +403,7 @@ spr land per-pr --until 2
 spr move 2..3 --after 4 --safe
 
 # Reorder stable groups without depending on local PR renumbering
-spr move pr:beta..pr:gamma --after pr:delta
+spr move beta..gamma --after delta
 
 # Fix PR base chain on GitHub to reflect local stack
 spr relink-prs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ pub enum Extent {
     /// Update the first N PRs (bottom-up)
     Pr {
         /// Limit updates through this local PR number or stable handle
-        #[arg(long, value_name = "N|pr:<label>", conflicts_with_all = ["n", "legacy_n"])]
+        #[arg(long, value_name = "N|label|pr:<label>", conflicts_with_all = ["n", "legacy_n"])]
         to: Option<crate::selectors::GroupSelector>,
         /// Legacy numeric-only limit
         #[arg(long, value_name = "N", conflicts_with_all = ["to", "legacy_n"])]
@@ -73,7 +73,7 @@ pub enum Cmd {
     /// Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base
     Restack {
         /// Keep groups through this selector in place and rebuild only the groups above it
-        #[arg(long, value_name = "N|0|bottom|top|last|all|pr:<label>")]
+        #[arg(long, value_name = "N|0|bottom|top|last|all|label|pr:<label>")]
         after: crate::selectors::AfterSelector,
 
         /// Create a local backup tag at current HEAD before rebasing
@@ -139,10 +139,10 @@ pub enum Cmd {
     /// Reorder local PR groups by moving one or a range to come after a target PR
     #[command(alias = "mv")]
     Move {
-        /// Position or range to move: either `A`, `A..B`, `pr:<label>`, or `pr:<a>..pr:<b>`
+        /// Position or range to move: `A`, `A..B`, `label`, `pr:<label>`, `a..b`, or `pr:<a>..pr:<b>`
         range: crate::selectors::GroupRangeSelector,
         /// Target PR position to come after: number, stable handle, or one of bottom/top/last/all
-        #[arg(long, value_name = "C|bottom|top|last|all|pr:<label>")]
+        #[arg(long, value_name = "C|bottom|top|last|all|label|pr:<label>")]
         after: crate::selectors::AfterSelector,
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
@@ -178,10 +178,10 @@ pub struct Cli {
     #[arg(long, global = true, visible_alias = "dr")]
     pub dry_run: bool,
     /// Global until (used by prep/land). Accepts 0, a local PR number, or a stable handle
-    #[arg(long, global = true, value_name = "N|0|pr:<label>")]
+    #[arg(long, global = true, value_name = "N|0|label|pr:<label>")]
     pub until: Option<crate::selectors::InclusiveSelector>,
     /// Global exact (used by prep). Accepts a local PR number or a stable handle
-    #[arg(long, global = true, value_name = "I|pr:<label>")]
+    #[arg(long, global = true, value_name = "I|label|pr:<label>")]
     pub exact: Option<crate::selectors::GroupSelector>,
     #[command(subcommand)]
     pub cmd: Cmd,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,17 +1,27 @@
 use clap::{Parser, Subcommand};
 
-#[derive(Subcommand, Debug, Clone, Copy)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum Extent {
     /// Update the first N PRs (bottom-up)
-    Pr { n: usize },
+    Pr {
+        /// Limit updates through this local PR number or stable handle
+        #[arg(long, value_name = "N|pr:<label>", conflicts_with_all = ["n", "legacy_n"])]
+        to: Option<crate::selectors::GroupSelector>,
+        /// Legacy numeric-only limit
+        #[arg(long, value_name = "N", conflicts_with_all = ["to", "legacy_n"])]
+        n: Option<usize>,
+        /// Backward-compatible positional numeric limit
+        #[arg(value_name = "N", hide = true, conflicts_with_all = ["to", "n"])]
+        legacy_n: Option<usize>,
+    },
     /// Update only the first N commits from base..from (push partial groups if needed)
     Commits { n: usize },
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum PrepSelection {
-    Until(usize),
-    Exact(usize),
+    Until(crate::selectors::InclusiveSelector),
+    Exact(crate::selectors::GroupSelector),
     All,
 }
 
@@ -62,9 +72,9 @@ pub enum Cmd {
 
     /// Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base
     Restack {
-        /// Ignore the bottom N PRs; rebase the remaining commits onto base. Accepts a number, or keywords: bottom|top|last
-        #[arg(long, value_name = "N|bottom|top|last")]
-        after: String,
+        /// Keep groups through this selector in place and rebuild only the groups above it
+        #[arg(long, value_name = "N|0|bottom|top|last|all|pr:<label>")]
+        after: crate::selectors::AfterSelector,
 
         /// Create a local backup tag at current HEAD before rebasing
         #[arg(long)]
@@ -116,8 +126,8 @@ pub enum Cmd {
     /// Move the last M commits (top of stack) to the tail of PR N (1-based, bottom→top)
     #[command(visible_alias = "fix")]
     FixPr {
-        /// Target PR number (1-based, bottom→top)
-        n: usize,
+        /// Target local PR number or stable handle
+        target: crate::selectors::GroupSelector,
         /// Number of top commits to move to PR N's tail
         #[arg(short = 't', long = "tail", default_value_t = 1)]
         tail: usize,
@@ -129,11 +139,11 @@ pub enum Cmd {
     /// Reorder local PR groups by moving one or a range to come after a target PR
     #[command(alias = "mv")]
     Move {
-        /// Position or range to move: either `A` or `A..B` (1-based, bottom→top)
-        range: String,
-        /// Target PR position to come after: number (0..=N), or one of: bottom, top. Must not be in [A..B]
-        #[arg(long, value_name = "C|bottom|top")]
-        after: String,
+        /// Position or range to move: either `A`, `A..B`, `pr:<label>`, or `pr:<a>..pr:<b>`
+        range: crate::selectors::GroupRangeSelector,
+        /// Target PR position to come after: number, stable handle, or one of bottom/top/last/all
+        #[arg(long, value_name = "C|bottom|top|last|all|pr:<label>")]
+        after: crate::selectors::AfterSelector,
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
@@ -167,12 +177,12 @@ pub struct Cli {
     /// Global dry-run flag (applies to all subcommands)
     #[arg(long, global = true, visible_alias = "dr")]
     pub dry_run: bool,
-    /// Global until (used by prep/land). 0 means all
-    #[arg(long, global = true)]
-    pub until: Option<usize>,
-    /// Global exact (used by prep)
-    #[arg(long, global = true)]
-    pub exact: Option<usize>,
+    /// Global until (used by prep/land). Accepts 0, a local PR number, or a stable handle
+    #[arg(long, global = true, value_name = "N|0|pr:<label>")]
+    pub until: Option<crate::selectors::InclusiveSelector>,
+    /// Global exact (used by prep). Accepts a local PR number or a stable handle
+    #[arg(long, global = true, value_name = "I|pr:<label>")]
+    pub exact: Option<crate::selectors::GroupSelector>,
     #[command(subcommand)]
     pub cmd: Cmd,
 }

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -8,6 +8,14 @@ use tracing::info;
 use crate::commands::common;
 use crate::git::git_ro;
 use crate::parsing::derive_local_groups_with_ignored;
+use crate::selectors::{resolve_group_ordinal, GroupSelector};
+
+fn resolve_fix_pr_target(
+    groups: &[crate::parsing::Group],
+    target: &GroupSelector,
+) -> Result<usize> {
+    resolve_group_ordinal(groups, target)
+}
 
 /// Move the last `tail_count` commits (top-of-stack) to become the tail of PR `n` (1-based, bottom→top).
 ///
@@ -22,7 +30,7 @@ use crate::parsing::derive_local_groups_with_ignored;
 pub fn fix_pr_tail(
     base: &str,
     ignore_tag: &str,
-    n: usize,
+    target: &GroupSelector,
     tail_count: usize,
     safe: bool,
     dry: bool,
@@ -38,15 +46,7 @@ pub fn fix_pr_tail(
         return Ok(());
     }
 
-    // Validate target PR index (1-based)
-    if n == 0 || n > total_groups {
-        return Err(anyhow!(
-            "Target PR N={} out of bounds (1..={})",
-            n,
-            total_groups
-        ));
-    }
-    let target_n = n;
+    let target_n = resolve_fix_pr_target(&groups, target)?;
 
     // Flatten commits bottom→top
     let mut all_commits: Vec<String> = Vec::new();
@@ -160,4 +160,33 @@ pub fn fix_pr_tail(
     common::cleanup_temp_worktree(dry, &tmp_path, &tmp_branch)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_fix_pr_target;
+    use crate::parsing::Group;
+    use crate::selectors::{GroupSelector, StableHandle};
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter()
+            .map(|tag| Group {
+                tag: tag.to_string(),
+                subjects: vec![format!("feat: {tag}")],
+                commits: vec![format!("{tag}1")],
+                first_message: Some(format!("feat: {tag} pr:{tag}")),
+                ignored_after: Vec::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fix_pr_resolves_stable_handle_to_current_local_ordinal() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let target = GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        });
+
+        assert_eq!(resolve_fix_pr_target(&groups, &target).unwrap(), 2);
+    }
 }

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -1,7 +1,6 @@
 //! Adjust the tail of a PR group while preserving ignore blocks.
 
 use anyhow::{anyhow, bail, Result};
-use regex::Regex;
 use std::collections::HashSet;
 use tracing::info;
 
@@ -65,11 +64,10 @@ pub fn fix_pr_tail(
     let top_commits: Vec<String> = all_commits.split_off(all_commits.len() - m);
 
     // Validate: moved commits must NOT contain pr:<tag> markers
-    let re_tag = Regex::new(r"(?i)\bpr:([A-Za-z0-9._\-]+)\b")?;
     let mut offenders: Vec<String> = vec![];
     for sha in &top_commits {
         let msg = git_ro(["log", "-n", "1", "--format=%B", sha].as_slice())?;
-        if re_tag.is_match(&msg) {
+        if crate::pr_labels::candidate_marker_regex().is_match(&msg) {
             offenders.push(sha.clone());
         }
     }

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -7,16 +7,24 @@ use crate::github::{
     fetch_pr_bodies_graphql, fetch_pr_ci_review_status, graphql_escape, list_open_prs_for_heads,
 };
 use crate::parsing::derive_local_groups;
+use crate::selectors::{resolve_inclusive_count, InclusiveSelector};
+
+fn resolve_land_take_count(
+    groups: &[crate::parsing::Group],
+    until: &InclusiveSelector,
+) -> Result<usize> {
+    resolve_inclusive_count(groups, until)
+}
 
 pub fn land_until(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-    n: usize,
+    until: &InclusiveSelector,
     dry: bool,
     mode: LandCmd,
     bypass_safety: bool,
-) -> Result<()> {
+) -> Result<usize> {
     // Local stack is the source of truth: derive order from local groups
     let (_merge_base, groups) = derive_local_groups(base, ignore_tag)?;
     if groups.is_empty() {
@@ -43,11 +51,7 @@ pub fn land_until(
             );
         }
     }
-    let take_n = if n == 0 {
-        ordered.len()
-    } else {
-        n.min(ordered.len())
-    };
+    let take_n = resolve_land_take_count(&groups, until)?;
     let segment = &ordered[..take_n];
 
     // Safety validation: CI and Reviews must be passing/approved for all PRs being landed
@@ -210,7 +214,7 @@ pub fn land_until(
         ["api", "graphql", "-f", &format!("query={}", m)].as_slice(),
     )?;
 
-    Ok(())
+    Ok(take_n)
 }
 
 /// Per-PR: land N PRs bottom-up, each PR as its own commit using rebase merge.
@@ -219,15 +223,15 @@ pub fn land_per_pr_until(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-    n: usize,
+    until: &InclusiveSelector,
     dry: bool,
     bypass_safety: bool,
-) -> Result<()> {
+) -> Result<usize> {
     land_until(
         base,
         prefix,
         ignore_tag,
-        n,
+        until,
         dry,
         LandCmd::PerPr,
         bypass_safety,
@@ -239,17 +243,46 @@ pub fn land_flatten_until(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-    n: usize,
+    until: &InclusiveSelector,
     dry: bool,
     bypass_safety: bool,
-) -> Result<()> {
+) -> Result<usize> {
     land_until(
         base,
         prefix,
         ignore_tag,
-        n,
+        until,
         dry,
         LandCmd::Flatten,
         bypass_safety,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_land_take_count;
+    use crate::parsing::Group;
+    use crate::selectors::{GroupSelector, InclusiveSelector, StableHandle};
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter()
+            .map(|tag| Group {
+                tag: tag.to_string(),
+                subjects: vec![format!("feat: {tag}")],
+                commits: vec![format!("{tag}1")],
+                first_message: Some(format!("feat: {tag} pr:{tag}")),
+                ignored_after: Vec::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn land_until_resolves_stable_handle_as_inclusive_prefix() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let until = InclusiveSelector::Group(GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        }));
+
+        assert_eq!(resolve_land_take_count(&groups, &until).unwrap(), 2);
+    }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -68,6 +68,56 @@ fn summary_subject(subjects: &[String], _list_order: ListOrder) -> &str {
     subjects.first().map(|s| s.as_str()).unwrap_or("")
 }
 
+fn stable_handle_text(tag: &str) -> String {
+    format!("pr:{tag}")
+}
+
+struct PrSummaryLine<'a> {
+    ci_icon: &'a str,
+    rv_icon: &'a str,
+    local_pr_num: usize,
+    stable_handle: &'a str,
+    short: &'a str,
+    head_branch: &'a str,
+    pr_number: Option<u64>,
+    count: usize,
+}
+
+fn format_pr_summary_line(line: PrSummaryLine<'_>) -> String {
+    let remote_pr_num = if let Some(pr_number) = line.pr_number {
+        format!(" (#{pr_number})")
+    } else {
+        String::new()
+    };
+    let plural = if line.count == 1 { "commit" } else { "commits" };
+    format!(
+        "{}{} LPR #{} / {} - {} : {}{} - {} {}",
+        line.ci_icon,
+        line.rv_icon,
+        line.local_pr_num,
+        line.stable_handle,
+        line.short,
+        line.head_branch,
+        remote_pr_num,
+        line.count,
+        plural
+    )
+}
+
+fn format_commit_group_header(
+    local_pr_num: usize,
+    stable_handle: &str,
+    pr_number: Option<u64>,
+    head_branch: &str,
+) -> String {
+    let remote_pr_num = if let Some(pr_number) = pr_number {
+        format!(" (#{pr_number})")
+    } else {
+        String::new()
+    };
+    format!("===== Local PR #{local_pr_num} / {stable_handle}{remote_pr_num} : {head_branch} =====")
+}
+
 /// Print a per-PR summary for the current local stack.
 ///
 /// The local stack order is derived bottom-up from commits, so local PR numbers are based
@@ -120,22 +170,27 @@ pub fn list_prs_display(
         let num = pr.map(|p| p.number);
         let pr_state = pr.map(|p| p.state);
         let count = g.commits.len();
-        let plural = if count == 1 { "commit" } else { "commits" };
         let first_sha = g.commits.first().map(|s| s.as_str()).unwrap_or("");
         let short = if first_sha.len() >= 8 {
             &first_sha[..8]
         } else {
             first_sha
         };
-        let remote_pr_num_str = match num {
-            Some(n) => format!(" (#{})", n),
-            None => "".to_string(),
-        };
         let (ci_icon, rv_icon) = status_icons(pr_state, num, &status_map);
         let local_pr_num = group_idx + 1;
+        let stable_handle = stable_handle_text(&g.tag);
         info!(
-            "{}{} LPR #{} - {} : {}{} - {} {}",
-            ci_icon, rv_icon, local_pr_num, short, head_branch, remote_pr_num_str, count, plural
+            "{}",
+            format_pr_summary_line(PrSummaryLine {
+                ci_icon,
+                rv_icon,
+                local_pr_num,
+                stable_handle: &stable_handle,
+                short,
+                head_branch: &head_branch,
+                pr_number: num,
+                count,
+            })
         );
         let first_subject = summary_subject(&g.subjects, list_order);
         info!(
@@ -188,17 +243,12 @@ pub fn list_commits_display(
         let g = &groups[group_idx];
         let head_branch = format!("{}{}", prefix, g.tag);
         let num = prs.iter().find(|p| p.head == head_branch).map(|p| p.number);
-        let remote_pr_num_str = match num {
-            Some(n) => format!(" (#{})", n),
-            None => String::new(),
-        };
+        let stable_handle = stable_handle_text(&g.tag);
 
         // Group separator with local PR number
         info!(
-            "===== Local PR #{}{} : {} =====",
-            group_idx + 1,
-            remote_pr_num_str,
-            head_branch
+            "{}",
+            format_commit_group_header(group_idx + 1, &stable_handle, num, &head_branch)
         );
 
         let start_idx = group_start_idx[group_idx];
@@ -273,6 +323,37 @@ mod tests {
         assert_eq!(
             summary_subject(&subjects, ListOrder::RecentOnTop),
             "oldest commit subject"
+        );
+    }
+
+    #[test]
+    fn pr_summary_line_includes_stable_handle() {
+        let line = format_pr_summary_line(PrSummaryLine {
+            ci_icon: "✓",
+            rv_icon: "✓",
+            local_pr_num: 2,
+            stable_handle: "pr:beta",
+            short: "abcdef12",
+            head_branch: "dank-spr/beta",
+            pr_number: Some(17),
+            count: 3,
+        });
+
+        assert_eq!(
+            line,
+            "✓✓ LPR #2 / pr:beta - abcdef12 : dank-spr/beta (#17) - 3 commits"
+        );
+    }
+
+    #[test]
+    fn commit_group_header_includes_stable_handle_for_any_display_order() {
+        assert_eq!(
+            format_commit_group_header(2, "pr:beta", Some(17), "dank-spr/beta"),
+            "===== Local PR #2 / pr:beta (#17) : dank-spr/beta ====="
+        );
+        assert_eq!(
+            format_commit_group_header(2, "pr:beta", None, "dank-spr/beta"),
+            "===== Local PR #2 / pr:beta : dank-spr/beta ====="
         );
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,5 +17,5 @@ pub use list::list_prs_display;
 pub use prep::prep_squash;
 pub use r#move::move_groups_after;
 pub use relink_prs::relink_prs;
-pub use restack::restack_after;
+pub use restack::{restack_after, restack_after_count};
 pub use update::{build_from_groups, build_from_tags};

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -5,19 +5,9 @@ use tracing::info;
 
 use crate::commands::common;
 use crate::parsing::derive_local_groups_with_ignored;
-
-fn parse_range(input: &str) -> Result<(usize, usize)> {
-    if let Some(dots) = input.find("..") {
-        let (a, b) = input.split_at(dots);
-        let b = &b[2..];
-        let ai: usize = a.trim().parse()?;
-        let bi: usize = b.trim().parse()?;
-        Ok((ai, bi))
-    } else {
-        let ai: usize = input.trim().parse()?;
-        Ok((ai, ai))
-    }
-}
+use crate::selectors::{
+    resolve_after_count, resolve_group_range, AfterSelector, GroupRangeSelector,
+};
 
 fn format_simple_plan(old: &[usize], new: &[usize], a: usize, b: usize, c: usize) -> String {
     let lhs = if a == b {
@@ -54,6 +44,16 @@ fn cherry_pick_block(dry: bool, tmp_path: &str, commits: &[String]) -> Result<()
     }
 }
 
+fn resolve_move_targets(
+    groups: &[crate::parsing::Group],
+    range: &GroupRangeSelector,
+    after: &AfterSelector,
+) -> Result<(usize, usize, usize)> {
+    let (a, b) = resolve_group_range(groups, range)?;
+    let c = resolve_after_count(groups, after)?;
+    Ok((a, b, c))
+}
+
 /// Move a group (or group range) to come after a target group index.
 ///
 /// Ignore blocks (`pr:ignore` and its configured alias) remain attached to the
@@ -66,8 +66,8 @@ fn cherry_pick_block(dry: bool, tmp_path: &str, commits: &[String]) -> Result<()
 pub fn move_groups_after(
     base: &str,
     ignore_tag: &str,
-    range: &str,
-    after: &str,
+    range: &GroupRangeSelector,
+    after: &AfterSelector,
     safe: bool,
     dry: bool,
 ) -> Result<()> {
@@ -79,7 +79,7 @@ pub fn move_groups_after(
         return Ok(());
     }
 
-    let (a, b) = parse_range(range)?; // 1-based inclusive
+    let (a, b, c) = resolve_move_targets(&groups, range, after)?;
     if a == 0 || b == 0 || a > n || b > n {
         return Err(anyhow!(
             "Range out of bounds: {}..{} with N={} groups",
@@ -88,17 +88,6 @@ pub fn move_groups_after(
             n
         ));
     }
-    let c: usize = match after.trim().to_lowercase().as_str() {
-        "bottom" => 0,
-        "top" => n,
-        s => s.parse::<usize>().map_err(|_| {
-            anyhow!(
-                "--after must be a number in 0..={} or one of: bottom, top (got '{}')",
-                n,
-                after
-            )
-        })?,
-    };
     if c > n {
         return Err(anyhow!("--after must be in 0..={} (got {})", n, c));
     }
@@ -185,4 +174,44 @@ pub fn move_groups_after(
     common::cleanup_temp_worktree(dry, &tmp_path, &tmp_branch)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_move_targets;
+    use crate::parsing::Group;
+    use crate::selectors::{AfterSelector, GroupRangeSelector, GroupSelector, StableHandle};
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter()
+            .map(|tag| Group {
+                tag: tag.to_string(),
+                subjects: vec![format!("feat: {tag}")],
+                commits: vec![format!("{tag}1")],
+                first_message: Some(format!("feat: {tag} pr:{tag}")),
+                ignored_after: Vec::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn move_range_and_after_resolve_from_stable_handles() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let range = GroupRangeSelector::Inclusive {
+            start: GroupSelector::Stable(StableHandle {
+                tag: "beta".to_string(),
+            }),
+            end: GroupSelector::Stable(StableHandle {
+                tag: "gamma".to_string(),
+            }),
+        };
+        let after = AfterSelector::Group(GroupSelector::Stable(StableHandle {
+            tag: "alpha".to_string(),
+        }));
+
+        assert_eq!(
+            resolve_move_targets(&groups, &range, &after).unwrap(),
+            (2, 3, 1)
+        );
+    }
 }

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -1,10 +1,28 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use tracing::info;
 
 use crate::git::{git_ro, git_rw};
 use crate::github::{append_warning_to_pr, list_open_prs_for_heads};
 use crate::limit::Limit;
 use crate::parsing::derive_local_groups;
+use crate::selectors::{resolve_group_ordinal, resolve_inclusive_count};
+
+fn resolve_prep_window(
+    groups: &[crate::parsing::Group],
+    selection: &crate::cli::PrepSelection,
+) -> Result<(usize, usize)> {
+    match selection {
+        crate::cli::PrepSelection::All => Ok((0, groups.len())),
+        crate::cli::PrepSelection::Until(selector) => {
+            let end = resolve_inclusive_count(groups, selector)?;
+            Ok((0, end.min(groups.len())))
+        }
+        crate::cli::PrepSelection::Exact(selector) => {
+            let ordinal = resolve_group_ordinal(groups, selector)?;
+            Ok((ordinal - 1, ordinal))
+        }
+    }
+}
 
 /// Squash PRs according to selection; operate locally then run update for the affected groups.
 ///
@@ -27,16 +45,7 @@ pub fn prep_squash(
     }
 
     // Determine selected range of groups to prep (squash)
-    let (start_idx, end_idx_exclusive) = match selection {
-        crate::cli::PrepSelection::All => (0usize, groups.len()),
-        crate::cli::PrepSelection::Until(n) => (0usize, n.min(groups.len())),
-        crate::cli::PrepSelection::Exact(i) => {
-            if i == 0 || i > groups.len() {
-                bail!("--exact out of range (1..={})", groups.len());
-            }
-            (i - 1, (i - 1) + 1)
-        }
-    };
+    let (start_idx, end_idx_exclusive) = resolve_prep_window(&groups, &selection)?;
 
     // Start rebuilding history from just before the selected window
     let mut parent_sha = if start_idx == 0 {
@@ -192,14 +201,18 @@ pub fn prep_squash(
     // Decide limit for pushing and whether to warn the next PR
     let (limit, next_idx_opt) = match selection {
         crate::cli::PrepSelection::All => (None, None),
-        crate::cli::PrepSelection::Until(n) => {
+        crate::cli::PrepSelection::Until(selector) => {
+            let n = resolve_inclusive_count(&groups, &selector)?;
             if n == 0 {
                 (None, None)
             } else {
                 (Some(Limit::ByPr(n)), Some(n))
             }
         }
-        crate::cli::PrepSelection::Exact(i) => (Some(Limit::ByPr(i)), Some(i)),
+        crate::cli::PrepSelection::Exact(selector) => {
+            let i = resolve_group_ordinal(&groups, &selector)?;
+            (Some(Limit::ByPr(i)), Some(i))
+        }
     };
 
     // Push updates for the selected scope (respect PR body overwrite config)
@@ -241,4 +254,46 @@ pub fn prep_squash(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_prep_window;
+    use crate::cli::PrepSelection;
+    use crate::parsing::Group;
+    use crate::selectors::{GroupSelector, InclusiveSelector, StableHandle};
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter()
+            .map(|tag| Group {
+                tag: tag.to_string(),
+                subjects: vec![format!("feat: {tag}")],
+                commits: vec![format!("{tag}1")],
+                first_message: Some(format!("feat: {tag} pr:{tag}")),
+                ignored_after: Vec::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn prep_until_stable_handle_resolves_inclusive_window() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let selection = PrepSelection::Until(InclusiveSelector::Group(GroupSelector::Stable(
+            StableHandle {
+                tag: "beta".to_string(),
+            },
+        )));
+
+        assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (0, 2));
+    }
+
+    #[test]
+    fn prep_exact_stable_handle_resolves_single_group_window() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let selection = PrepSelection::Exact(GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        }));
+
+        assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (1, 2));
+    }
 }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -19,6 +19,7 @@ use crate::commands::common;
 use crate::config::RestackConflictPolicy;
 use crate::git::git_rw;
 use crate::parsing::{derive_local_groups_with_ignored, Group};
+use crate::selectors::{resolve_after_count, AfterSelector};
 
 /// A single planned cherry-pick step used to rebuild the restacked history.
 ///
@@ -193,6 +194,95 @@ fn emit_halt_instructions(
     info!("  spr update");
 }
 
+fn resolve_restack_after_count(groups: &[Group], after: &AfterSelector) -> Result<usize> {
+    resolve_after_count(groups, after)
+}
+
+fn restack_after_resolved(
+    base: &str,
+    leading_ignored: Vec<String>,
+    groups: Vec<Group>,
+    after: usize,
+    safe: bool,
+    dry: bool,
+    conflict_policy: RestackConflictPolicy,
+) -> Result<()> {
+    let (cur_branch, short) = common::get_current_branch_and_short()?;
+    let after = std::cmp::min(after, groups.len());
+    let kept_ignored: Vec<String> = leading_ignored
+        .into_iter()
+        .chain(
+            groups
+                .iter()
+                .take(after)
+                .flat_map(|group| group.ignored_after.iter().cloned()),
+        )
+        .collect();
+    let remaining = &groups[after..];
+    if remaining.is_empty() && kept_ignored.is_empty() {
+        if safe {
+            let _ = common::create_backup_tag(dry, "restack", &cur_branch, &short)?;
+        }
+        info!(
+            "Skipping all {} PR(s); syncing current branch {} to {}",
+            groups.len(),
+            cur_branch,
+            base
+        );
+        common::reset_current_branch_to(dry, base)?;
+        Ok(())
+    } else {
+        let backup_tag = if safe {
+            Some(common::create_backup_tag(
+                dry,
+                "restack",
+                &cur_branch,
+                &short,
+            )?)
+        } else {
+            None
+        };
+
+        let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "restack", base, &short)?;
+        let ops = build_cherry_pick_plan(&kept_ignored, remaining);
+        for (idx, op) in ops.iter().enumerate() {
+            if let Err(err) = op.run(dry, &tmp_path) {
+                let conflict = cherry_pick_head_exists(&tmp_path);
+                if conflict && conflict_policy == RestackConflictPolicy::Halt {
+                    emit_halt_instructions(
+                        &cur_branch,
+                        backup_tag.as_deref(),
+                        base,
+                        &tmp_path,
+                        &tmp_branch,
+                        idx,
+                        &ops,
+                    );
+                    return Err(anyhow!(
+                        "restack halted due to conflict; resolve in temp worktree and continue manually"
+                    ));
+                }
+
+                if conflict {
+                    abort_cherry_pick_best_effort(dry, &tmp_path);
+                }
+                cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
+                return Err(err).context("restack failed; temp restack state was cleaned up");
+            }
+        }
+
+        let new_tip = common::tip_of_tmp(&tmp_path)?;
+        info!(
+            "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
+            after, cur_branch, base
+        );
+        common::reset_current_branch_to(dry, &new_tip)?;
+        cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
+
+        Ok(())
+    }
+}
+
 /// Restack the local stack by rebasing commits after the first `after` PRs onto `base`.
 ///
 /// This preserves ignored commits (`pr:ignore` blocks) by carrying them into the
@@ -215,90 +305,85 @@ fn emit_halt_instructions(
 pub fn restack_after(
     base: &str,
     ignore_tag: &str,
-    after: usize,
+    after: &AfterSelector,
     safe: bool,
     dry: bool,
     conflict_policy: RestackConflictPolicy,
 ) -> Result<()> {
-    // Ensure we operate against the latest remote state
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
     let (_merge_base, leading_ignored, groups) =
         derive_local_groups_with_ignored(base, ignore_tag)?;
     if groups.is_empty() {
         info!("No local PR groups found; nothing to restack.");
-        return Ok(());
-    }
-    let (cur_branch, short) = common::get_current_branch_and_short()?;
-    // Clamp 'after' to the number of groups; if equal, there is nothing to move
-    let after = std::cmp::min(after, groups.len());
-    let mut kept_ignored: Vec<String> = leading_ignored;
-    for g in groups.iter().take(after) {
-        kept_ignored.extend(g.ignored_after.iter().cloned());
-    }
-    let remaining = &groups[after..];
-    if remaining.is_empty() && kept_ignored.is_empty() {
-        // Nothing to move; sync current branch to base
-        if safe {
-            let _ = common::create_backup_tag(dry, "restack", &cur_branch, &short)?;
-        }
-        info!(
-            "Skipping all {} PR(s); syncing current branch {} to {}",
-            groups.len(),
-            cur_branch,
-            base
-        );
-        common::reset_current_branch_to(dry, base)?;
-        return Ok(());
-    }
-
-    // Create a local backup tag pointing to current HEAD before rewriting
-    let backup_tag = if safe {
-        Some(common::create_backup_tag(
-            dry,
-            "restack",
-            &cur_branch,
-            &short,
-        )?)
+        Ok(())
     } else {
-        None
-    };
+        let after = resolve_restack_after_count(&groups, after)?;
+        restack_after_resolved(
+            base,
+            leading_ignored,
+            groups,
+            after,
+            safe,
+            dry,
+            conflict_policy,
+        )
+    }
+}
 
-    let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "restack", base, &short)?;
-    let ops = build_cherry_pick_plan(&kept_ignored, remaining);
-    for (idx, op) in ops.iter().enumerate() {
-        if let Err(err) = op.run(dry, &tmp_path) {
-            let conflict = cherry_pick_head_exists(&tmp_path);
-            if conflict && conflict_policy == RestackConflictPolicy::Halt {
-                emit_halt_instructions(
-                    &cur_branch,
-                    backup_tag.as_deref(),
-                    base,
-                    &tmp_path,
-                    &tmp_branch,
-                    idx,
-                    &ops,
-                );
-                return Err(anyhow!(
-                    "restack halted due to conflict; resolve in temp worktree and continue manually"
-                ));
-            }
+/// Restack the local stack by keeping the first `after` groups in place.
+pub fn restack_after_count(
+    base: &str,
+    ignore_tag: &str,
+    after: usize,
+    safe: bool,
+    dry: bool,
+    conflict_policy: RestackConflictPolicy,
+) -> Result<()> {
+    git_rw(dry, ["fetch", "origin"].as_slice())?;
 
-            if conflict {
-                abort_cherry_pick_best_effort(dry, &tmp_path);
-            }
-            cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
-            return Err(err).context("restack failed; temp restack state was cleaned up");
-        }
+    let (_merge_base, leading_ignored, groups) =
+        derive_local_groups_with_ignored(base, ignore_tag)?;
+    if groups.is_empty() {
+        Ok(())
+    } else {
+        restack_after_resolved(
+            base,
+            leading_ignored,
+            groups,
+            after,
+            safe,
+            dry,
+            conflict_policy,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_restack_after_count;
+    use crate::parsing::Group;
+    use crate::selectors::{AfterSelector, GroupSelector, StableHandle};
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter()
+            .map(|tag| Group {
+                tag: tag.to_string(),
+                subjects: vec![format!("feat: {tag}")],
+                commits: vec![format!("{tag}1")],
+                first_message: Some(format!("feat: {tag} pr:{tag}")),
+                ignored_after: Vec::new(),
+            })
+            .collect()
     }
 
-    let new_tip = common::tip_of_tmp(&tmp_path)?;
-    info!(
-        "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
-        after, cur_branch, base
-    );
-    common::reset_current_branch_to(dry, &new_tip)?;
-    cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
+    #[test]
+    fn restack_after_stable_handle_keeps_that_group_and_lower_groups() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let after = AfterSelector::Group(GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        }));
 
-    Ok(())
+        assert_eq!(resolve_restack_after_count(&groups, &after).unwrap(), 2);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,13 @@ fn resolve_update_pr_limit(
     n: Option<usize>,
     legacy_n: Option<usize>,
 ) -> Result<crate::limit::Limit> {
-    if let Some(to) = to {
+    let provided_limit_count =
+        usize::from(to.is_some()) + usize::from(n.is_some()) + usize::from(legacy_n.is_some());
+    if provided_limit_count > 1 {
+        Err(anyhow::anyhow!(
+            "`spr update pr` accepts only one limit selector: `--to <N|label|pr:<label>>`, `--n <N>`, or the positional `N`."
+        ))
+    } else if let Some(to) = to {
         let count = crate::selectors::resolve_group_ordinal(groups, &to)?;
         Ok(crate::limit::Limit::ByPr(count))
     } else if let Some(n) = n {
@@ -287,4 +293,43 @@ fn main() -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_update_pr_limit;
+    use crate::parsing::Group;
+    use crate::selectors::{GroupSelector, StableHandle};
+
+    fn group(tag: &str) -> Group {
+        Group {
+            tag: tag.to_string(),
+            subjects: vec![format!("feat: {tag}")],
+            commits: vec![format!("{tag}1")],
+            first_message: Some(format!("feat: {tag} pr:{tag}")),
+            ignored_after: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_update_pr_limit_rejects_conflicting_selectors() {
+        let groups = vec![group("alpha")];
+        let result = resolve_update_pr_limit(
+            &groups,
+            Some(GroupSelector::Stable(StableHandle {
+                tag: "alpha".to_string(),
+            })),
+            Some(1),
+            None,
+        );
+        let err = match result {
+            Ok(_) => panic!("expected conflicting selector inputs to fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("accepts only one limit selector"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,37 @@ mod git;
 mod github;
 mod limit;
 mod parsing;
+mod selectors;
+
+fn resolve_update_pr_limit(
+    groups: &[crate::parsing::Group],
+    to: Option<crate::selectors::GroupSelector>,
+    n: Option<usize>,
+    legacy_n: Option<usize>,
+) -> Result<crate::limit::Limit> {
+    if let Some(to) = to {
+        let count = crate::selectors::resolve_group_ordinal(groups, &to)?;
+        Ok(crate::limit::Limit::ByPr(count))
+    } else if let Some(n) = n {
+        if n == 0 {
+            Err(anyhow::anyhow!("`spr update pr --n` must be 1 or greater."))
+        } else {
+            Ok(crate::limit::Limit::ByPr(n))
+        }
+    } else if let Some(n) = legacy_n {
+        if n == 0 {
+            Err(anyhow::anyhow!(
+                "`spr update pr` positional limit must be 1 or greater."
+            ))
+        } else {
+            Ok(crate::limit::Limit::ByPr(n))
+        }
+    } else {
+        Err(anyhow::anyhow!(
+            "`spr update pr` requires either `--to <N|pr:<label>>` or `--n <N>`."
+        ))
+    }
+}
 
 fn init_tools() -> Result<()> {
     crate::git::ensure_tool("git")?;
@@ -97,10 +128,6 @@ fn main() -> Result<()> {
             extent,
         } => {
             set_dry_run_env(cli.dry_run, assume_existing_prs);
-            let limit = extent.map(|e| match e {
-                crate::cli::Extent::Pr { n } => crate::limit::Limit::ByPr(n),
-                crate::cli::Extent::Commits { n } => crate::limit::Limit::ByCommits(n),
-            });
             let pr_description_mode = pr_description_mode_override.unwrap_or(pr_description_mode);
             if restack {
                 return Err(anyhow::anyhow!(
@@ -116,6 +143,18 @@ fn main() -> Result<()> {
                         from
                     ));
                 }
+                let limit = if let Some(extent) = extent {
+                    match extent {
+                        crate::cli::Extent::Pr { to, n, legacy_n } => {
+                            Some(resolve_update_pr_limit(&groups, to, n, legacy_n)?)
+                        }
+                        crate::cli::Extent::Commits { n } => {
+                            Some(crate::limit::Limit::ByCommits(n))
+                        }
+                    }
+                } else {
+                    None
+                };
                 crate::commands::build_from_groups(
                     &base,
                     &prefix,
@@ -132,20 +171,10 @@ fn main() -> Result<()> {
         }
         crate::cli::Cmd::Restack { after, safe } => {
             set_dry_run_env(cli.dry_run, false);
-            let after_num: usize = match after.to_lowercase().as_str() {
-                "bottom" => 0,
-                "top" | "last" | "all" => usize::MAX,
-                s => s.parse::<usize>().map_err(|_| {
-                    anyhow::anyhow!(
-                        "Invalid value for --after: {} (expected number or bottom|top|last)",
-                        s
-                    )
-                })?,
-            };
             crate::commands::restack_after(
                 &base,
                 &ignore_tag,
-                after_num,
+                &after,
                 safe,
                 cli.dry_run,
                 restack_conflict_policy,
@@ -157,7 +186,7 @@ fn main() -> Result<()> {
                 return Err(anyhow::anyhow!("--until conflicts with --exact"));
             }
             let selection = if let Some(n) = cli.until {
-                if n == 0 {
+                if n == crate::selectors::InclusiveSelector::All {
                     crate::cli::PrepSelection::All
                 } else {
                     crate::cli::PrepSelection::Until(n)
@@ -199,13 +228,15 @@ fn main() -> Result<()> {
                 "per-pr" | "perpr" | "per_pr" => crate::cli::LandCmd::PerPr,
                 _ => crate::cli::LandCmd::Flatten,
             });
-            let until = cli.until.unwrap_or(0);
-            match mode {
+            let until = cli
+                .until
+                .unwrap_or(crate::selectors::InclusiveSelector::All);
+            let landed_count = match mode {
                 crate::cli::LandCmd::Flatten => crate::commands::land_flatten_until(
                     &base,
                     &prefix,
                     &ignore_tag,
-                    until,
+                    &until,
                     cli.dry_run,
                     r#unsafe,
                 )?,
@@ -213,17 +244,17 @@ fn main() -> Result<()> {
                     &base,
                     &prefix,
                     &ignore_tag,
-                    until,
+                    &until,
                     cli.dry_run,
                     r#unsafe,
                 )?,
-            }
+            };
             if !no_restack {
                 // After landing the first N PRs, restack the remaining commits onto the latest base
-                crate::commands::restack_after(
+                crate::commands::restack_after_count(
                     &base,
                     &ignore_tag,
-                    until,
+                    landed_count,
                     false,
                     cli.dry_run,
                     restack_conflict_policy,
@@ -238,9 +269,9 @@ fn main() -> Result<()> {
             set_dry_run_env(cli.dry_run, false);
             crate::commands::cleanup_remote_branches(&prefix, cli.dry_run)?;
         }
-        crate::cli::Cmd::FixPr { n, tail, safe } => {
+        crate::cli::Cmd::FixPr { target, tail, safe } => {
             set_dry_run_env(cli.dry_run, false);
-            crate::commands::fix_pr_tail(&base, &ignore_tag, n, tail, safe, cli.dry_run)?;
+            crate::commands::fix_pr_tail(&base, &ignore_tag, &target, tail, safe, cli.dry_run)?;
         }
         crate::cli::Cmd::Move { range, after, safe } => {
             set_dry_run_env(cli.dry_run, false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod git;
 mod github;
 mod limit;
 mod parsing;
+mod pr_labels;
 mod selectors;
 
 fn resolve_update_pr_limit(
@@ -36,7 +37,7 @@ fn resolve_update_pr_limit(
         }
     } else {
         Err(anyhow::anyhow!(
-            "`spr update pr` requires either `--to <N|pr:<label>>` or `--n <N>`."
+            "`spr update pr` requires either `--to <N|label|pr:<label>>` or `--n <N>`."
         ))
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -7,6 +7,7 @@
 use crate::git::git_ro;
 use anyhow::{bail, Result};
 use regex::Regex;
+use std::collections::HashSet;
 use tracing::warn;
 
 /// A PR group derived from `pr:<tag>` markers in commit messages.
@@ -103,6 +104,36 @@ impl Group {
             .trim()
             .to_string())
     }
+}
+
+#[derive(Debug)]
+struct DuplicateGroupTagError {
+    tag: String,
+}
+
+impl std::fmt::Display for DuplicateGroupTagError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Duplicate outstanding PR group tag `pr:{}`. `pr:<label>` starts a PR group, must remain unique within the outstanding stack, and is now used as a stable handle.",
+            self.tag
+        )
+    }
+}
+
+impl std::error::Error for DuplicateGroupTagError {}
+
+fn ensure_unique_group_tags(groups: &[Group]) -> Result<()> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    for group in groups {
+        if !seen.insert(group.tag.as_str()) {
+            return Err(DuplicateGroupTagError {
+                tag: group.tag.clone(),
+            }
+            .into());
+        }
+    }
+    Ok(())
 }
 
 /// Parse a reversed git log stream into PR groups, honoring an ignore tag.
@@ -209,6 +240,7 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
     if ignoring {
         flush_ignored(&mut ignored_block, &mut groups, &mut leading_ignored);
     }
+    ensure_unique_group_tags(&groups)?;
     Ok((leading_ignored, groups))
 }
 
@@ -376,5 +408,21 @@ mod tests {
         assert_eq!(groups[0].tag, "alpha");
         assert_eq!(groups[1].tag, "IGNORE");
         assert_eq!(groups[2].tag, "beta");
+    }
+
+    #[test]
+    fn parse_groups_rejects_duplicate_outstanding_tags() {
+        let raw = make_log(&[
+            ("a1", "feat: alpha start pr:alpha"),
+            ("a2", "feat: alpha follow-up"),
+            ("b1", "feat: duplicate alpha pr:alpha"),
+        ]);
+
+        let err = parse_groups(&raw, "ignore").unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Duplicate outstanding PR group tag `pr:alpha`"),
+            "unexpected error: {message}"
+        );
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -6,7 +6,6 @@
 
 use crate::git::git_ro;
 use anyhow::{bail, Result};
-use regex::Regex;
 use std::collections::HashSet;
 use tracing::warn;
 
@@ -32,8 +31,10 @@ pub struct Group {
 impl Group {
     pub fn pr_title(&self) -> Result<String> {
         if let Some(s) = self.subjects.first() {
-            let re = Regex::new(r"(?i)\bpr:([A-Za-z0-9._\-]+)\b")?;
-            let t = re.replace_all(s, "").trim().to_string();
+            let t = crate::pr_labels::valid_marker_regex()
+                .replace_all(s, "")
+                .trim()
+                .to_string();
             if !t.is_empty() {
                 return Ok(t);
             }
@@ -43,8 +44,7 @@ impl Group {
     pub fn squash_commit_message(&self) -> Result<String> {
         if let Some(full) = &self.first_message {
             // Validate the first commit contains the expected pr:<tag> marker
-            let re = Regex::new(r"(?i)\bpr:([A-Za-z0-9._\-]+)\b")?;
-            if let Some(cap) = re.captures(full) {
+            if let Some(cap) = crate::pr_labels::valid_marker_regex().captures(full) {
                 let found = cap.get(1).unwrap().as_str();
                 if !found.eq_ignore_ascii_case(&self.tag) {
                     bail!(
@@ -74,8 +74,7 @@ impl Group {
         } else {
             String::new()
         };
-        let re = Regex::new(r"(?i)\bpr:([A-Za-z0-9._\-]+)\b")?;
-        let cleaned = re
+        let cleaned = crate::pr_labels::valid_marker_regex()
             .replace_all(&base_body, "")
             .to_string()
             .trim()
@@ -97,8 +96,7 @@ impl Group {
         } else {
             String::new()
         };
-        let re = Regex::new(r"(?i)\bpr:([A-Za-z0-9._\-]+)\b")?;
-        Ok(re
+        Ok(crate::pr_labels::valid_marker_regex()
             .replace_all(&base_body, "")
             .to_string()
             .trim()
@@ -164,7 +162,6 @@ pub fn parse_groups(raw: &str, ignore_tag: &str) -> Result<Vec<Group>> {
 ///
 /// Returns an error if any commit message contains more than one `pr:<tag>` marker.
 pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<String>, Vec<Group>)> {
-    let re = Regex::new(r"(?i)\bpr:([A-Za-z0-9._\-]+)\b")?;
     let mut groups: Vec<Group> = vec![];
     let mut current: Option<Group> = None;
     let mut ignoring = false;
@@ -201,14 +198,18 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
         let message = parts.next().unwrap_or_default().to_string();
         let subj = message.lines().next().unwrap_or_default().to_string();
 
-        let tag_matches = re.captures_iter(&message).count();
-        if tag_matches > 1 {
+        let tags: Vec<String> = crate::pr_labels::candidate_marker_regex()
+            .captures_iter(&message)
+            .map(|cap| cap.get(1).unwrap().as_str().to_string())
+            .collect();
+        if tags.len() > 1 {
             bail!("Multiple pr:<tag> markers found in commit {sha}");
         }
 
-        if tag_matches == 1 {
-            let cap = re.captures(&message).unwrap();
-            let tag = cap.get(1).unwrap().as_str().to_string();
+        if let Some(tag) = tags.first() {
+            if let Err(err) = crate::pr_labels::validate_label(tag) {
+                bail!("Commit {sha} has invalid PR tag `pr:{tag}`: {err}");
+            }
             if tag == ignore_tag {
                 flush_current(&mut current, &mut groups);
                 ignoring = true;
@@ -221,7 +222,7 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
             }
             flush_current(&mut current, &mut groups);
             current = Some(Group {
-                tag,
+                tag: tag.clone(),
                 subjects: vec![subj.clone()],
                 commits: vec![sha],
                 first_message: Some(message.clone()),
@@ -422,6 +423,22 @@ mod tests {
         let message = format!("{err:#}");
         assert!(
             message.contains("Duplicate outstanding PR group tag `pr:alpha`"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_groups_rejects_digit_prefixed_tag() {
+        let raw = make_log(&[("a1", "feat: invalid start pr:1alpha")]);
+
+        let err = parse_groups(&raw, "ignore").unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Commit a1 has invalid PR tag `pr:1alpha`"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("must start with an ASCII letter"),
             "unexpected error: {message}"
         );
     }

--- a/src/pr_labels.rs
+++ b/src/pr_labels.rs
@@ -1,0 +1,65 @@
+//! Shared parsing and validation for PR-group labels.
+//!
+//! Labels are the immutable payload in `pr:<label>` commit markers and in
+//! stable selector inputs. They must start with an ASCII letter and may then
+//! use ASCII letters, digits, `.`, `_`, or `-`.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+const VALID_MARKER_PATTERN: &str = r"(?i)\bpr:([A-Za-z][A-Za-z0-9._\-]*)\b";
+const CANDIDATE_MARKER_PATTERN: &str = r"(?i)\bpr:([A-Za-z0-9._\-]+)\b";
+
+static VALID_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
+static CANDIDATE_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
+
+/// A validation failure for a PR-group label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabelValidationError {
+    MustStartWithLetter,
+    InvalidCharacters,
+}
+
+impl std::fmt::Display for LabelValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MustStartWithLetter => write!(f, "must start with an ASCII letter"),
+            Self::InvalidCharacters => write!(
+                f,
+                "must use only ASCII letters, digits, `.`, `_`, or `-` after the first letter"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LabelValidationError {}
+
+/// Returns the regex for valid `pr:<label>` markers in commit messages.
+pub fn valid_marker_regex() -> &'static Regex {
+    VALID_MARKER_REGEX.get_or_init(|| {
+        Regex::new(VALID_MARKER_PATTERN).expect("valid PR label regex should compile")
+    })
+}
+
+/// Returns the regex used to find candidate `pr:<tag>` markers before validation.
+pub fn candidate_marker_regex() -> &'static Regex {
+    CANDIDATE_MARKER_REGEX.get_or_init(|| {
+        Regex::new(CANDIDATE_MARKER_PATTERN).expect("candidate PR label regex should compile")
+    })
+}
+
+/// Validates one PR-group label against the shared commit-marker and selector grammar.
+pub fn validate_label(label: &str) -> std::result::Result<(), LabelValidationError> {
+    let mut chars = label.chars();
+    if let Some(first) = chars.next() {
+        if !first.is_ascii_alphabetic() {
+            Err(LabelValidationError::MustStartWithLetter)
+        } else if chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')) {
+            Ok(())
+        } else {
+            Err(LabelValidationError::InvalidCharacters)
+        }
+    } else {
+        Err(LabelValidationError::MustStartWithLetter)
+    }
+}

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -132,9 +132,7 @@ impl FromStr for GroupSelector {
 
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let trimmed = input.trim();
-        if has_pr_prefix(trimmed) {
-            parse_handle(trimmed).map(Self::Stable)
-        } else if is_digits_only(trimmed) {
+        if is_digits_only(trimmed) {
             parse_local_pr(trimmed).map(Self::LocalPr)
         } else {
             parse_handle(trimmed).map(Self::Stable)
@@ -147,11 +145,7 @@ impl FromStr for InclusiveSelector {
 
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let trimmed = input.trim();
-        if has_pr_prefix(trimmed) {
-            parse_handle(trimmed)
-                .map(GroupSelector::Stable)
-                .map(Self::Group)
-        } else if is_digits_only(trimmed) {
+        if is_digits_only(trimmed) {
             let parsed = trimmed.parse::<usize>().map_err(|_| {
                 format!("`{trimmed}` must be 0, a local PR number, a label, or `pr:<label>`")
             })?;
@@ -174,15 +168,7 @@ impl FromStr for AfterSelector {
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let trimmed = input.trim();
         let lowered = trimmed.to_ascii_lowercase();
-        if lowered == "bottom" {
-            Ok(Self::Bottom)
-        } else if lowered == "top" || lowered == "last" || lowered == "all" {
-            Ok(Self::Top)
-        } else if has_pr_prefix(trimmed) {
-            parse_handle(trimmed)
-                .map(GroupSelector::Stable)
-                .map(Self::Group)
-        } else if is_digits_only(trimmed) {
+        if is_digits_only(trimmed) {
             let parsed = trimmed.parse::<usize>().map_err(|_| {
                 format!(
                     "`{trimmed}` must be 0, a local PR number, `bottom`, `top`, `last`, `all`, a label, or `pr:<label>`"
@@ -193,6 +179,10 @@ impl FromStr for AfterSelector {
             } else {
                 Ok(Self::Group(GroupSelector::LocalPr(parsed)))
             }
+        } else if lowered == "bottom" {
+            Ok(Self::Bottom)
+        } else if lowered == "top" || lowered == "last" || lowered == "all" {
+            Ok(Self::Top)
         } else {
             parse_handle(trimmed)
                 .map(GroupSelector::Stable)

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -1,0 +1,393 @@
+//! Typed parsing and resolution for PR-group selectors.
+//!
+//! These types separate user-facing selector syntax from the current local PR
+//! numbering. Command entrypoints parse into these enums once, then resolve
+//! them against the current `Vec<Group>` to recover the numeric boundary or
+//! local ordinal that existing command logic already understands.
+
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use anyhow::{anyhow, bail, Result};
+
+use crate::parsing::Group;
+
+/// An immutable `pr:<label>` handle that refers to one outstanding PR group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StableHandle {
+    pub tag: String,
+}
+
+impl Display for StableHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "pr:{}", self.tag)
+    }
+}
+
+/// A selector for a single current PR group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupSelector {
+    LocalPr(usize),
+    Stable(StableHandle),
+}
+
+impl Display for GroupSelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LocalPr(n) => write!(f, "LPR #{}", n),
+            Self::Stable(handle) => write!(f, "{handle}"),
+        }
+    }
+}
+
+/// A selector for "through this group" semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InclusiveSelector {
+    All,
+    Group(GroupSelector),
+}
+
+/// A selector for "after this group" semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AfterSelector {
+    Bottom,
+    Top,
+    Group(GroupSelector),
+}
+
+/// A selector for moving either one group or an inclusive range of groups.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupRangeSelector {
+    Single(GroupSelector),
+    Inclusive {
+        start: GroupSelector,
+        end: GroupSelector,
+    },
+}
+
+fn has_pr_prefix(input: &str) -> bool {
+    if let Some(prefix) = input.get(..3) {
+        prefix.eq_ignore_ascii_case("pr:")
+    } else {
+        false
+    }
+}
+
+fn parse_handle(input: &str) -> std::result::Result<StableHandle, String> {
+    let trimmed = input.trim();
+    if !has_pr_prefix(trimmed) {
+        Err(format!("`{trimmed}` must start with `pr:`"))
+    } else if let Some(tag) = trimmed.get(3..) {
+        if tag.is_empty() {
+            Err(format!(
+                "stable selector `{trimmed}` is missing the label after `pr:`"
+            ))
+        } else if tag
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+        {
+            Ok(StableHandle {
+                tag: tag.to_string(),
+            })
+        } else {
+            Err(format!(
+                "stable selector `{trimmed}` must use only [A-Za-z0-9._-] after `pr:`"
+            ))
+        }
+    } else {
+        Err(format!("`{trimmed}` must start with `pr:`"))
+    }
+}
+
+fn parse_local_pr(input: &str) -> std::result::Result<usize, String> {
+    let trimmed = input.trim();
+    let parsed = trimmed
+        .parse::<usize>()
+        .map_err(|_| format!("`{trimmed}` is not a valid local PR number"))?;
+    if parsed == 0 {
+        Err("local PR numbers are 1-based; use 1 or greater".to_string())
+    } else {
+        Ok(parsed)
+    }
+}
+
+impl FromStr for GroupSelector {
+    type Err = String;
+
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        if has_pr_prefix(trimmed) {
+            parse_handle(trimmed).map(Self::Stable)
+        } else {
+            parse_local_pr(trimmed).map(Self::LocalPr)
+        }
+    }
+}
+
+impl FromStr for InclusiveSelector {
+    type Err = String;
+
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        if has_pr_prefix(trimmed) {
+            parse_handle(trimmed)
+                .map(GroupSelector::Stable)
+                .map(Self::Group)
+        } else {
+            let parsed = trimmed.parse::<usize>().map_err(|_| {
+                format!("`{trimmed}` must be 0, a local PR number, or `pr:<label>`")
+            })?;
+            if parsed == 0 {
+                Ok(Self::All)
+            } else {
+                Ok(Self::Group(GroupSelector::LocalPr(parsed)))
+            }
+        }
+    }
+}
+
+impl FromStr for AfterSelector {
+    type Err = String;
+
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        let lowered = trimmed.to_ascii_lowercase();
+        if lowered == "bottom" {
+            Ok(Self::Bottom)
+        } else if lowered == "top" || lowered == "last" || lowered == "all" {
+            Ok(Self::Top)
+        } else if has_pr_prefix(trimmed) {
+            parse_handle(trimmed)
+                .map(GroupSelector::Stable)
+                .map(Self::Group)
+        } else {
+            let parsed = trimmed.parse::<usize>().map_err(|_| {
+                format!(
+                    "`{trimmed}` must be 0, a local PR number, `bottom`, `top`, `last`, `all`, or `pr:<label>`"
+                )
+            })?;
+            if parsed == 0 {
+                Ok(Self::Bottom)
+            } else {
+                Ok(Self::Group(GroupSelector::LocalPr(parsed)))
+            }
+        }
+    }
+}
+
+impl FromStr for GroupRangeSelector {
+    type Err = String;
+
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        if let Some((start, end)) = trimmed.split_once("..") {
+            let start = start.parse::<GroupSelector>()?;
+            let end = end.parse::<GroupSelector>()?;
+            Ok(Self::Inclusive { start, end })
+        } else {
+            trimmed.parse::<GroupSelector>().map(Self::Single)
+        }
+    }
+}
+
+/// Resolve a selector to a 0-based index into the current local stack.
+pub fn resolve_group_index(groups: &[Group], selector: &GroupSelector) -> Result<usize> {
+    match selector {
+        GroupSelector::LocalPr(n) => {
+            if *n > 0 && *n <= groups.len() {
+                Ok(*n - 1)
+            } else if groups.is_empty() {
+                bail!("No outstanding PR groups are available.")
+            } else {
+                bail!(
+                    "{} is out of range for the current stack (1..={}).",
+                    selector,
+                    groups.len()
+                )
+            }
+        }
+        GroupSelector::Stable(handle) => groups
+            .iter()
+            .position(|group| group.tag == handle.tag)
+            .ok_or_else(|| anyhow!("No outstanding PR group matches stable handle `{handle}`.")),
+    }
+}
+
+/// Resolve a selector to the current 1-based local PR ordinal.
+pub fn resolve_group_ordinal(groups: &[Group], selector: &GroupSelector) -> Result<usize> {
+    resolve_group_index(groups, selector).map(|index| index + 1)
+}
+
+/// Resolve an inclusive boundary to the number of groups to include from the bottom.
+pub fn resolve_inclusive_count(groups: &[Group], selector: &InclusiveSelector) -> Result<usize> {
+    match selector {
+        InclusiveSelector::All => Ok(groups.len()),
+        InclusiveSelector::Group(selector) => resolve_group_ordinal(groups, selector),
+    }
+}
+
+/// Resolve an after-boundary to the number of groups to keep in place.
+pub fn resolve_after_count(groups: &[Group], selector: &AfterSelector) -> Result<usize> {
+    match selector {
+        AfterSelector::Bottom => Ok(0),
+        AfterSelector::Top => Ok(groups.len()),
+        AfterSelector::Group(selector) => resolve_group_ordinal(groups, selector),
+    }
+}
+
+/// Resolve a move-range selector to inclusive 1-based local ordinals.
+pub fn resolve_group_range(
+    groups: &[Group],
+    selector: &GroupRangeSelector,
+) -> Result<(usize, usize)> {
+    match selector {
+        GroupRangeSelector::Single(selector) => {
+            let ordinal = resolve_group_ordinal(groups, selector)?;
+            Ok((ordinal, ordinal))
+        }
+        GroupRangeSelector::Inclusive { start, end } => {
+            let start = resolve_group_ordinal(groups, start)?;
+            let end = resolve_group_ordinal(groups, end)?;
+            Ok((start, end))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_after_count, resolve_group_index, resolve_group_range, resolve_inclusive_count,
+        AfterSelector, GroupRangeSelector, GroupSelector, InclusiveSelector, StableHandle,
+    };
+    use crate::parsing::Group;
+
+    fn group(tag: &str) -> Group {
+        Group {
+            tag: tag.to_string(),
+            subjects: vec![format!("feat: {tag}")],
+            commits: vec![format!("{tag}1")],
+            first_message: Some(format!("feat: {tag} pr:{tag}")),
+            ignored_after: Vec::new(),
+        }
+    }
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter().map(|tag| group(tag)).collect()
+    }
+
+    #[test]
+    fn group_selector_parses_numeric_and_stable_forms() {
+        assert_eq!(
+            "2".parse::<GroupSelector>().unwrap(),
+            GroupSelector::LocalPr(2)
+        );
+        assert_eq!(
+            "PR:Beta".parse::<GroupSelector>().unwrap(),
+            GroupSelector::Stable(StableHandle {
+                tag: "Beta".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn inclusive_selector_parses_zero_as_all() {
+        assert_eq!(
+            "0".parse::<InclusiveSelector>().unwrap(),
+            InclusiveSelector::All
+        );
+    }
+
+    #[test]
+    fn after_selector_parses_keywords_and_stable_handle() {
+        assert_eq!(
+            "bottom".parse::<AfterSelector>().unwrap(),
+            AfterSelector::Bottom
+        );
+        assert_eq!("last".parse::<AfterSelector>().unwrap(), AfterSelector::Top);
+        assert_eq!(
+            "pr:beta".parse::<AfterSelector>().unwrap(),
+            AfterSelector::Group(GroupSelector::Stable(StableHandle {
+                tag: "beta".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn group_range_selector_parses_single_and_range_forms() {
+        assert_eq!(
+            "pr:beta..3".parse::<GroupRangeSelector>().unwrap(),
+            GroupRangeSelector::Inclusive {
+                start: GroupSelector::Stable(StableHandle {
+                    tag: "beta".to_string()
+                }),
+                end: GroupSelector::LocalPr(3)
+            }
+        );
+        assert_eq!(
+            "2".parse::<GroupRangeSelector>().unwrap(),
+            GroupRangeSelector::Single(GroupSelector::LocalPr(2))
+        );
+    }
+
+    #[test]
+    fn malformed_stable_handle_is_rejected() {
+        let err = "pr:beta!oops".parse::<GroupSelector>().unwrap_err();
+        assert!(err.contains("[A-Za-z0-9._-]"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn stable_handle_resolution_survives_local_pr_renumbering() {
+        let before = groups(&["alpha", "beta", "gamma"]);
+        let after = groups(&["beta", "gamma"]);
+        let selector = GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        });
+
+        let before_index = resolve_group_index(&before, &selector).unwrap();
+        let after_index = resolve_group_index(&after, &selector).unwrap();
+
+        assert_eq!(before[before_index].tag, "beta");
+        assert_eq!(after[after_index].tag, "beta");
+        assert_eq!(before_index + 1, 2);
+        assert_eq!(after_index + 1, 1);
+    }
+
+    #[test]
+    fn resolution_helpers_map_boundaries_to_counts() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+
+        assert_eq!(
+            resolve_inclusive_count(
+                &groups,
+                &InclusiveSelector::Group(GroupSelector::Stable(StableHandle {
+                    tag: "beta".to_string()
+                }))
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            resolve_after_count(
+                &groups,
+                &AfterSelector::Group(GroupSelector::Stable(StableHandle {
+                    tag: "beta".to_string()
+                }))
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            resolve_group_range(
+                &groups,
+                &GroupRangeSelector::Inclusive {
+                    start: GroupSelector::Stable(StableHandle {
+                        tag: "beta".to_string()
+                    }),
+                    end: GroupSelector::LocalPr(3)
+                }
+            )
+            .unwrap(),
+            (2, 3)
+        );
+    }
+}

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -3,7 +3,9 @@
 //! These types separate user-facing selector syntax from the current local PR
 //! numbering. Command entrypoints parse into these enums once, then resolve
 //! them against the current `Vec<Group>` to recover the numeric boundary or
-//! local ordinal that existing command logic already understands.
+//! local ordinal that existing command logic already understands. Stable-label
+//! selectors accept either bare labels or the explicit `pr:<label>` form, while
+//! digits-only inputs remain local PR ordinals.
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
@@ -73,29 +75,43 @@ fn has_pr_prefix(input: &str) -> bool {
     }
 }
 
+fn is_digits_only(input: &str) -> bool {
+    !input.is_empty() && input.chars().all(|ch| ch.is_ascii_digit())
+}
+
 fn parse_handle(input: &str) -> std::result::Result<StableHandle, String> {
     let trimmed = input.trim();
-    if !has_pr_prefix(trimmed) {
-        Err(format!("`{trimmed}` must start with `pr:`"))
-    } else if let Some(tag) = trimmed.get(3..) {
-        if tag.is_empty() {
-            Err(format!(
-                "stable selector `{trimmed}` is missing the label after `pr:`"
-            ))
-        } else if tag
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
-        {
-            Ok(StableHandle {
-                tag: tag.to_string(),
-            })
+    let tag = if has_pr_prefix(trimmed) {
+        if let Some(tag) = trimmed.get(3..) {
+            if tag.is_empty() {
+                return Err(format!(
+                    "stable selector `{trimmed}` is missing the label after `pr:`"
+                ));
+            } else {
+                tag
+            }
         } else {
-            Err(format!(
-                "stable selector `{trimmed}` must use only [A-Za-z0-9._-] after `pr:`"
-            ))
+            return Err(format!(
+                "stable selector `{trimmed}` is missing the label after `pr:`"
+            ));
         }
     } else {
-        Err(format!("`{trimmed}` must start with `pr:`"))
+        trimmed
+    };
+
+    if let Err(err) = crate::pr_labels::validate_label(tag) {
+        match err {
+            crate::pr_labels::LabelValidationError::MustStartWithLetter => Err(format!(
+                "stable selector `{trimmed}` must start with an ASCII letter"
+            )),
+            crate::pr_labels::LabelValidationError::InvalidCharacters => Err(format!(
+                "stable selector `{trimmed}` must use only ASCII letters, digits, `.`, `_`, or `-` after the first letter"
+            )),
+        }
+    } else {
+        Ok(StableHandle {
+            tag: tag.to_string(),
+        })
     }
 }
 
@@ -118,8 +134,10 @@ impl FromStr for GroupSelector {
         let trimmed = input.trim();
         if has_pr_prefix(trimmed) {
             parse_handle(trimmed).map(Self::Stable)
-        } else {
+        } else if is_digits_only(trimmed) {
             parse_local_pr(trimmed).map(Self::LocalPr)
+        } else {
+            parse_handle(trimmed).map(Self::Stable)
         }
     }
 }
@@ -133,15 +151,19 @@ impl FromStr for InclusiveSelector {
             parse_handle(trimmed)
                 .map(GroupSelector::Stable)
                 .map(Self::Group)
-        } else {
+        } else if is_digits_only(trimmed) {
             let parsed = trimmed.parse::<usize>().map_err(|_| {
-                format!("`{trimmed}` must be 0, a local PR number, or `pr:<label>`")
+                format!("`{trimmed}` must be 0, a local PR number, a label, or `pr:<label>`")
             })?;
             if parsed == 0 {
                 Ok(Self::All)
             } else {
                 Ok(Self::Group(GroupSelector::LocalPr(parsed)))
             }
+        } else {
+            parse_handle(trimmed)
+                .map(GroupSelector::Stable)
+                .map(Self::Group)
         }
     }
 }
@@ -160,10 +182,10 @@ impl FromStr for AfterSelector {
             parse_handle(trimmed)
                 .map(GroupSelector::Stable)
                 .map(Self::Group)
-        } else {
+        } else if is_digits_only(trimmed) {
             let parsed = trimmed.parse::<usize>().map_err(|_| {
                 format!(
-                    "`{trimmed}` must be 0, a local PR number, `bottom`, `top`, `last`, `all`, or `pr:<label>`"
+                    "`{trimmed}` must be 0, a local PR number, `bottom`, `top`, `last`, `all`, a label, or `pr:<label>`"
                 )
             })?;
             if parsed == 0 {
@@ -171,6 +193,10 @@ impl FromStr for AfterSelector {
             } else {
                 Ok(Self::Group(GroupSelector::LocalPr(parsed)))
             }
+        } else {
+            parse_handle(trimmed)
+                .map(GroupSelector::Stable)
+                .map(Self::Group)
         }
     }
 }
@@ -287,6 +313,12 @@ mod tests {
                 tag: "Beta".to_string()
             })
         );
+        assert_eq!(
+            "beta".parse::<GroupSelector>().unwrap(),
+            GroupSelector::Stable(StableHandle {
+                tag: "beta".to_string()
+            })
+        );
     }
 
     #[test]
@@ -294,6 +326,12 @@ mod tests {
         assert_eq!(
             "0".parse::<InclusiveSelector>().unwrap(),
             InclusiveSelector::All
+        );
+        assert_eq!(
+            "beta".parse::<InclusiveSelector>().unwrap(),
+            InclusiveSelector::Group(GroupSelector::Stable(StableHandle {
+                tag: "beta".to_string()
+            }))
         );
     }
 
@@ -310,12 +348,18 @@ mod tests {
                 tag: "beta".to_string()
             }))
         );
+        assert_eq!(
+            "beta".parse::<AfterSelector>().unwrap(),
+            AfterSelector::Group(GroupSelector::Stable(StableHandle {
+                tag: "beta".to_string()
+            }))
+        );
     }
 
     #[test]
     fn group_range_selector_parses_single_and_range_forms() {
         assert_eq!(
-            "pr:beta..3".parse::<GroupRangeSelector>().unwrap(),
+            "beta..3".parse::<GroupRangeSelector>().unwrap(),
             GroupRangeSelector::Inclusive {
                 start: GroupSelector::Stable(StableHandle {
                     tag: "beta".to_string()
@@ -327,12 +371,62 @@ mod tests {
             "2".parse::<GroupRangeSelector>().unwrap(),
             GroupRangeSelector::Single(GroupSelector::LocalPr(2))
         );
+        assert_eq!(
+            "beta..gamma".parse::<GroupRangeSelector>().unwrap(),
+            GroupRangeSelector::Inclusive {
+                start: GroupSelector::Stable(StableHandle {
+                    tag: "beta".to_string()
+                }),
+                end: GroupSelector::Stable(StableHandle {
+                    tag: "gamma".to_string()
+                })
+            }
+        );
     }
 
     #[test]
     fn malformed_stable_handle_is_rejected() {
-        let err = "pr:beta!oops".parse::<GroupSelector>().unwrap_err();
-        assert!(err.contains("[A-Za-z0-9._-]"), "unexpected error: {err}");
+        let err = "beta!oops".parse::<GroupSelector>().unwrap_err();
+        assert!(
+            err.contains("ASCII letters, digits"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn digit_prefixed_stable_handle_is_rejected() {
+        let err = "1beta".parse::<GroupSelector>().unwrap_err();
+        assert!(
+            err.contains("must start with an ASCII letter"),
+            "unexpected error: {err}"
+        );
+        let prefixed = "pr:1beta".parse::<GroupSelector>().unwrap_err();
+        assert!(
+            prefixed.contains("must start with an ASCII letter"),
+            "unexpected error: {prefixed}"
+        );
+    }
+
+    #[test]
+    fn prefixed_keyword_can_still_target_a_stable_handle() {
+        assert_eq!(
+            "pr:all".parse::<AfterSelector>().unwrap(),
+            AfterSelector::Group(GroupSelector::Stable(StableHandle {
+                tag: "all".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn digits_only_selectors_remain_local_pr_ordinals() {
+        assert_eq!(
+            "2".parse::<InclusiveSelector>().unwrap(),
+            InclusiveSelector::Group(GroupSelector::LocalPr(2))
+        );
+        assert_eq!(
+            "2".parse::<AfterSelector>().unwrap(),
+            AfterSelector::Group(GroupSelector::LocalPr(2))
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Problem Solved

Local PR numbers are only a view over the current outstanding stack. After landing or removing lower groups, `LPR #N` renumbers, which makes commands like `land`, `restack`, `prep`, `move`, `fix-pr`, and `update pr` awkward to script or reason about over time. This change promotes the existing `pr:<label>` group tag into a stable selector that resolves against the current local stack while keeping numeric selectors working.

# Mental model

- `pr:<label>` is now the stable identity of an outstanding PR group.
- `LPR #N` remains a derived local ordinal for display and backward-compatible CLI targeting.
- Commands parse typed selectors once, then resolve them to the current group ordinal or boundary before entering the existing command logic.
- Existing range keywords like `0`, `bottom`, `top`, `last`, and `all` keep their current meanings where they already existed.

# Example flow

Assume the current stack starts as:

```text
LPR #1 / pr:alpha
LPR #2 / pr:beta
LPR #3 / pr:gamma
```

You can land through the stable `beta` group without caring what its current local number is:

```bash
spr land flatten --until pr:beta
```

After that land completes, the outstanding stack renumbers to:

```text
LPR #1 / pr:gamma
```

That renumbering is the point of the feature: follow-on commands can still target the same surviving group by stable handle instead of guessing its new local ordinal.

```bash
spr prep --exact pr:gamma
spr update pr --to pr:gamma
spr restack --after pr:gamma
```

The same idea applies before the land as well:

```bash
spr move pr:beta --after pr:alpha
spr fix-pr pr:gamma --tail 1
```

# Non-goals

- This does not change how groups are discovered from commit history; groups still come from `pr:<tag>` commit markers.
- This does not persist a new identifier anywhere outside the existing commit metadata.
- This does not remove numeric selectors or change branch naming, GitHub PR numbering, or stack order semantics.
- This does not add rename or migration support for changing a group's `pr:<label>` after the fact.

# Tradeoffs

- Outstanding group tags now have to be unique. Previously duplicate `pr:<label>` groups could exist; now parsing fails because the label doubles as a stable handle. That is an intentional behavior change for duplicate-tag stacks.
- Stable handles survive local renumbering, but they still only resolve within the current outstanding stack.
- `spr update pr` grows a new canonical `--to` selector, while `--n` and the positional numeric form remain as compatibility paths for numeric-only usage.

# Architecture

- Add `src/selectors.rs` with typed selector enums for single-group, inclusive, after-boundary, and range selection plus shared resolution helpers over the current `Vec<Group>`.
- Wire those selector types through clap so malformed selectors fail at parse time instead of being passed around as raw strings.
- Route `land`, `restack`, `prep`, `move`, `fix-pr`, and `update pr` through the shared resolver layer so every command answers "which current group does this refer to?" the same way.
- Return the resolved landed group count from `land` so the automatic follow-on restack still targets the correct remaining groups even when `--until` was specified as `pr:<label>` and that label disappears after landing.
- Reject duplicate outstanding tags in `parsing.rs` because stable-handle lookup depends on one outstanding group per tag.
- Update `spr list pr`, `spr list commit`, clap help text, and README examples to show both the current `LPR #N` ordinal and the stable `pr:<label>` handle.

# Observability

- `spr list pr` summary lines and `spr list commit` group headers now show both the local ordinal and the stable handle, making it easier to copy the selector that will survive renumbering.
- Selector parsing errors now spell out the accepted forms such as `N`, `0`, keywords, and `pr:<label>`.
- Duplicate outstanding tags fail with an explicit error explaining that stable handles must be unique.

# Tests

- Add selector parsing and resolution coverage in `src/selectors.rs`.
- Add command-level tests proving stable handles resolve correctly for `land`, `restack`, `prep`, `move`, and `fix-pr`.
- Add parser coverage for duplicate outstanding tag rejection.
- Add output-format coverage for the new `spr list pr` summary line and `spr list commit` group header.
- Test scope stays within the touched selector, parser, command, and display boundaries.

<!-- spr-stack:start -->
**Stack**:
-   #114
-   #113
-   #112
-   #111
-   #110
- ➡ #109

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
