### PR TITLE
absorb: fold appended per-PR branch tails back into the stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Stack-friendly CLI to manage, update, and land stacked GitHub pull requests.
 Installation
 ------------
 
-- Requires `git` and GitHub CLI `gh` (authenticated) in `PATH`.
+- Requires `git` in `PATH`. GitHub CLI `gh` (authenticated) is required for GitHub-backed commands such as `spr update`, `spr list`, and `spr land`, and also for `spr move` because it checks the bottom PR's auto-merge state before rewriting the stack.
 - Build from source:
 
 ```bash
@@ -44,6 +44,14 @@ spr update
 # Inspect the stack
 spr list pr
 spr list commit
+
+# After appending commits directly to canonical local per-PR branches,
+# fold those tails back into the checked-out stack branch.
+spr absorb
+
+# Inspect the rewritten stack, then republish the per-PR branches.
+spr list commit
+spr update
 ```
 
 `pr:<tag>` is the stable handle for a PR group, and `<tag>` must start with an
@@ -178,6 +186,44 @@ Behavior:
 - `halt` stops on conflict, leaves the temp restack worktree and branch in place, and prints manual rollback/continue instructions.
 - When using `halt`, resolve conflicts inside the printed temp worktree path; resolving in your original worktree will not advance the halted cherry-pick.
 
+### spr absorb
+
+Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.
+
+Behavior:
+
+- If you append commits to the end of a local PR branch such as `user-spr/alpha`, `spr absorb` rebuilds the local stack so the new commits become part of the matching PR group while preserving PR-group order
+- Inspects only exact local branches named `prefix + tag`
+- Skips missing branches, branches whose rewritten-equivalent prefix still descends from the same stack merge-base and ends at the same pre-tail tree as the current stack, and branches that are behind the current stack
+- Refuses to operate when two live PR groups would derive synthetic branch names that differ only by case
+- Refuses to guess through divergence, source branches that incorporated later stack commits, merge commits, or absorbed commits that contain `pr:<tag>` markers
+- By default, also blocks copied later stack commits whose original replay would otherwise become empty or ambiguous
+- `--allow-replayed-duplicates` overrides that copied-commit blocker for safe cases by absorbing the copied commit and keeping its later non-seed replay in the rebuilt stack
+- Rebuilds the current stack from its existing `merge-base(base, HEAD)` rather than restacking onto the latest base tip
+- Inserts absorbed commits after the group's real commits and before that group's trailing ignored block
+- Creates a local backup tag before rewriting the stack
+- Does not update GitHub; inspect the rewritten stack first, then run `spr update`
+
+Typical workflow:
+
+```bash
+# The current stack has three PR groups: pr:alpha, pr:beta, and pr:gamma.
+git checkout user-spr/alpha
+git commit -m "feat: alpha branch tail"
+git commit -m "feat: alpha branch tail 2"
+
+git checkout <stack-branch>
+spr absorb
+spr list commit
+spr update
+```
+
+Override example for intentionally keeping both an earlier copied follow-up commit and its later replay:
+
+```bash
+spr absorb --allow-replayed-duplicates
+```
+
 ### spr list pr
 
 Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top, but the output now shows both the current `LPR #N` and the stable `pr:<label>` handle for each group.
@@ -217,6 +263,10 @@ Aliases:
 ### spr move
 
 Reorder local PR groups by moving one or a range to come after a target PR.
+
+Requires authenticated GitHub CLI `gh` because `spr move` checks whether the
+current bottom PR has auto-merge enabled before allowing a rewrite that would
+move another PR below it.
 
 Aliases:
 
@@ -308,7 +358,7 @@ spr fix-pr 1 --tail 2
 
 Behavior:
 
-- Rewrites local history to move the tail M commits after PR N’s tail commit
+- Rewrites local history to move the tail M commits after the selected PR group's tail commit
 - `--safe`: create a local backup tag at current `HEAD` before executing
 - Ignore blocks (`pr:ignore`) are preserved and cannot be moved; the command aborts if the tail intersects an ignore block
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,16 @@ pub enum Cmd {
         safe: bool,
     },
 
+    /// Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch
+    #[command(
+        long_about = "Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.\n\nIf you append commits to the end of a local PR branch such as `user-spr/alpha`, run `spr absorb` while the stack branch is checked out. `spr` rebuilds the local stack so the new commits become part of the matching PR group. The PR-group order stays the same.\n\nThis command is local-only: it rewrites the current stack branch, creates a backup tag, and does not update GitHub. After checking the result, run `spr update`.\n\nOnly exact local branches named `prefix + tag` are considered. If one of those branches still points at rewritten-equivalent stack commits, `spr absorb` accepts that prefix only when the branch still descends from the same stack merge-base and the matched pre-tail commit ends at the same tree as the canonical stack prefix. A no-op rewritten match is reported as `skip (rewritten-equivalent prefix)`, and only commits appended above that proven prefix are absorbed. `spr absorb` also refuses to operate when two live PR groups would derive synthetic branch names that differ only by case.\n\nExample:\n- The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`.\n- Check out `user-spr/alpha` and append 2 commits.\n- Check out the stack branch.\n- Run `spr absorb`.\n- Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same.\n- Then run `spr update`.\n\nOn cherry-pick conflict, `spr absorb` leaves the temp rewrite worktree in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and run the printed resume command.\n\nAdvanced:\n- By default, absorb blocks copied later commits when replaying the stack would become empty or ambiguous.\n- `--allow-replayed-duplicates` allows an earlier copied non-seed follow-up commit to coexist with its later replayed copy by keeping both commits in the rewritten stack."
+    )]
+    Absorb {
+        /// Allow replayed duplicates and keep both copies when the later replay is non-seed
+        #[arg(long)]
+        allow_replayed_duplicates: bool,
+    },
+
     /// Prepare PRs for landing (e.g., squash)
     Prep {
         // selection is provided via global --until/--exact flags
@@ -123,12 +133,12 @@ pub enum Cmd {
         // dry-run is provided via global --dry-run
     },
 
-    /// Move the last M commits (top of stack) to the tail of PR N (1-based, bottom→top)
+    /// Move the last M commits (top of stack) to the tail of a selected PR group
     #[command(visible_alias = "fix")]
     FixPr {
         /// Target local PR number or stable handle
         target: crate::selectors::GroupSelector,
-        /// Number of top commits to move to PR N's tail
+        /// Number of top commits to move to the selected PR group's tail
         #[arg(short = 't', long = "tail", default_value_t = 1)]
         tail: usize,
         /// Create a local backup tag at current HEAD before rewriting
@@ -185,4 +195,40 @@ pub struct Cli {
     pub exact: Option<crate::selectors::GroupSelector>,
     #[command(subcommand)]
     pub cmd: Cmd,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Cmd};
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn absorb_override_flag_parses() {
+        let cli = Cli::try_parse_from(["spr", "absorb", "--allow-replayed-duplicates"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Absorb {
+                allow_replayed_duplicates,
+            } => assert!(allow_replayed_duplicates),
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn absorb_help_text_mentions_pr_groups_and_example_flow() {
+        let mut cli = Cli::command();
+        let absorb = cli.find_subcommand_mut("absorb").unwrap();
+        let long_about = absorb.get_long_about().unwrap().to_string();
+
+        assert!(long_about.contains(
+            "The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`."
+        ));
+        assert!(long_about.contains("Check out `user-spr/alpha` and append 2 commits."));
+        assert!(long_about.contains("Check out the stack branch."));
+        assert!(long_about.contains("Run `spr absorb`."));
+        assert!(long_about.contains(
+            "Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same."
+        ));
+        assert!(long_about.contains("skip (rewritten-equivalent prefix)"));
+    }
 }

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -1,0 +1,2346 @@
+//! Absorb append-only local per-PR branch tails back into the current stack.
+//!
+//! `spr absorb` inspects the current local stack, looks for exact local source
+//! branches named `prefix + tag`, and classifies each one as absorbable,
+//! skippable, or blocking. When one or more groups have append-only local
+//! branch tails, the command rebuilds the checked-out stack branch from its
+//! current merge-base and inserts those tails immediately after their owning
+//! group's real commits and before any trailing ignored block. Rewritten local
+//! per-PR branches are treated as a distinct no-op only when they still descend
+//! from the same stack merge-base and reach the same pre-tail tree as the
+//! canonical stack prefix.
+
+use anyhow::{anyhow, Context, Result};
+use std::collections::{HashMap, HashSet};
+use tracing::{info, warn};
+
+use crate::commands::common::{self, CherryPickEmptyPolicy, CherryPickOp};
+use crate::git::{
+    git_commit_message, git_commit_parent_count, git_commit_tree, git_is_ancestor,
+    git_local_branch_tip, git_merge_base, git_patch_ids_for_commits, git_rev_list_range,
+    git_rev_parse,
+};
+use crate::parsing::{derive_local_groups_with_ignored, Group};
+
+/// Rebuilds the current stack branch by folding append-only local per-PR branch
+/// tails back into their owning PR groups.
+///
+/// The exact source branch rule is intentional: only the local branch named
+/// `prefix + tag` is considered for each group. Missing branches and branches
+/// that are unchanged or behind the stack are no-op states. Divergence, source
+/// branches that incorporated later stack commits, merge commits, and embedded
+/// `pr:<tag>` markers in absorbed tails are blocking errors. A local branch
+/// whose canonical stack prefix was rewritten to patch-equivalent commits is
+/// still acceptable when that rewritten prefix descends from the same stack
+/// merge-base and reaches the same tree at the matched pre-tail endpoint.
+/// Absorb then classifies only the unmatched tail. By default absorb also
+/// refuses to absorb a tail commit whose patch is already owned by a later
+/// stack commit that would still be replayed after this group's insertion
+/// point.
+pub fn absorb_branch_tails(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    dry: bool,
+    options: AbsorbOptions,
+) -> Result<()> {
+    let (_stack_head, plan) = build_plan_for_current_stack(base, prefix, ignore_tag, options)?;
+    let validation = validate_absorb_plan(&plan);
+    if !matches!(validation, AbsorbPlanValidation::NoGroups) {
+        emit_absorb_summary(&plan);
+    }
+    match validation {
+        AbsorbPlanValidation::NoGroups => {
+            info!("No local PR groups found; nothing to absorb.");
+            Ok(())
+        }
+        AbsorbPlanValidation::Blocked { lines } => Err(anyhow!(
+            "Refusing to absorb branch tails until blocking branches are fixed:\n{}",
+            lines.join("\n")
+        )),
+        AbsorbPlanValidation::NoAbsorbableGroups => {
+            info!("No absorbable branch tails found; nothing to rewrite.");
+            Ok(())
+        }
+        AbsorbPlanValidation::ReadyToRewrite => execute_absorb_plan(&plan, dry),
+    }
+}
+
+/// CLI-configurable behavior switches for `spr absorb`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AbsorbOptions {
+    /// Controls how absorb handles copied later stack commits in source-branch tails.
+    pub copied_later_stack_commit_policy: CopiedLaterStackCommitPolicy,
+}
+
+impl Default for AbsorbOptions {
+    fn default() -> Self {
+        Self {
+            copied_later_stack_commit_policy: CopiedLaterStackCommitPolicy::Block,
+        }
+    }
+}
+
+/// Policy for copied later stack commits discovered in an absorb tail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CopiedLaterStackCommitPolicy {
+    /// Treat copied later stack commits as blocking invalid input.
+    Block,
+    /// Absorb copied later non-seed commits and keep their later replay.
+    AllowKeepNonSeedDuplicates,
+}
+
+#[derive(Debug, Clone)]
+struct RewritePlan {
+    merge_base: String,
+    leading_ignored: Vec<String>,
+    groups: Vec<GroupRewritePlan>,
+    operations: Vec<CherryPickOp>,
+}
+
+impl RewritePlan {
+    fn has_blockers(&self) -> bool {
+        self.groups.iter().any(|group| {
+            matches!(
+                group.source.classification,
+                AbsorbClassification::Blocked(_)
+            )
+        })
+    }
+
+    fn has_absorbable_groups(&self) -> bool {
+        self.groups.iter().any(|group| group.source.is_absorbable())
+    }
+
+    fn blocking_lines(&self) -> Vec<String> {
+        self.groups
+            .iter()
+            .filter_map(|group| {
+                if matches!(
+                    group.source.classification,
+                    AbsorbClassification::Blocked(_)
+                ) {
+                    Some(group.source.summary_line())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+/// Pure validation result for an absorb rewrite plan before any local rewrite
+/// side effects are attempted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AbsorbPlanValidation {
+    NoGroups,
+    NoAbsorbableGroups,
+    ReadyToRewrite,
+    Blocked { lines: Vec<String> },
+}
+
+#[derive(Debug, Clone)]
+struct GroupRewritePlan {
+    group: Group,
+    source: SourceBranchRecord,
+}
+
+#[derive(Debug, Clone)]
+struct PreliminaryGroupRewritePlan {
+    group: Group,
+    source: PreliminarySourceBranchRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StackPrefix {
+    commits: Vec<String>,
+    group_start_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LaterReplayedCommitKind {
+    GroupSeed,
+    GroupFollowUp,
+    IgnoredAfter,
+}
+
+impl LaterReplayedCommitKind {
+    fn can_keep_duplicate_on_override(&self) -> bool {
+        !matches!(self, Self::GroupSeed)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LaterReplayedCommit {
+    tag: String,
+    sha: String,
+    kind: LaterReplayedCommitKind,
+}
+
+type LaterOwnedPatchMap = HashMap<String, Vec<LaterReplayedCommit>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PreliminarySourceBranchRecord {
+    tag: String,
+    branch_name: String,
+    group_tip: String,
+    source_tip: Option<String>,
+    classification: PreliminaryAbsorbClassification,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceBranchRecord {
+    tag: String,
+    branch_name: String,
+    group_tip: String,
+    source_tip: Option<String>,
+    classification: AbsorbClassification,
+}
+
+impl SourceBranchRecord {
+    fn summary_line(&self) -> String {
+        match &self.classification {
+            AbsorbClassification::Skip(reason) => {
+                format!(
+                    "pr:{} <- {} : skip ({})",
+                    self.tag, self.branch_name, reason
+                )
+            }
+            AbsorbClassification::Absorbable(tail) => {
+                let kept_text = if tail.kept_later_duplicate_replays.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        " (override keeps {})",
+                        commit_count_text(tail.kept_later_duplicate_replays.len())
+                    )
+                };
+                format!(
+                    "pr:{} <- {} : absorb {}{}",
+                    self.tag,
+                    self.branch_name,
+                    commit_count_text(tail.commits.len()),
+                    kept_text
+                )
+            }
+            AbsorbClassification::Blocked(reason) => {
+                format!(
+                    "pr:{} <- {} : block ({})",
+                    self.tag, self.branch_name, reason
+                )
+            }
+        }
+    }
+
+    fn absorbed_tail(&self) -> &[String] {
+        self.classification.absorbed_commits()
+    }
+
+    fn is_absorbable(&self) -> bool {
+        self.classification.is_absorbable()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PreliminaryAbsorbClassification {
+    Resolved(AbsorbClassification),
+    NeedsTailValidation { commits: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AbsorbClassification {
+    Skip(AbsorbSkipReason),
+    Absorbable(AbsorbTail),
+    Blocked(AbsorbBlocker),
+}
+
+impl AbsorbClassification {
+    fn absorbed_commits(&self) -> &[String] {
+        if let Self::Absorbable(tail) = self {
+            tail.commits.as_slice()
+        } else {
+            &[]
+        }
+    }
+
+    fn is_absorbable(&self) -> bool {
+        matches!(self, Self::Absorbable(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AbsorbTail {
+    commits: Vec<String>,
+    kept_later_duplicate_replays: Vec<LaterReplayedCommit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AbsorbSkipReason {
+    MissingBranch,
+    Unchanged,
+    RewrittenEquivalentPrefix,
+    BranchBehindStack,
+}
+
+impl std::fmt::Display for AbsorbSkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBranch => write!(f, "missing local branch"),
+            Self::Unchanged => write!(f, "branch unchanged"),
+            Self::RewrittenEquivalentPrefix => write!(f, "rewritten-equivalent prefix"),
+            Self::BranchBehindStack => write!(f, "branch behind stack"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AbsorbBlocker {
+    Diverged,
+    RewrittenPrefixWrongMergeBase {
+        expected_merge_base: String,
+    },
+    RewrittenPrefixTreeMismatch {
+        canonical_tip: String,
+        source_tip: String,
+    },
+    MergeBaseMismatch {
+        merge_base: String,
+    },
+    TailHasMergeCommit {
+        commit: String,
+    },
+    TailHasStackMarker {
+        commit: String,
+    },
+    TailOwnedByLaterReplayedCommit {
+        commit: String,
+        owner_tag: String,
+        owner_commit: String,
+    },
+    TailOwnedByLaterGroupSeed {
+        commit: String,
+        owner_tag: String,
+        owner_commit: String,
+    },
+}
+
+impl std::fmt::Display for AbsorbBlocker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Diverged => write!(f, "branch diverged from stack group tip"),
+            Self::RewrittenPrefixWrongMergeBase {
+                expected_merge_base,
+            } => write!(
+                f,
+                "rewritten-equivalent prefix does not descend from stack merge-base ({})",
+                short_sha(expected_merge_base)
+            ),
+            Self::RewrittenPrefixTreeMismatch {
+                canonical_tip,
+                source_tip,
+            } => write!(
+                f,
+                "rewritten-equivalent prefix ends at different tree than stack tip (stack {} vs branch {})",
+                short_sha(canonical_tip),
+                short_sha(source_tip)
+            ),
+            Self::MergeBaseMismatch { merge_base } => write!(
+                f,
+                "branch incorporated later stack commits (merge-base with HEAD is {})",
+                short_sha(merge_base)
+            ),
+            Self::TailHasMergeCommit { commit } => write!(
+                f,
+                "absorbed tail contains a merge commit ({})",
+                short_sha(commit)
+            ),
+            Self::TailHasStackMarker { commit } => write!(
+                f,
+                "absorbed tail contains a stack marker ({})",
+                short_sha(commit)
+            ),
+            Self::TailOwnedByLaterReplayedCommit {
+                commit,
+                owner_tag,
+                owner_commit,
+            } => write!(
+                f,
+                "absorbed tail commit {} duplicates later replayed pr:{} commit {}",
+                short_sha(commit),
+                owner_tag,
+                short_sha(owner_commit)
+            ),
+            Self::TailOwnedByLaterGroupSeed {
+                commit,
+                owner_tag,
+                owner_commit,
+            } => write!(
+                f,
+                "absorbed tail commit {} duplicates later pr:{} seed commit {}; --allow-replayed-duplicates only applies to later non-seed commits, so this still blocks",
+                short_sha(commit),
+                owner_tag,
+                short_sha(owner_commit)
+            ),
+        }
+    }
+}
+
+fn build_plan_for_current_stack(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    options: AbsorbOptions,
+) -> Result<(String, RewritePlan)> {
+    let (merge_base, leading_ignored, groups) = derive_local_groups_with_ignored(base, ignore_tag)?;
+    if groups.is_empty() {
+        Ok((
+            git_rev_parse("HEAD")?,
+            RewritePlan {
+                merge_base,
+                leading_ignored,
+                groups: Vec::new(),
+                operations: Vec::new(),
+            },
+        ))
+    } else {
+        let stack_head = git_rev_parse("HEAD")?;
+        let preliminary_group_plans = groups
+            .into_iter()
+            .map(|group| {
+                build_preliminary_group_rewrite_plan(group, prefix, &merge_base, &stack_head)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let later_owned_patch_maps = build_later_owned_patch_maps(&preliminary_group_plans)?;
+        let group_plans = preliminary_group_plans
+            .into_iter()
+            .zip(later_owned_patch_maps)
+            .map(|(group, later_owned_patches)| {
+                finalize_group_rewrite_plan(group, later_owned_patches.as_ref(), options)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let operations = build_rewrite_operations(&leading_ignored, &group_plans);
+        Ok((
+            stack_head,
+            RewritePlan {
+                merge_base,
+                leading_ignored,
+                groups: group_plans,
+                operations,
+            },
+        ))
+    }
+}
+
+fn build_preliminary_group_rewrite_plan(
+    group: Group,
+    prefix: &str,
+    stack_merge_base: &str,
+    stack_head: &str,
+) -> Result<PreliminaryGroupRewritePlan> {
+    let source =
+        classify_source_branch_preliminary(&group, prefix, stack_merge_base, stack_head)?;
+    Ok(PreliminaryGroupRewritePlan { group, source })
+}
+
+fn finalize_group_rewrite_plan(
+    group: PreliminaryGroupRewritePlan,
+    later_owned_patches: Option<&LaterOwnedPatchMap>,
+    options: AbsorbOptions,
+) -> Result<GroupRewritePlan> {
+    let source = finalize_source_branch_record(group.source, later_owned_patches, options)?;
+    Ok(GroupRewritePlan {
+        group: group.group,
+        source,
+    })
+}
+
+/// Classifies whether a rewrite plan is empty, blocked, a no-op, or ready to
+/// execute without touching local git state.
+fn validate_absorb_plan(plan: &RewritePlan) -> AbsorbPlanValidation {
+    if plan.groups.is_empty() {
+        AbsorbPlanValidation::NoGroups
+    } else if plan.has_blockers() {
+        AbsorbPlanValidation::Blocked {
+            lines: plan.blocking_lines(),
+        }
+    } else if !plan.has_absorbable_groups() {
+        AbsorbPlanValidation::NoAbsorbableGroups
+    } else {
+        AbsorbPlanValidation::ReadyToRewrite
+    }
+}
+
+fn classify_source_branch_preliminary(
+    group: &Group,
+    prefix: &str,
+    stack_merge_base: &str,
+    stack_head: &str,
+) -> Result<PreliminarySourceBranchRecord> {
+    let branch_name = format!("{}{}", prefix, group.tag);
+    let stack_prefix = build_stack_prefix(group, stack_merge_base)?;
+    let group_tip = stack_prefix
+        .commits
+        .last()
+        .cloned()
+        .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+    let source_tip = git_local_branch_tip(&branch_name)?;
+    let classification = if let Some(source_tip) = source_tip.as_deref() {
+        if source_tip == group_tip {
+            PreliminaryAbsorbClassification::Resolved(AbsorbClassification::Skip(
+                AbsorbSkipReason::Unchanged,
+            ))
+        } else if git_is_ancestor(source_tip, &group_tip)? {
+            PreliminaryAbsorbClassification::Resolved(AbsorbClassification::Skip(
+                AbsorbSkipReason::BranchBehindStack,
+            ))
+        } else if git_is_ancestor(&group_tip, source_tip)? {
+            let merge_base = git_merge_base(source_tip, stack_head)?;
+            if merge_base != group_tip {
+                PreliminaryAbsorbClassification::Resolved(AbsorbClassification::Blocked(
+                    AbsorbBlocker::MergeBaseMismatch { merge_base },
+                ))
+            } else {
+                PreliminaryAbsorbClassification::NeedsTailValidation {
+                    commits: git_rev_list_range(&group_tip, source_tip)?,
+                }
+            }
+        } else {
+            classify_rewritten_equivalent_source_branch_preliminary(
+                &stack_prefix,
+                source_tip,
+                stack_merge_base,
+            )?
+        }
+    } else {
+        PreliminaryAbsorbClassification::Resolved(AbsorbClassification::Skip(
+            AbsorbSkipReason::MissingBranch,
+        ))
+    };
+    Ok(PreliminarySourceBranchRecord {
+        tag: group.tag.clone(),
+        branch_name,
+        group_tip,
+        source_tip,
+        classification,
+    })
+}
+
+fn finalize_source_branch_record(
+    source: PreliminarySourceBranchRecord,
+    later_owned_patches: Option<&LaterOwnedPatchMap>,
+    options: AbsorbOptions,
+) -> Result<SourceBranchRecord> {
+    let classification = match source.classification {
+        PreliminaryAbsorbClassification::Resolved(classification) => classification,
+        PreliminaryAbsorbClassification::NeedsTailValidation { commits } => {
+            let later_owned_patches = later_owned_patches.ok_or_else(|| {
+                anyhow!(
+                    "Missing later-owned patch map for absorb candidate pr:{}",
+                    source.tag
+                )
+            })?;
+            classify_absorbed_tail(&commits, later_owned_patches, options)?
+        }
+    };
+    Ok(SourceBranchRecord {
+        tag: source.tag,
+        branch_name: source.branch_name,
+        group_tip: source.group_tip,
+        source_tip: source.source_tip,
+        classification,
+    })
+}
+
+fn build_stack_prefix(group: &Group, stack_merge_base: &str) -> Result<StackPrefix> {
+    let group_tip = group
+        .commits
+        .last()
+        .cloned()
+        .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+    let commits = git_rev_list_range(stack_merge_base, &group_tip)?;
+    let group_start_index = commits
+        .len()
+        .checked_sub(group.commits.len())
+        .ok_or_else(|| anyhow!("Group {} stack prefix is shorter than the group", group.tag))?;
+    Ok(StackPrefix {
+        commits,
+        group_start_index,
+    })
+}
+
+fn classify_rewritten_equivalent_source_branch_preliminary(
+    stack_prefix: &StackPrefix,
+    source_tip: &str,
+    stack_merge_base: &str,
+) -> Result<PreliminaryAbsorbClassification> {
+    if !git_is_ancestor(stack_merge_base, source_tip)? {
+        return Ok(PreliminaryAbsorbClassification::Resolved(
+            AbsorbClassification::Blocked(AbsorbBlocker::RewrittenPrefixWrongMergeBase {
+                expected_merge_base: stack_merge_base.to_string(),
+            }),
+        ));
+    }
+    let source_commits = git_rev_list_range(stack_merge_base, source_tip)?;
+    let patch_ids = git_patch_ids_for_commits(
+        &stack_prefix
+            .commits
+            .iter()
+            .chain(source_commits.iter())
+            .cloned()
+            .collect::<Vec<_>>(),
+    )?;
+    let stack_patch_ids = patch_id_sequence(&stack_prefix.commits, &patch_ids)?;
+    let source_patch_ids = patch_id_sequence(&source_commits, &patch_ids)?;
+    let matched = common_patch_prefix_len(&stack_patch_ids, &source_patch_ids);
+    if source_commits.len() == matched {
+        if matched < stack_prefix.group_start_index {
+            Ok(PreliminaryAbsorbClassification::Resolved(
+                AbsorbClassification::Blocked(AbsorbBlocker::Diverged),
+            ))
+        } else if let Some(blocked) =
+            validate_rewritten_prefix_endpoint(stack_prefix, &source_commits, matched)?
+        {
+            Ok(PreliminaryAbsorbClassification::Resolved(blocked))
+        } else if stack_prefix.commits.len() == matched {
+            Ok(PreliminaryAbsorbClassification::Resolved(
+                AbsorbClassification::Skip(AbsorbSkipReason::RewrittenEquivalentPrefix),
+            ))
+        } else {
+            Ok(PreliminaryAbsorbClassification::Resolved(
+                AbsorbClassification::Skip(AbsorbSkipReason::BranchBehindStack),
+            ))
+        }
+    } else if matched != stack_prefix.commits.len() {
+        Ok(PreliminaryAbsorbClassification::Resolved(
+            AbsorbClassification::Blocked(AbsorbBlocker::Diverged),
+        ))
+    } else if let Some(blocked) =
+        validate_rewritten_prefix_endpoint(stack_prefix, &source_commits, matched)?
+    {
+        Ok(PreliminaryAbsorbClassification::Resolved(blocked))
+    } else {
+        Ok(PreliminaryAbsorbClassification::NeedsTailValidation {
+            commits: source_commits.into_iter().skip(matched).collect::<Vec<_>>(),
+        })
+    }
+}
+
+fn validate_rewritten_prefix_endpoint(
+    stack_prefix: &StackPrefix,
+    source_commits: &[String],
+    matched: usize,
+) -> Result<Option<AbsorbClassification>> {
+    if matched == 0 {
+        Ok(Some(AbsorbClassification::Blocked(AbsorbBlocker::Diverged)))
+    } else {
+        let canonical_tip = stack_prefix
+            .commits
+            .get(matched - 1)
+            .cloned()
+            .ok_or_else(|| anyhow!("missing canonical matched prefix tip at index {}", matched))?;
+        let source_tip = source_commits
+            .get(matched - 1)
+            .cloned()
+            .ok_or_else(|| anyhow!("missing source matched prefix tip at index {}", matched))?;
+        if git_commit_tree(&canonical_tip)? == git_commit_tree(&source_tip)? {
+            Ok(None)
+        } else {
+            Ok(Some(AbsorbClassification::Blocked(
+                AbsorbBlocker::RewrittenPrefixTreeMismatch {
+                    canonical_tip,
+                    source_tip,
+                },
+            )))
+        }
+    }
+}
+
+fn patch_id_sequence(
+    commits: &[String],
+    patch_ids: &HashMap<String, String>,
+) -> Result<Vec<String>> {
+    commits
+        .iter()
+        .map(|sha| {
+            patch_ids
+                .get(sha)
+                .cloned()
+                .ok_or_else(|| anyhow!("missing patch id for {}", sha))
+        })
+        .collect()
+}
+
+fn common_patch_prefix_len(left: &[String], right: &[String]) -> usize {
+    left.iter()
+        .zip(right.iter())
+        .take_while(|(left_patch, right_patch)| left_patch == right_patch)
+        .count()
+}
+fn classify_absorbed_tail(
+    tail: &[String],
+    later_owned_patches: &LaterOwnedPatchMap,
+    options: AbsorbOptions,
+) -> Result<AbsorbClassification> {
+    for sha in tail {
+        let parent_count = git_commit_parent_count(sha)?;
+        if parent_count > 1 {
+            return Ok(AbsorbClassification::Blocked(
+                AbsorbBlocker::TailHasMergeCommit {
+                    commit: sha.clone(),
+                },
+            ));
+        }
+        let message = git_commit_message(sha)?;
+        if crate::pr_labels::contains_candidate_marker(&message) {
+            return Ok(AbsorbClassification::Blocked(
+                AbsorbBlocker::TailHasStackMarker {
+                    commit: sha.clone(),
+                },
+            ));
+        }
+    }
+    let tail_patch_ids = git_patch_ids_for_commits(tail)?;
+    let mut kept_later_replay_shas = HashSet::new();
+    let mut kept_later_duplicate_replays = Vec::new();
+    for sha in tail {
+        let Some(patch_id) = tail_patch_ids.get(sha) else {
+            continue;
+        };
+        if let Some(owners) = later_owned_patches.get(patch_id) {
+            match options.copied_later_stack_commit_policy {
+                CopiedLaterStackCommitPolicy::Block => {
+                    let owner = owners.first().expect("owners must not be empty");
+                    return Ok(AbsorbClassification::Blocked(
+                        AbsorbBlocker::TailOwnedByLaterReplayedCommit {
+                            commit: sha.clone(),
+                            owner_tag: owner.tag.clone(),
+                            owner_commit: owner.sha.clone(),
+                        },
+                    ));
+                }
+                CopiedLaterStackCommitPolicy::AllowKeepNonSeedDuplicates => {
+                    if let Some(owner) = owners
+                        .iter()
+                        .find(|owner| !owner.kind.can_keep_duplicate_on_override())
+                    {
+                        return Ok(AbsorbClassification::Blocked(
+                            AbsorbBlocker::TailOwnedByLaterGroupSeed {
+                                commit: sha.clone(),
+                                owner_tag: owner.tag.clone(),
+                                owner_commit: owner.sha.clone(),
+                            },
+                        ));
+                    }
+                    for owner in owners {
+                        if kept_later_replay_shas.insert(owner.sha.clone()) {
+                            kept_later_duplicate_replays.push(owner.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(AbsorbClassification::Absorbable(AbsorbTail {
+        commits: tail.to_vec(),
+        kept_later_duplicate_replays,
+    }))
+}
+
+fn build_later_owned_patch_maps(
+    groups: &[PreliminaryGroupRewritePlan],
+) -> Result<Vec<Option<LaterOwnedPatchMap>>> {
+    let candidate_group_indices = groups
+        .iter()
+        .enumerate()
+        .filter_map(|(index, group)| {
+            if matches!(
+                group.source.classification,
+                PreliminaryAbsorbClassification::NeedsTailValidation { .. }
+            ) {
+                Some(index)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    if candidate_group_indices.is_empty() {
+        return Ok(vec![None; groups.len()]);
+    }
+
+    let earliest_candidate_index = candidate_group_indices
+        .iter()
+        .min()
+        .copied()
+        .expect("candidate group indices should not be empty");
+    let replayed_commits = groups
+        .iter()
+        .enumerate()
+        .filter(|(index, _group)| *index > earliest_candidate_index)
+        .flat_map(|(_index, group)| {
+            group
+                .group
+                .commits
+                .iter()
+                .chain(group.group.ignored_after.iter())
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let patch_ids_by_commit = if replayed_commits.is_empty() {
+        HashMap::new()
+    } else {
+        git_patch_ids_for_commits(&replayed_commits)?
+    };
+    let mut later_owned_patches = HashMap::new();
+    let mut later_owned_patch_maps = Vec::with_capacity(groups.len());
+
+    for (index, group) in groups.iter().enumerate().rev() {
+        if index > earliest_candidate_index {
+            record_later_replayed_commits(
+                &mut later_owned_patches,
+                &group.group.ignored_after,
+                &group.group.tag,
+                &patch_ids_by_commit,
+                LaterReplayedCommitKind::IgnoredAfter,
+            );
+        }
+        if candidate_group_indices.contains(&index) {
+            later_owned_patch_maps.push(Some(later_owned_patches.clone()));
+        } else {
+            later_owned_patch_maps.push(None);
+        }
+        if index > earliest_candidate_index {
+            record_later_replayed_commits(
+                &mut later_owned_patches,
+                &group.group.commits,
+                &group.group.tag,
+                &patch_ids_by_commit,
+                LaterReplayedCommitKind::GroupFollowUp,
+            );
+        }
+    }
+
+    later_owned_patch_maps.reverse();
+    Ok(later_owned_patch_maps)
+}
+
+fn record_later_replayed_commits(
+    later_owned_patches: &mut LaterOwnedPatchMap,
+    commits: &[String],
+    tag: &str,
+    patch_ids_by_commit: &HashMap<String, String>,
+    default_kind: LaterReplayedCommitKind,
+) {
+    for (index, sha) in commits.iter().enumerate().rev() {
+        if let Some(patch_id) = patch_ids_by_commit.get(sha) {
+            let kind =
+                if matches!(default_kind, LaterReplayedCommitKind::GroupFollowUp) && index == 0 {
+                    LaterReplayedCommitKind::GroupSeed
+                } else {
+                    default_kind.clone()
+                };
+            later_owned_patches
+                .entry(patch_id.clone())
+                .or_default()
+                .push(LaterReplayedCommit {
+                    tag: tag.to_string(),
+                    sha: sha.clone(),
+                    kind,
+                });
+        }
+    }
+}
+
+fn build_rewrite_operations(
+    leading_ignored: &[String],
+    group_plans: &[GroupRewritePlan],
+) -> Vec<CherryPickOp> {
+    let kept_later_replay_shas = kept_later_replay_shas(group_plans);
+    let mut ops = build_replay_ops_for_commits(leading_ignored, &HashSet::new());
+    for group_plan in group_plans {
+        ops.extend(build_replay_ops_for_commits(
+            &group_plan.group.commits,
+            &kept_later_replay_shas,
+        ));
+        ops.extend(build_replay_ops_for_commits(
+            group_plan.source.absorbed_tail(),
+            &HashSet::new(),
+        ));
+        ops.extend(build_replay_ops_for_commits(
+            &group_plan.group.ignored_after,
+            &kept_later_replay_shas,
+        ));
+    }
+    ops
+}
+
+fn kept_later_replay_shas(group_plans: &[GroupRewritePlan]) -> HashSet<String> {
+    group_plans
+        .iter()
+        .flat_map(|group_plan| match &group_plan.source.classification {
+            AbsorbClassification::Absorbable(tail) => tail
+                .kept_later_duplicate_replays
+                .iter()
+                .map(|commit| commit.sha.clone())
+                .collect::<Vec<_>>(),
+            AbsorbClassification::Skip(_) | AbsorbClassification::Blocked(_) => Vec::new(),
+        })
+        .collect()
+}
+
+fn build_replay_ops_for_commits(
+    commits: &[String],
+    kept_later_replay_shas: &HashSet<String>,
+) -> Vec<CherryPickOp> {
+    let mut ops = Vec::new();
+    let mut segment_start: Option<usize> = None;
+    let mut segment_policy = CherryPickEmptyPolicy::StopOnEmpty;
+
+    for (index, sha) in commits.iter().enumerate() {
+        let next_policy = if kept_later_replay_shas.contains(sha) {
+            CherryPickEmptyPolicy::KeepRedundantCommits
+        } else {
+            CherryPickEmptyPolicy::StopOnEmpty
+        };
+        if let Some(start) = segment_start {
+            if next_policy != segment_policy {
+                ops.extend(CherryPickOp::from_commits_with_empty_policy(
+                    &commits[start..index],
+                    segment_policy,
+                ));
+                segment_start = Some(index);
+                segment_policy = next_policy;
+            }
+        } else {
+            segment_start = Some(index);
+            segment_policy = next_policy;
+        }
+    }
+
+    if let Some(start) = segment_start {
+        ops.extend(CherryPickOp::from_commits_with_empty_policy(
+            &commits[start..],
+            segment_policy,
+        ));
+    }
+
+    ops
+}
+
+fn cleanup_temp_worktree_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str) {
+    if let Err(err) = common::cleanup_temp_worktree(dry, tmp_path, tmp_branch) {
+        warn!(
+            "Failed to clean up temp absorb state ({} / {}): {}",
+            tmp_path, tmp_branch, err
+        );
+    }
+}
+
+/// Executes a validated absorb rewrite plan by rebuilding the current stack in
+/// a temporary worktree and resetting the checked-out branch to the new tip.
+fn execute_absorb_plan(plan: &RewritePlan, dry: bool) -> Result<()> {
+    emit_rewrite_plan(plan);
+    if dry {
+        info!("Dry run complete. No local git state or GitHub state was changed.");
+        info!("Run `spr absorb` without `--dry-run` to apply the rewrite.");
+        info!("After inspecting the rewritten stack, run `spr update`.");
+        Ok(())
+    } else {
+        let (cur_branch, short) = common::get_current_branch_and_short()?;
+        let _backup_tag = common::create_backup_tag(dry, "absorb", &cur_branch, &short)?;
+        let (tmp_path, tmp_branch) =
+            common::create_temp_worktree(dry, "absorb", &plan.merge_base, &short)?;
+        for op in &plan.operations {
+            if let Err(err) = op.run(dry, &tmp_path) {
+                return Err(err).with_context(|| {
+                    format!(
+                        "absorb rewrite failed in temp worktree {} on branch {}",
+                        tmp_path, tmp_branch
+                    )
+                });
+            }
+        }
+        let new_tip = common::tip_of_tmp(&tmp_path)?;
+        info!(
+            "Updating current branch {} to new tip {} (absorbed branch tails)...",
+            cur_branch, new_tip
+        );
+        common::reset_current_branch_to(dry, &new_tip)?;
+        cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
+        info!(
+            "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+        );
+        Ok(())
+    }
+}
+
+fn emit_absorb_summary(plan: &RewritePlan) {
+    info!("Absorb plan:");
+    for group in &plan.groups {
+        info!("{}", group.source.summary_line());
+    }
+}
+
+fn emit_rewrite_plan(plan: &RewritePlan) {
+    info!("Rewrite plan:");
+    if !plan.leading_ignored.is_empty() {
+        info!(
+            "  leading ignored: replay {}",
+            commit_count_text(plan.leading_ignored.len())
+        );
+    }
+    for group in &plan.groups {
+        let absorbed = group.source.absorbed_tail().len();
+        let kept_replays = match &group.source.classification {
+            AbsorbClassification::Absorbable(tail) => tail.kept_later_duplicate_replays.len(),
+            AbsorbClassification::Skip(_) | AbsorbClassification::Blocked(_) => 0,
+        };
+        let absorbed_text = if absorbed == 0 {
+            String::new()
+        } else {
+            format!(" + {}", commit_count_text(absorbed))
+        };
+        let ignored_text = if group.group.ignored_after.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " + {} ignored",
+                commit_count_text(group.group.ignored_after.len())
+            )
+        };
+        let kept_text = if kept_replays == 0 {
+            String::new()
+        } else {
+            format!(" + keep {}", commit_count_text(kept_replays))
+        };
+        info!(
+            "  pr:{}: replay {}{}{}{}",
+            group.group.tag,
+            commit_count_text(group.group.commits.len()),
+            absorbed_text,
+            ignored_text,
+            kept_text
+        );
+    }
+}
+
+fn commit_count_text(count: usize) -> String {
+    if count == 1 {
+        "1 commit".to_string()
+    } else {
+        format!("{} commits", count)
+    }
+}
+
+fn short_sha(sha: &str) -> &str {
+    if sha.len() > 8 {
+        &sha[..8]
+    } else {
+        sha
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        absorb_branch_tails, build_plan_for_current_stack, build_rewrite_operations,
+        validate_absorb_plan, AbsorbBlocker, AbsorbClassification, AbsorbOptions,
+        AbsorbPlanValidation, AbsorbSkipReason, AbsorbTail, CopiedLaterStackCommitPolicy,
+        GroupRewritePlan, LaterReplayedCommit, LaterReplayedCommitKind, RewritePlan,
+        SourceBranchRecord,
+    };
+    use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
+    use crate::parsing::{derive_local_groups_with_ignored, Group};
+    use std::env;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::{Mutex, MutexGuard};
+    use tempfile::TempDir;
+
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_cwd() -> MutexGuard<'static, ()> {
+        CWD_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+    }
+
+    struct DirGuard {
+        original: PathBuf,
+    }
+
+    impl DirGuard {
+        fn change_to(path: &Path) -> Self {
+            let original = env::current_dir().expect("current dir available");
+            env::set_current_dir(path).expect("set current dir to temp repo");
+            Self { original }
+        }
+    }
+
+    impl Drop for DirGuard {
+        fn drop(&mut self) {
+            env::set_current_dir(&self.original).expect("restore original current dir");
+        }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            let original = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.original {
+                env::set_var(self.key, value);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    struct StackRepo {
+        dir: TempDir,
+        repo: PathBuf,
+        stack_branch: String,
+        base_branch: String,
+        prefix: String,
+        ignore_tag: String,
+        alpha_tip: String,
+        beta_tip: Option<String>,
+        gamma_tip: Option<String>,
+    }
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path();
+        git(repo, ["init", "-b", "main"].as_slice());
+        git(repo, ["config", "user.email", "spr@example.com"].as_slice());
+        git(repo, ["config", "user.name", "SPR Tests"].as_slice());
+        write_file(repo, "README.md", "init\n");
+        git(repo, ["add", "."].as_slice());
+        git(repo, ["commit", "-m", "init"].as_slice());
+        dir
+    }
+
+    fn write_file(repo: &Path, file: &str, contents: &str) {
+        fs::write(repo.join(file), contents).expect("write file");
+    }
+
+    fn commit_file(repo: &Path, file: &str, contents: &str, message: &str) -> String {
+        write_file(repo, file, contents);
+        git(repo, ["add", file].as_slice());
+        git(repo, ["commit", "-m", message].as_slice());
+        rev_parse(repo, "HEAD")
+    }
+
+    fn rev_parse(repo: &Path, revision: &str) -> String {
+        git(repo, ["rev-parse", revision].as_slice())
+            .trim()
+            .to_string()
+    }
+
+    fn current_branch(repo: &Path) -> String {
+        git(repo, ["rev-parse", "--abbrev-ref", "HEAD"].as_slice())
+            .trim()
+            .to_string()
+    }
+
+    fn current_path() -> String {
+        env::var("PATH").expect("PATH is set")
+    }
+
+    fn find_git_binary() -> String {
+        let out = Command::new("sh")
+            .args(["-c", "command -v git"])
+            .output()
+            .expect("find git binary");
+        assert!(
+            out.status.success(),
+            "failed to locate git binary\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn install_cleanup_failure_git_wrapper(tmp_path: &str) -> TempDir {
+        let dir = tempfile::tempdir().expect("create wrapper dir");
+        let wrapper_path = dir.path().join("git");
+        let script = format!(
+            "#!/bin/sh\nif [ \"$1\" = \"worktree\" ] && [ \"$2\" = \"remove\" ] && [ \"$3\" = \"-f\" ] && [ \"$4\" = \"{tmp_path}\" ]; then\n  echo \"simulated absorb cleanup failure\" >&2\n  exit 1\nfi\nexec \"{}\" \"$@\"\n",
+            find_git_binary()
+        );
+        fs::write(&wrapper_path, script).expect("write git wrapper");
+        let mut permissions = fs::metadata(&wrapper_path)
+            .expect("read git wrapper metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&wrapper_path, permissions).expect("chmod git wrapper");
+        dir
+    }
+
+    fn tags_with_pattern(repo: &Path, pattern: &str) -> Vec<String> {
+        git(repo, ["tag", "--list", pattern].as_slice())
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    fn branches_with_pattern(repo: &Path, pattern: &str) -> Vec<String> {
+        git(repo, ["branch", "--list", pattern].as_slice())
+            .lines()
+            .map(str::trim)
+            .map(|line| line.strip_prefix("* ").unwrap_or(line))
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    fn commit_range(repo: &Path, from_exclusive: &str, to_inclusive: &str) -> Vec<String> {
+        let range = format!("{from_exclusive}..{to_inclusive}");
+        git(repo, ["rev-list", "--reverse", &range].as_slice())
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    fn rewrite_stack_branch_equivalently(repo: &StackRepo) {
+        let commits = commit_range(&repo.repo, &repo.base_branch, &repo.stack_branch);
+        git(
+            &repo.repo,
+            ["checkout", "-b", "rewrite-copy", &repo.base_branch].as_slice(),
+        );
+        for commit in &commits {
+            git(
+                &repo.repo,
+                [
+                    "-c",
+                    "user.name=Rewrite Stack",
+                    "-c",
+                    "user.email=rewrite@example.com",
+                    "cherry-pick",
+                    commit,
+                ]
+                .as_slice(),
+            );
+        }
+        git(
+            &repo.repo,
+            ["branch", "-f", &repo.stack_branch, "HEAD"].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+        git(&repo.repo, ["branch", "-D", "rewrite-copy"].as_slice());
+    }
+
+    fn recreate_alpha_branch_on_equivalent_orphan_base(repo: &StackRepo) {
+        let alpha_commits = commit_range(&repo.repo, &repo.base_branch, &repo.alpha_tip);
+        git(&repo.repo, ["checkout", &repo.base_branch].as_slice());
+        git(
+            &repo.repo,
+            ["checkout", "--orphan", "foreign-alpha"].as_slice(),
+        );
+        git(&repo.repo, ["add", "."].as_slice());
+        git(&repo.repo, ["commit", "-m", "foreign init"].as_slice());
+        for commit in &alpha_commits {
+            git(&repo.repo, ["cherry-pick", commit].as_slice());
+        }
+        git(
+            &repo.repo,
+            ["branch", "-f", "dank-spr/alpha", "HEAD"].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+        git(&repo.repo, ["branch", "-D", "foreign-alpha"].as_slice());
+    }
+
+    fn setup_single_group_stack(create_alpha_branch: bool) -> StackRepo {
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let base_branch = "main".to_string();
+        let stack_branch = "stack".to_string();
+        let prefix = "dank-spr/".to_string();
+        let ignore_tag = "ignore".to_string();
+
+        git(&repo, ["checkout", "-b", &stack_branch].as_slice());
+        let _alpha_seed = commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\n",
+            "feat: alpha seed\n\npr:alpha",
+        );
+        let alpha_tip = commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\n",
+            "feat: alpha follow-up",
+        );
+        if create_alpha_branch {
+            git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        }
+
+        StackRepo {
+            dir,
+            repo,
+            stack_branch,
+            base_branch,
+            prefix,
+            ignore_tag,
+            alpha_tip,
+            beta_tip: None,
+            gamma_tip: None,
+        }
+    }
+
+    fn setup_three_group_stack() -> StackRepo {
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let base_branch = "main".to_string();
+        let stack_branch = "stack".to_string();
+        let prefix = "dank-spr/".to_string();
+        let ignore_tag = "ignore".to_string();
+
+        git(&repo, ["checkout", "-b", &stack_branch].as_slice());
+        let _alpha_seed = commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\n",
+            "feat: alpha seed\n\npr:alpha",
+        );
+        let alpha_tip = commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\n",
+            "feat: alpha follow-up",
+        );
+        let _ignore_seed = commit_file(
+            &repo,
+            "scratch.txt",
+            "scratch-1\n",
+            "chore: local experiments\n\npr:ignore",
+        );
+        let _ignore_follow = commit_file(
+            &repo,
+            "scratch.txt",
+            "scratch-1\nscratch-2\n",
+            "wip: scratch cleanup",
+        );
+        let beta_tip = commit_file(&repo, "beta.txt", "beta-1\n", "feat: beta seed\n\npr:beta");
+        let gamma_tip = commit_file(
+            &repo,
+            "gamma.txt",
+            "gamma-1\n",
+            "feat: gamma seed\n\npr:gamma",
+        );
+
+        git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        git(&repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
+        git(&repo, ["branch", "dank-spr/gamma", &gamma_tip].as_slice());
+
+        StackRepo {
+            dir,
+            repo,
+            stack_branch,
+            base_branch,
+            prefix,
+            ignore_tag,
+            alpha_tip,
+            beta_tip: Some(beta_tip),
+            gamma_tip: Some(gamma_tip),
+        }
+    }
+
+    fn setup_three_group_stack_with_beta_follow_up() -> StackRepo {
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let base_branch = "main".to_string();
+        let stack_branch = "stack".to_string();
+        let prefix = "dank-spr/".to_string();
+        let ignore_tag = "ignore".to_string();
+
+        git(&repo, ["checkout", "-b", &stack_branch].as_slice());
+        let _alpha_seed = commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\n",
+            "feat: alpha seed\n\npr:alpha",
+        );
+        let alpha_tip = commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\n",
+            "feat: alpha follow-up",
+        );
+        let _ignore_seed = commit_file(
+            &repo,
+            "scratch.txt",
+            "scratch-1\n",
+            "chore: local experiments\n\npr:ignore",
+        );
+        let _ignore_follow = commit_file(
+            &repo,
+            "scratch.txt",
+            "scratch-1\nscratch-2\n",
+            "wip: scratch cleanup",
+        );
+        let _beta_seed = commit_file(&repo, "beta.txt", "beta-1\n", "feat: beta seed\n\npr:beta");
+        let beta_tip = commit_file(
+            &repo,
+            "beta-extra.txt",
+            "beta-extra-1\n",
+            "feat: beta follow-up",
+        );
+        let gamma_tip = commit_file(
+            &repo,
+            "gamma.txt",
+            "gamma-1\n",
+            "feat: gamma seed\n\npr:gamma",
+        );
+
+        git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        git(&repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
+        git(&repo, ["branch", "dank-spr/gamma", &gamma_tip].as_slice());
+
+        StackRepo {
+            dir,
+            repo,
+            stack_branch,
+            base_branch,
+            prefix,
+            ignore_tag,
+            alpha_tip,
+            beta_tip: Some(beta_tip),
+            gamma_tip: Some(gamma_tip),
+        }
+    }
+
+    fn append_commit_to_branch(
+        repo: &Path,
+        branch: &str,
+        file: &str,
+        contents: &str,
+        message: &str,
+    ) -> String {
+        git(repo, ["checkout", branch].as_slice());
+        commit_file(repo, file, contents, message)
+    }
+
+    fn default_absorb_options() -> AbsorbOptions {
+        AbsorbOptions::default()
+    }
+
+    fn absorb_override_options() -> AbsorbOptions {
+        AbsorbOptions {
+            copied_later_stack_commit_policy:
+                CopiedLaterStackCommitPolicy::AllowKeepNonSeedDuplicates,
+        }
+    }
+
+    fn classify_alpha(repo: &StackRepo, options: AbsorbOptions) -> AbsorbClassification {
+        let _guard = DirGuard::change_to(&repo.repo);
+        let (_stack_head, plan) = build_plan_for_current_stack(
+            &repo.base_branch,
+            &repo.prefix,
+            &repo.ignore_tag,
+            options,
+        )
+        .unwrap();
+        plan.groups[0].source.classification.clone()
+    }
+
+    #[test]
+    fn classify_missing_source_branch_as_skip() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(false);
+        let _keep_dir_alive = repo.dir.path();
+
+        assert_eq!(
+            classify_alpha(&repo, default_absorb_options()),
+            AbsorbClassification::Skip(AbsorbSkipReason::MissingBranch)
+        );
+    }
+
+    #[test]
+    fn classify_unchanged_source_branch_as_skip() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+
+        assert_eq!(
+            classify_alpha(&repo, default_absorb_options()),
+            AbsorbClassification::Skip(AbsorbSkipReason::Unchanged)
+        );
+    }
+
+    #[test]
+    fn classify_branch_behind_stack_as_skip() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+        let _new_alpha_tip = commit_file(
+            &repo.repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-3\n",
+            "feat: alpha on stack",
+        );
+
+        assert_eq!(
+            classify_alpha(&repo, default_absorb_options()),
+            AbsorbClassification::Skip(AbsorbSkipReason::BranchBehindStack)
+        );
+    }
+
+    #[test]
+    fn classify_patch_equivalent_rewritten_source_branch_as_skip() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        rewrite_stack_branch_equivalently(&repo);
+
+        assert_eq!(
+            classify_alpha(&repo, default_absorb_options()),
+            AbsorbClassification::Skip(AbsorbSkipReason::RewrittenEquivalentPrefix)
+        );
+    }
+
+    #[test]
+    fn classify_patch_equivalent_rewritten_source_branch_with_tail_as_absorbable() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        rewrite_stack_branch_equivalently(&repo);
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        let tail_sha = commit_file(
+            &repo.repo,
+            "alpha-branch.txt",
+            "alpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        match classify_alpha(&repo, default_absorb_options()) {
+            AbsorbClassification::Absorbable(tail) => {
+                assert_eq!(tail.commits, vec![tail_sha]);
+            }
+            other => panic!("unexpected classification: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_patch_equivalent_rewritten_source_branch_from_different_base_as_blocking() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        recreate_alpha_branch_on_equivalent_orphan_base(&repo);
+
+        assert_eq!(
+            classify_alpha(&repo, default_absorb_options()),
+            AbsorbClassification::Blocked(AbsorbBlocker::RewrittenPrefixWrongMergeBase {
+                expected_merge_base: rev_parse(&repo.repo, &repo.base_branch),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_diverged_source_branch_as_blocking() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+        let _new_alpha_tip = commit_file(
+            &repo.repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-stack\n",
+            "feat: alpha on stack",
+        );
+        let _branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha on branch",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        assert_eq!(
+            classify_alpha(&repo, default_absorb_options()),
+            AbsorbClassification::Blocked(AbsorbBlocker::Diverged)
+        );
+    }
+
+    #[test]
+    fn classify_branch_with_later_stack_commits_as_blocking() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        git(
+            &repo.repo,
+            ["merge", "--ff-only", &repo.stack_branch].as_slice(),
+        );
+        let _branch_tip = commit_file(
+            &repo.repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha after stack ff",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        match classify_alpha(&repo, default_absorb_options()) {
+            AbsorbClassification::Blocked(AbsorbBlocker::MergeBaseMismatch { .. }) => {}
+            other => panic!("unexpected classification: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_tail_with_later_replayed_stack_patch_as_blocking() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack_with_beta_follow_up();
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        git(
+            &repo.repo,
+            ["cherry-pick", repo.beta_tip.as_ref().unwrap()].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        match classify_alpha(&repo, default_absorb_options()) {
+            AbsorbClassification::Blocked(AbsorbBlocker::TailOwnedByLaterReplayedCommit {
+                owner_tag,
+                owner_commit,
+                ..
+            }) => {
+                assert_eq!(owner_tag, "beta");
+                assert_eq!(owner_commit, repo.beta_tip.unwrap());
+            }
+            other => panic!("unexpected classification: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_tail_with_later_replayed_stack_patch_is_absorbable_with_override() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack_with_beta_follow_up();
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        git(
+            &repo.repo,
+            ["cherry-pick", repo.beta_tip.as_ref().unwrap()].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        match classify_alpha(&repo, absorb_override_options()) {
+            AbsorbClassification::Absorbable(tail) => {
+                assert_eq!(tail.commits.len(), 1);
+                assert_eq!(tail.kept_later_duplicate_replays.len(), 1);
+                assert_eq!(tail.kept_later_duplicate_replays[0].tag, "beta");
+                assert_eq!(
+                    tail.kept_later_duplicate_replays[0].sha,
+                    repo.beta_tip.unwrap()
+                );
+            }
+            other => panic!("unexpected classification: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_tail_with_merge_commit_as_blocking() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        git(
+            &repo.repo,
+            ["checkout", "-b", "side", &repo.alpha_tip].as_slice(),
+        );
+        let _side_tip = commit_file(&repo.repo, "side.txt", "side-1\n", "feat: side change");
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        let _alpha_tail = commit_file(
+            &repo.repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(
+            &repo.repo,
+            ["merge", "--no-ff", "side", "-m", "merge side"].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        match classify_alpha(&repo, default_absorb_options()) {
+            AbsorbClassification::Blocked(AbsorbBlocker::TailHasMergeCommit { .. }) => {}
+            other => panic!("unexpected classification: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_tail_with_stack_marker_as_blocking() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        let _branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: branch marker\n\npr:beta",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        match classify_alpha(&repo, default_absorb_options()) {
+            AbsorbClassification::Blocked(AbsorbBlocker::TailHasStackMarker { .. }) => {}
+            other => panic!("unexpected classification: {:?}", other),
+        }
+    }
+
+    fn synthetic_group_plan(
+        tag: &str,
+        commits: &[&str],
+        absorbed_tail: &[&str],
+        ignored_after: &[&str],
+    ) -> GroupRewritePlan {
+        GroupRewritePlan {
+            group: Group {
+                tag: tag.to_string(),
+                subjects: Vec::new(),
+                commits: commits.iter().map(|sha| sha.to_string()).collect(),
+                first_message: None,
+                ignored_after: ignored_after.iter().map(|sha| sha.to_string()).collect(),
+            },
+            source: SourceBranchRecord {
+                tag: tag.to_string(),
+                branch_name: format!("dank-spr/{tag}"),
+                group_tip: commits.last().unwrap().to_string(),
+                source_tip: Some(
+                    absorbed_tail
+                        .last()
+                        .copied()
+                        .unwrap_or_else(|| commits.last().unwrap())
+                        .to_string(),
+                ),
+                classification: if absorbed_tail.is_empty() {
+                    AbsorbClassification::Skip(AbsorbSkipReason::Unchanged)
+                } else {
+                    AbsorbClassification::Absorbable(AbsorbTail {
+                        commits: absorbed_tail.iter().map(|sha| sha.to_string()).collect(),
+                        kept_later_duplicate_replays: Vec::new(),
+                    })
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn validate_plan_reports_blocked_groups_without_git_side_effects() {
+        let blocked_group = synthetic_group_plan("alpha", &["alpha-1"], &[], &[]);
+        let plan = RewritePlan {
+            merge_base: "base".to_string(),
+            leading_ignored: Vec::new(),
+            groups: vec![GroupRewritePlan {
+                source: SourceBranchRecord {
+                    classification: AbsorbClassification::Blocked(AbsorbBlocker::Diverged),
+                    ..blocked_group.source
+                },
+                ..blocked_group
+            }],
+            operations: Vec::new(),
+        };
+
+        assert_eq!(
+            validate_absorb_plan(&plan),
+            AbsorbPlanValidation::Blocked {
+                lines: vec![
+                    "pr:alpha <- dank-spr/alpha : block (branch diverged from stack group tip)"
+                        .to_string()
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn rewritten_equivalent_prefix_skip_reason_has_distinct_summary_text() {
+        let record = SourceBranchRecord {
+            tag: "alpha".to_string(),
+            branch_name: "dank-spr/alpha".to_string(),
+            group_tip: "alpha-2".to_string(),
+            source_tip: Some("alpha-rewrite-2".to_string()),
+            classification: AbsorbClassification::Skip(AbsorbSkipReason::RewrittenEquivalentPrefix),
+        };
+
+        assert_eq!(
+            record.summary_line(),
+            "pr:alpha <- dank-spr/alpha : skip (rewritten-equivalent prefix)"
+        );
+    }
+
+    #[test]
+    fn build_rewrite_operations_replays_all_segments_in_order() {
+        let alpha = synthetic_group_plan("alpha", &["a1", "a2"], &["a3"], &["i1", "i2"]);
+        let beta = synthetic_group_plan("beta", &["b1"], &[], &[]);
+
+        assert_eq!(
+            build_rewrite_operations(&["l1".to_string(), "l2".to_string()], &[alpha, beta]),
+            vec![
+                CherryPickOp::Range {
+                    first: "l1".to_string(),
+                    last: "l2".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Range {
+                    first: "a1".to_string(),
+                    last: "a2".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Commit {
+                    sha: "a3".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Range {
+                    first: "i1".to_string(),
+                    last: "i2".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Commit {
+                    sha: "b1".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn build_rewrite_operations_keeps_later_duplicate_replays_with_empty_keep_policy() {
+        let mut alpha = synthetic_group_plan("alpha", &["a1", "a2"], &["x1"], &[]);
+        if let AbsorbClassification::Absorbable(tail) = &mut alpha.source.classification {
+            tail.kept_later_duplicate_replays = vec![LaterReplayedCommit {
+                tag: "beta".to_string(),
+                sha: "b2".to_string(),
+                kind: LaterReplayedCommitKind::GroupFollowUp,
+            }];
+        }
+        let beta = synthetic_group_plan("beta", &["b1", "b2", "b3"], &[], &[]);
+
+        assert_eq!(
+            build_rewrite_operations(&[], &[alpha, beta]),
+            vec![
+                CherryPickOp::Range {
+                    first: "a1".to_string(),
+                    last: "a2".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Commit {
+                    sha: "x1".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Commit {
+                    sha: "b1".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Commit {
+                    sha: "b2".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::KeepRedundantCommits,
+                },
+                CherryPickOp::Commit {
+                    sha: "b3".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn absorb_blocked_plan_leaves_head_and_backup_tags_unchanged() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+        let _new_alpha_tip = commit_file(
+            &repo.repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-stack\n",
+            "feat: alpha on stack",
+        );
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        let _branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha on branch",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let result = {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                default_absorb_options(),
+            )
+        };
+
+        assert!(result.is_err(), "blocked absorb should fail");
+        assert_eq!(
+            rev_parse(&repo.repo, "HEAD"),
+            original_head,
+            "blocked absorb must not rewrite HEAD"
+        );
+        assert!(
+            tags_with_pattern(&repo.repo, "backup/absorb/*").is_empty(),
+            "blocked absorb should not create a backup tag"
+        );
+    }
+
+    #[test]
+    fn absorb_skips_patch_equivalent_rewritten_branch_without_rewrite() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        rewrite_stack_branch_equivalently(&repo);
+        let original_head = rev_parse(&repo.repo, "HEAD");
+
+        let result = {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                crate::config::DirtyWorktreePolicy::Discard,
+                default_absorb_options(),
+            )
+            .unwrap()
+        };
+
+        assert_eq!(result, RewriteCommandOutcome::Completed);
+        assert_eq!(
+            rev_parse(&repo.repo, "HEAD"),
+            original_head,
+            "patch-equivalent stale branches should not rewrite HEAD"
+        );
+        assert!(
+            tags_with_pattern(&repo.repo, "backup/absorb/*").is_empty(),
+            "no-op absorb should not create a backup tag"
+        );
+    }
+
+    #[test]
+    fn absorb_rejects_tail_owned_by_later_stack_commit_without_rewrite() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack_with_beta_follow_up();
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        git(
+            &repo.repo,
+            ["cherry-pick", repo.beta_tip.as_ref().unwrap()].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let result = {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                default_absorb_options(),
+            )
+        };
+
+        assert!(
+            result.is_err(),
+            "copied later stack commit should block absorb"
+        );
+        assert_eq!(
+            rev_parse(&repo.repo, "HEAD"),
+            original_head,
+            "blocked absorb must not rewrite HEAD"
+        );
+        assert!(
+            tags_with_pattern(&repo.repo, "backup/absorb/*").is_empty(),
+            "blocked absorb should not create a backup tag"
+        );
+    }
+
+    #[test]
+    fn absorb_override_keeps_later_duplicate_replay_and_rewrites_stack() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack_with_beta_follow_up();
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        git(&repo.repo, ["checkout", "dank-spr/alpha"].as_slice());
+        git(
+            &repo.repo,
+            ["cherry-pick", repo.beta_tip.as_ref().unwrap()].as_slice(),
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                absorb_override_options(),
+            )
+            .unwrap();
+        }
+
+        let rewritten_head = rev_parse(&repo.repo, "HEAD");
+        assert_ne!(
+            rewritten_head, original_head,
+            "override absorb should rewrite HEAD"
+        );
+        let backup_tags = tags_with_pattern(&repo.repo, "backup/absorb/*");
+        assert_eq!(
+            backup_tags.len(),
+            1,
+            "override absorb should create one backup tag"
+        );
+
+        let _guard = DirGuard::change_to(&repo.repo);
+        let (_merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored(&repo.base_branch, &repo.ignore_tag).unwrap();
+        assert!(leading_ignored.is_empty());
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| group.tag.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta", "gamma"]
+        );
+        assert_eq!(
+            groups[0].commits.len(),
+            3,
+            "alpha should absorb the copied beta follow-up"
+        );
+        assert_eq!(
+            groups[0].subjects.last().unwrap(),
+            "feat: beta follow-up",
+            "alpha should gain the copied later follow-up"
+        );
+        assert_eq!(
+            groups[1].commits.len(),
+            2,
+            "beta should keep the later duplicate replay under the override"
+        );
+        assert_eq!(
+            groups[1].subjects,
+            vec![
+                "feat: beta seed".to_string(),
+                "feat: beta follow-up".to_string()
+            ],
+            "beta should retain both its seed and follow-up commits"
+        );
+    }
+
+    #[test]
+    fn absorb_rewrites_multiple_groups_and_preserves_ignored_blocks() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        let original_merge_base = git(
+            &repo.repo,
+            ["merge-base", &repo.base_branch, "HEAD"].as_slice(),
+        )
+        .trim()
+        .to_string();
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\nalpha-branch-2\n",
+            "feat: alpha branch tail 2",
+        );
+        let _gamma_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/gamma",
+            "gamma.txt",
+            "gamma-1\ngamma-branch\n",
+            "feat: gamma branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                default_absorb_options(),
+            )
+            .unwrap();
+        }
+
+        let rewritten_head = rev_parse(&repo.repo, "HEAD");
+        assert_ne!(rewritten_head, original_head, "absorb should rewrite HEAD");
+        let backup_tags = tags_with_pattern(&repo.repo, "backup/absorb/*");
+        assert_eq!(backup_tags.len(), 1, "absorb should create one backup tag");
+        let backup_target = rev_parse(&repo.repo, &format!("refs/tags/{}", backup_tags[0]));
+        assert_eq!(
+            backup_target, original_head,
+            "backup tag should point at the pre-absorb HEAD"
+        );
+
+        let rewritten_merge_base = git(
+            &repo.repo,
+            ["merge-base", &repo.base_branch, "HEAD"].as_slice(),
+        )
+        .trim()
+        .to_string();
+        assert_eq!(
+            rewritten_merge_base, original_merge_base,
+            "absorb should preserve the current stack/base merge-base"
+        );
+
+        let _guard = DirGuard::change_to(&repo.repo);
+        let (_merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored(&repo.base_branch, &repo.ignore_tag).unwrap();
+        assert!(
+            leading_ignored.is_empty(),
+            "stack should not gain leading ignored commits"
+        );
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| group.tag.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta", "gamma"]
+        );
+        assert_eq!(
+            groups[0].commits.len(),
+            4,
+            "alpha should include both absorbed branch-tail commits"
+        );
+        assert_eq!(
+            groups[0].subjects[2..].to_vec(),
+            vec![
+                "feat: alpha branch tail".to_string(),
+                "feat: alpha branch tail 2".to_string(),
+            ],
+            "alpha should keep the absorbed tail subjects in order"
+        );
+        assert_eq!(
+            groups[0].ignored_after.len(),
+            2,
+            "alpha ignored block should remain attached after the absorbed commits"
+        );
+        assert_eq!(groups[1].commits.len(), 1, "beta should remain unchanged");
+        assert_eq!(
+            groups[2].commits.len(),
+            2,
+            "gamma should include the absorbed branch tail"
+        );
+        assert_eq!(
+            groups[2].subjects.last().unwrap(),
+            "feat: gamma branch tail"
+        );
+    }
+
+    #[test]
+    fn absorb_succeeds_even_if_post_reset_cleanup_fails() {
+        let _lock = lock_cwd();
+        let repo = setup_single_group_stack(true);
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        let _branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let short = git(&repo.repo, ["rev-parse", "--short", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        let tmp_path = format!("/tmp/spr-absorb-{}", short);
+        let tmp_branch = format!("spr/tmp-absorb-{}", short);
+        let wrapper_dir = install_cleanup_failure_git_wrapper(&tmp_path);
+
+        {
+            let wrapped_path = format!("{}:{}", wrapper_dir.path().display(), current_path());
+            let _path_guard = EnvVarGuard::set("PATH", wrapped_path);
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                default_absorb_options(),
+            )
+            .expect("cleanup failure after reset should not fail absorb");
+        }
+
+        let rewritten_head = rev_parse(&repo.repo, "HEAD");
+        assert_ne!(
+            rewritten_head, original_head,
+            "absorb should still rewrite HEAD when cleanup fails afterward"
+        );
+        assert!(
+            Path::new(&tmp_path).exists(),
+            "the temp worktree should remain when cleanup is forced to fail"
+        );
+
+        git(
+            &repo.repo,
+            ["worktree", "remove", "-f", &tmp_path].as_slice(),
+        );
+        git(&repo.repo, ["branch", "-D", &tmp_branch].as_slice());
+    }
+
+    #[test]
+    fn absorb_is_noop_when_no_groups_are_absorbable() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+
+        {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                default_absorb_options(),
+            )
+            .unwrap();
+        }
+
+        assert_eq!(rev_parse(&repo.repo, "HEAD"), original_head);
+        assert!(
+            tags_with_pattern(&repo.repo, "backup/absorb/*").is_empty(),
+            "no-op absorb should not create a backup tag"
+        );
+    }
+
+    #[test]
+    fn absorb_dry_run_leaves_head_unchanged() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                true,
+                default_absorb_options(),
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            rev_parse(&repo.repo, "HEAD"),
+            original_head,
+            "dry-run absorb must not change HEAD"
+        );
+        assert!(
+            tags_with_pattern(&repo.repo, "backup/absorb/*").is_empty(),
+            "dry-run absorb should not create a backup tag"
+        );
+        assert!(
+            branches_with_pattern(&repo.repo, "spr/tmp-absorb-*").is_empty(),
+            "dry-run absorb should not leave temp absorb branches behind"
+        );
+    }
+
+    #[test]
+    fn build_plan_records_absorbable_groups_for_rewrite() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let _guard = DirGuard::change_to(&repo.repo);
+        let (_stack_head, plan) = build_plan_for_current_stack(
+            &repo.base_branch,
+            &repo.prefix,
+            &repo.ignore_tag,
+            default_absorb_options(),
+        )
+        .unwrap();
+        assert!(plan.has_absorbable_groups());
+        assert!(!plan.has_blockers());
+        assert!(
+            plan.operations.len() >= 4,
+            "rewrite plan should include leading replay plus group operations"
+        );
+    }
+
+    #[test]
+    fn setup_helpers_keep_expected_branches() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+
+        assert_eq!(current_branch(&repo.repo), repo.stack_branch);
+        assert_eq!(rev_parse(&repo.repo, "dank-spr/alpha"), repo.alpha_tip);
+        assert_eq!(
+            rev_parse(&repo.repo, "dank-spr/beta"),
+            repo.beta_tip.unwrap()
+        );
+        assert_eq!(
+            rev_parse(&repo.repo, "dank-spr/gamma"),
+            repo.gamma_tip.unwrap()
+        );
+    }
+}

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -212,14 +212,40 @@ fn cleanup_existing_temp_state(dry: bool, tmp_path: &str, tmp_branch: &str) -> R
     Ok(())
 }
 
-pub fn cherry_pick_commit(dry: bool, tmp_path: &str, sha: &str) -> Result<()> {
-    let _ = git_rw(dry, ["-C", tmp_path, "cherry-pick", sha].as_slice())?;
+fn cherry_pick_args<'a>(
+    tmp_path: &'a str,
+    empty_policy: CherryPickEmptyPolicy,
+    tail_args: &[&'a str],
+) -> Vec<&'a str> {
+    let mut args = vec!["-C", tmp_path, "cherry-pick"];
+    if empty_policy == CherryPickEmptyPolicy::KeepRedundantCommits {
+        args.push("--empty=keep");
+    }
+    args.extend_from_slice(tail_args);
+    args
+}
+
+pub fn cherry_pick_commit(
+    dry: bool,
+    tmp_path: &str,
+    sha: &str,
+    empty_policy: CherryPickEmptyPolicy,
+) -> Result<()> {
+    let args = cherry_pick_args(tmp_path, empty_policy, &[sha]);
+    let _ = git_rw(dry, args.as_slice())?;
     Ok(())
 }
 
-pub fn cherry_pick_range(dry: bool, tmp_path: &str, first: &str, last: &str) -> Result<()> {
+pub fn cherry_pick_range(
+    dry: bool,
+    tmp_path: &str,
+    first: &str,
+    last: &str,
+    empty_policy: CherryPickEmptyPolicy,
+) -> Result<()> {
     let range = format!("{}^..{}", first, last);
-    let _ = git_rw(dry, ["-C", tmp_path, "cherry-pick", &range].as_slice())?;
+    let args = cherry_pick_args(tmp_path, empty_policy, &[range.as_str()]);
+    let _ = git_rw(dry, args.as_slice())?;
     Ok(())
 }
 
@@ -238,6 +264,108 @@ pub fn cleanup_temp_worktree(dry: bool, tmp_path: &str, tmp_branch: &str) -> Res
     let _ = git_rw(dry, ["worktree", "remove", "-f", tmp_path].as_slice())?;
     let _ = git_rw(dry, ["branch", "-D", tmp_branch].as_slice())?;
     Ok(())
+}
+
+/// A single cherry-pick operation used to rebuild stack history.
+///
+/// `Range` represents an inclusive `first^..last` cherry-pick over a contiguous
+/// commit interval. Callers must supply commits that already reflect the
+/// intended replay order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CherryPickEmptyPolicy {
+    /// Stop when a replay becomes empty because earlier history already applied it.
+    StopOnEmpty,
+    /// Keep redundant replays as explicit empty commits.
+    KeepRedundantCommits,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CherryPickOp {
+    /// Cherry-pick exactly one commit.
+    Commit {
+        sha: String,
+        empty_policy: CherryPickEmptyPolicy,
+    },
+    /// Cherry-pick one contiguous inclusive range.
+    Range {
+        first: String,
+        last: String,
+        empty_policy: CherryPickEmptyPolicy,
+    },
+}
+
+impl CherryPickOp {
+    /// Builds the smallest cherry-pick operation that can replay `commits`.
+    ///
+    /// Returns `None` when the slice is empty.
+    pub fn from_commits(commits: &[String]) -> Option<Self> {
+        Self::from_commits_with_empty_policy(commits, CherryPickEmptyPolicy::StopOnEmpty)
+    }
+
+    /// Builds the smallest cherry-pick operation that can replay `commits`
+    /// under a specific empty-commit policy.
+    pub fn from_commits_with_empty_policy(
+        commits: &[String],
+        empty_policy: CherryPickEmptyPolicy,
+    ) -> Option<Self> {
+        if let (Some(first), Some(last)) = (commits.first(), commits.last()) {
+            if commits.len() == 1 {
+                Some(Self::Commit {
+                    sha: first.clone(),
+                    empty_policy,
+                })
+            } else {
+                Some(Self::Range {
+                    first: first.clone(),
+                    last: last.clone(),
+                    empty_policy,
+                })
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Executes the operation in the temp worktree at `tmp_path`.
+    pub fn run(&self, dry: bool, tmp_path: &str) -> Result<()> {
+        match self {
+            Self::Commit { sha, empty_policy } => {
+                cherry_pick_commit(dry, tmp_path, sha, *empty_policy)
+            }
+            Self::Range {
+                first,
+                last,
+                empty_policy,
+            } => cherry_pick_range(dry, tmp_path, first, last, *empty_policy),
+        }
+    }
+
+    /// Renders the matching `git cherry-pick` command for human continuation.
+    pub fn command_for_user(&self, tmp_path: &str) -> String {
+        match self {
+            Self::Commit { sha, empty_policy } => {
+                if *empty_policy == CherryPickEmptyPolicy::KeepRedundantCommits {
+                    format!("git -C {} cherry-pick --empty=keep {}", tmp_path, sha)
+                } else {
+                    format!("git -C {} cherry-pick {}", tmp_path, sha)
+                }
+            }
+            Self::Range {
+                first,
+                last,
+                empty_policy,
+            } => {
+                if *empty_policy == CherryPickEmptyPolicy::KeepRedundantCommits {
+                    format!(
+                        "git -C {} cherry-pick --empty=keep {}^..{}",
+                        tmp_path, first, last
+                    )
+                } else {
+                    format!("git -C {} cherry-pick {}^..{}", tmp_path, first, last)
+                }
+            }
+        }
+    }
 }
 
 /// Build expected (head, base) chain bottom→top from local groups

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -16,7 +16,7 @@ fn resolve_fix_pr_target(
     resolve_group_ordinal(groups, target)
 }
 
-/// Move the last `tail_count` commits (top-of-stack) to become the tail of PR `n` (1-based, bottom→top).
+/// Move the last `tail_count` commits (top-of-stack) to the tail of a selected PR group.
 ///
 /// Ignore blocks are treated as part of the preceding group and are never moved.
 /// If the selected tail commits intersect an ignore block, the operation aborts.
@@ -67,7 +67,7 @@ pub fn fix_pr_tail(
     let mut offenders: Vec<String> = vec![];
     for sha in &top_commits {
         let msg = git_ro(["log", "-n", "1", "--format=%B", sha].as_slice())?;
-        if crate::pr_labels::candidate_marker_regex().is_match(&msg) {
+        if crate::pr_labels::contains_candidate_marker(&msg) {
             offenders.push(sha.clone());
         }
     }
@@ -143,7 +143,12 @@ pub fn fix_pr_tail(
 
     for sha in &new_order {
         // Cherry-pick the commit onto tmp
-        common::cherry_pick_commit(dry, &tmp_path, sha)?;
+        common::cherry_pick_commit(
+            dry,
+            &tmp_path,
+            sha,
+            common::CherryPickEmptyPolicy::StopOnEmpty,
+        )?;
     }
 
     // Point current branch to new tip

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod absorb;
 pub mod cleanup;
 pub mod common;
 pub mod fix_pr;
@@ -9,6 +10,7 @@ pub mod relink_prs;
 pub mod restack;
 pub mod update;
 
+pub use absorb::{absorb_branch_tails, AbsorbOptions, CopiedLaterStackCommitPolicy};
 pub use cleanup::cleanup_remote_branches;
 pub use fix_pr::fix_pr_tail;
 pub use land::{land_flatten_until, land_per_pr_until};

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -39,9 +39,20 @@ fn cherry_pick_block(dry: bool, tmp_path: &str, commits: &[String]) -> Result<()
     let first = commits.first().expect("commits not empty");
     let last = commits.last().expect("commits not empty");
     if commits.len() == 1 {
-        common::cherry_pick_commit(dry, tmp_path, first)
+        common::cherry_pick_commit(
+            dry,
+            tmp_path,
+            first,
+            common::CherryPickEmptyPolicy::StopOnEmpty,
+        )
     } else {
-        common::cherry_pick_range(dry, tmp_path, first, last)
+        common::cherry_pick_range(
+            dry,
+            tmp_path,
+            first,
+            last,
+            common::CherryPickEmptyPolicy::StopOnEmpty,
+        )
     }
 }
 
@@ -209,7 +220,13 @@ pub fn move_groups_after(
     for idx in &new_order {
         let g = &groups[*idx - 1];
         if let (Some(first), Some(last)) = (g.commits.first(), g.commits.last()) {
-            common::cherry_pick_range(dry, &tmp_path, first, last)?;
+            common::cherry_pick_range(
+                dry,
+                &tmp_path,
+                first,
+                last,
+                common::CherryPickEmptyPolicy::StopOnEmpty,
+            )?;
         }
         cherry_pick_block(dry, &tmp_path, &g.ignored_after)?;
     }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -16,58 +16,11 @@ use anyhow::{anyhow, Context, Result};
 use tracing::{info, warn};
 
 use crate::commands::common;
+use crate::commands::common::CherryPickOp;
 use crate::config::RestackConflictPolicy;
 use crate::git::git_rw;
 use crate::parsing::{derive_local_groups_with_ignored, Group};
 use crate::selectors::{resolve_after_count, AfterSelector};
-
-/// A single planned cherry-pick step used to rebuild the restacked history.
-///
-/// `spr restack` constructs an ordered plan of these operations and executes
-/// them inside a temporary worktree and branch. A `Range` represents a
-/// contiguous commit interval (inclusive) expressed as `first^..last`.
-///
-/// Callers should treat this as an execution primitive: errors are surfaced to
-/// the caller, and cleanup/rollback decisions are intentionally handled at a
-/// higher level where the conflict policy is known.
-#[derive(Debug, Clone)]
-enum CherryPickOp {
-    /// Cherry-pick a single commit SHA.
-    Commit { sha: String },
-    /// Cherry-pick an inclusive range from `first` through `last`.
-    Range { first: String, last: String },
-}
-
-impl CherryPickOp {
-    /// Execute this cherry-pick operation in the temp worktree at `tmp_path`.
-    ///
-    /// This method is intentionally thin and does not attempt to detect or
-    /// resolve conflicts; callers must check for conflict state and decide
-    /// whether to halt or roll back based on policy.
-    fn run(&self, dry: bool, tmp_path: &str) -> Result<()> {
-        match self {
-            CherryPickOp::Commit { sha } => common::cherry_pick_commit(dry, tmp_path, sha),
-            CherryPickOp::Range { first, last } => {
-                common::cherry_pick_range(dry, tmp_path, first, last)
-            }
-        }
-    }
-
-    /// Render a user-facing git command that mirrors this operation.
-    ///
-    /// This string is used in halt instructions so a human can continue the
-    /// remaining plan manually from the temp worktree.
-    fn command_for_user(&self, tmp_path: &str) -> String {
-        match self {
-            CherryPickOp::Commit { sha } => {
-                format!("git -C {} cherry-pick {}", tmp_path, sha)
-            }
-            CherryPickOp::Range { first, last } => {
-                format!("git -C {} cherry-pick {}^..{}", tmp_path, first, last)
-            }
-        }
-    }
-}
 
 fn cherry_pick_head_exists(tmp_path: &str) -> bool {
     Command::new("git")
@@ -105,40 +58,43 @@ fn cleanup_temp_worktree_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str
 /// 1. Ignored commits attached to dropped groups, kept before the remaining stack.
 /// 2. Each remaining PR group's commits.
 /// 3. Each remaining group's trailing ignored block.
-fn build_cherry_pick_plan(kept_ignored: &[String], remaining: &[Group]) -> Vec<CherryPickOp> {
-    let mut ops: Vec<CherryPickOp> = vec![];
-
-    if let (Some(first), Some(last)) = (kept_ignored.first(), kept_ignored.last()) {
-        if kept_ignored.len() == 1 {
-            ops.push(CherryPickOp::Commit { sha: first.clone() });
-        } else {
-            ops.push(CherryPickOp::Range {
-                first: first.clone(),
-                last: last.clone(),
-            });
-        }
-    }
+fn build_cherry_pick_plan(
+    kept_ignored_segments: &[Vec<String>],
+    remaining: &[Group],
+) -> Vec<CherryPickOp> {
+    let mut ops: Vec<CherryPickOp> = kept_ignored_segments
+        .iter()
+        .filter_map(|segment| CherryPickOp::from_commits(segment))
+        .collect();
 
     for g in remaining {
-        if let (Some(first), Some(last)) = (g.commits.first(), g.commits.last()) {
-            ops.push(CherryPickOp::Range {
-                first: first.clone(),
-                last: last.clone(),
-            });
-        }
-        if let (Some(first), Some(last)) = (g.ignored_after.first(), g.ignored_after.last()) {
-            if g.ignored_after.len() == 1 {
-                ops.push(CherryPickOp::Commit { sha: first.clone() });
-            } else {
-                ops.push(CherryPickOp::Range {
-                    first: first.clone(),
-                    last: last.clone(),
-                });
-            }
-        }
+        ops.extend(CherryPickOp::from_commits(&g.commits));
+        ops.extend(CherryPickOp::from_commits(&g.ignored_after));
     }
 
     ops
+}
+
+fn build_kept_ignored_segments(
+    leading_ignored: Vec<String>,
+    groups: &[Group],
+    after: usize,
+) -> Vec<Vec<String>> {
+    let mut segments: Vec<Vec<String>> = if leading_ignored.is_empty() {
+        Vec::new()
+    } else {
+        vec![leading_ignored]
+    };
+
+    segments.extend(
+        groups
+            .iter()
+            .take(after)
+            .filter(|group| !group.ignored_after.is_empty())
+            .map(|group| group.ignored_after.clone()),
+    );
+
+    segments
 }
 
 /// Emit user-facing rollback and manual-continue instructions for a halted restack.
@@ -209,17 +165,9 @@ fn restack_after_resolved(
 ) -> Result<()> {
     let (cur_branch, short) = common::get_current_branch_and_short()?;
     let after = std::cmp::min(after, groups.len());
-    let kept_ignored: Vec<String> = leading_ignored
-        .into_iter()
-        .chain(
-            groups
-                .iter()
-                .take(after)
-                .flat_map(|group| group.ignored_after.iter().cloned()),
-        )
-        .collect();
+    let kept_ignored_segments = build_kept_ignored_segments(leading_ignored, &groups, after);
     let remaining = &groups[after..];
-    if remaining.is_empty() && kept_ignored.is_empty() {
+    if remaining.is_empty() && kept_ignored_segments.is_empty() {
         if safe {
             let _ = common::create_backup_tag(dry, "restack", &cur_branch, &short)?;
         }
@@ -244,7 +192,7 @@ fn restack_after_resolved(
         };
 
         let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "restack", base, &short)?;
-        let ops = build_cherry_pick_plan(&kept_ignored, remaining);
+        let ops = build_cherry_pick_plan(&kept_ignored_segments, remaining);
         for (idx, op) in ops.iter().enumerate() {
             if let Err(err) = op.run(dry, &tmp_path) {
                 let conflict = cherry_pick_head_exists(&tmp_path);
@@ -361,7 +309,8 @@ pub fn restack_after_count(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_restack_after_count;
+    use super::{build_cherry_pick_plan, build_kept_ignored_segments, resolve_restack_after_count};
+    use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
     use crate::parsing::Group;
     use crate::selectors::{AfterSelector, GroupSelector, StableHandle};
 
@@ -385,5 +334,65 @@ mod tests {
         }));
 
         assert_eq!(resolve_restack_after_count(&groups, &after).unwrap(), 2);
+    }
+
+    #[test]
+    fn kept_ignored_segments_preserve_group_boundaries() {
+        let groups = vec![
+            Group {
+                tag: "alpha".to_string(),
+                subjects: vec!["feat: alpha".to_string()],
+                commits: vec!["a1".to_string()],
+                first_message: Some("feat: alpha pr:alpha".to_string()),
+                ignored_after: vec!["i1".to_string(), "i2".to_string()],
+            },
+            Group {
+                tag: "beta".to_string(),
+                subjects: vec!["feat: beta".to_string()],
+                commits: vec!["b1".to_string()],
+                first_message: Some("feat: beta pr:beta".to_string()),
+                ignored_after: vec!["i3".to_string(), "i4".to_string()],
+            },
+        ];
+
+        assert_eq!(
+            build_kept_ignored_segments(vec!["l1".to_string()], &groups, 2),
+            vec![
+                vec!["l1".to_string()],
+                vec!["i1".to_string(), "i2".to_string()],
+                vec!["i3".to_string(), "i4".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn build_cherry_pick_plan_keeps_ignored_segments_separate() {
+        let remaining = groups(&["gamma"]);
+
+        assert_eq!(
+            build_cherry_pick_plan(
+                &[
+                    vec!["i1".to_string(), "i2".to_string()],
+                    vec!["i3".to_string(), "i4".to_string()],
+                ],
+                &remaining,
+            ),
+            vec![
+                CherryPickOp::Range {
+                    first: "i1".to_string(),
+                    last: "i2".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Range {
+                    first: "i3".to_string(),
+                    last: "i4".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+                CherryPickOp::Commit {
+                    sha: "gamma1".to_string(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                },
+            ]
+        );
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{bail, Context, Result};
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::process::{Command, Stdio};
 use tracing::{error, info};
 
@@ -246,6 +247,163 @@ pub fn git_is_ancestor(ancestor: &str, descendant: &str) -> Result<bool> {
         .status()
         .with_context(|| "failed to run git merge-base --is-ancestor")?;
     Ok(status.success())
+}
+
+/// Resolves a revision to its full object id.
+pub fn git_rev_parse(revision: &str) -> Result<String> {
+    Ok(git_ro(["rev-parse", revision].as_slice())?
+        .trim()
+        .to_string())
+}
+
+/// Resolves the tree object id at a commit or tree-ish revision.
+pub fn git_commit_tree(revision: &str) -> Result<String> {
+    let tree_revision = format!("{revision}^{{tree}}");
+    git_rev_parse(&tree_revision)
+}
+
+/// Returns the merge-base object id of two revisions.
+pub fn git_merge_base(left: &str, right: &str) -> Result<String> {
+    Ok(git_ro(["merge-base", left, right].as_slice())?
+        .trim()
+        .to_string())
+}
+
+/// Returns the tip SHA of an exact local branch name, if it exists.
+pub fn git_local_branch_tip(branch: &str) -> Result<Option<String>> {
+    let reference = format!("refs/heads/{branch}^{{commit}}");
+    let out = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", &reference])
+        .output()
+        .with_context(|| format!("failed to inspect local branch {}", branch))?;
+    if out.status.success() {
+        let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        Ok(Some(sha))
+    } else if out.status.code() == Some(1) {
+        Ok(None)
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+        bail!(
+            "failed to inspect local branch {} via {}: {}",
+            branch,
+            reference,
+            stderr
+        );
+    }
+}
+
+/// Returns the commits in `from_exclusive..to_inclusive`, oldest first.
+pub fn git_rev_list_range(from_exclusive: &str, to_inclusive: &str) -> Result<Vec<String>> {
+    let range = format!("{from_exclusive}..{to_inclusive}");
+    let out = git_ro(["rev-list", "--reverse", &range].as_slice())?;
+    Ok(out
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+/// Returns the number of parents on the given commit.
+pub fn git_commit_parent_count(sha: &str) -> Result<usize> {
+    let out = git_ro(["rev-list", "--parents", "-n", "1", sha].as_slice())?;
+    let count = out.split_whitespace().count().saturating_sub(1);
+    Ok(count)
+}
+
+/// Returns the full commit message for `sha`.
+pub fn git_commit_message(sha: &str) -> Result<String> {
+    git_ro(["log", "-n", "1", "--format=%B", sha].as_slice())
+}
+
+/// Returns a verbatim patch fingerprint for each commit, keyed by commit SHA.
+///
+/// The fingerprint matches clean cherry-picks and rebases of the same patch
+/// even when the commit SHA differs. Commits that produce no patch output get
+/// a synthetic per-commit fallback so callers can still classify them without
+/// failing the whole lookup.
+pub fn git_patch_ids_for_commits(commits: &[String]) -> Result<HashMap<String, String>> {
+    if commits.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut diff_tree = Command::new("git")
+        .args(["diff-tree", "--stdin", "-p", "--root"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| "failed to spawn git diff-tree --stdin -p --root")?;
+    {
+        let mut stdin = diff_tree
+            .stdin
+            .take()
+            .with_context(|| "failed to open git diff-tree stdin")?;
+        for commit in commits {
+            writeln!(stdin, "{commit}")
+                .with_context(|| format!("failed to queue commit {commit} for patch-id lookup"))?;
+        }
+    }
+    let diff_output = diff_tree
+        .wait_with_output()
+        .with_context(|| "failed to collect git diff-tree output")?;
+    if !diff_output.status.success() {
+        let stdout = String::from_utf8_lossy(&diff_output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&diff_output.stderr).to_string();
+        bail!(
+            "command failed: git diff-tree --stdin -p --root\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+    }
+
+    let mut patch_id = Command::new("git")
+        .args(["patch-id", "--verbatim"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| "failed to spawn git patch-id --verbatim")?;
+    {
+        let mut stdin = patch_id
+            .stdin
+            .take()
+            .with_context(|| "failed to open git patch-id stdin")?;
+        stdin
+            .write_all(&diff_output.stdout)
+            .with_context(|| "failed to feed patch data into git patch-id")?;
+    }
+    let patch_output = patch_id
+        .wait_with_output()
+        .with_context(|| "failed to collect git patch-id output")?;
+    if !patch_output.status.success() {
+        let stdout = String::from_utf8_lossy(&patch_output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&patch_output.stderr).to_string();
+        bail!(
+            "command failed: git patch-id --verbatim\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr
+        );
+    }
+
+    let mut patch_ids = HashMap::new();
+    let patch_stdout = String::from_utf8_lossy(&patch_output.stdout);
+    for line in patch_stdout.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(patch_id) = fields.next() else {
+            continue;
+        };
+        let Some(commit) = fields.next() else {
+            continue;
+        };
+        patch_ids.insert(commit.to_string(), patch_id.to_string());
+    }
+    for commit in commits {
+        patch_ids
+            .entry(commit.clone())
+            .or_insert_with(|| format!("empty:{commit}"));
+    }
+    Ok(patch_ids)
 }
 
 pub fn list_remote_branches_with_prefix(prefix: &str) -> Result<Vec<String>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,27 @@ fn resolve_update_pr_limit(
     }
 }
 
-fn init_tools() -> Result<()> {
+fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
+    match cmd {
+        crate::cli::Cmd::Restack { .. }
+        | crate::cli::Cmd::Absorb { .. }
+        | crate::cli::Cmd::FixPr { .. } => false,
+        crate::cli::Cmd::Update { .. }
+        | crate::cli::Cmd::Prep {}
+        | crate::cli::Cmd::List { .. }
+        | crate::cli::Cmd::Status {}
+        | crate::cli::Cmd::Land { .. }
+        | crate::cli::Cmd::RelinkPrs {}
+        | crate::cli::Cmd::Cleanup {}
+        | crate::cli::Cmd::Move { .. } => true,
+    }
+}
+
+fn init_tools(needs_gh: bool) -> Result<()> {
     crate::git::ensure_tool("git")?;
-    crate::git::ensure_tool("gh")?;
+    if needs_gh {
+        crate::git::ensure_tool("gh")?;
+    }
     Ok(())
 }
 
@@ -116,7 +134,7 @@ fn main() -> Result<()> {
     if cli.verbose {
         std::env::set_var("SPR_VERBOSE", "1");
     }
-    init_tools()?;
+    init_tools(command_requires_gh(&cli.cmd))?;
     let cfg = crate::config::load_config()?;
     let (base, prefix, ignore_tag) =
         resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone())?;
@@ -188,6 +206,25 @@ fn main() -> Result<()> {
                 safe,
                 cli.dry_run,
                 restack_conflict_policy,
+            )?;
+        }
+        crate::cli::Cmd::Absorb {
+            allow_replayed_duplicates,
+        } => {
+            set_dry_run_env(cli.dry_run, false);
+            let options = crate::commands::AbsorbOptions {
+                copied_later_stack_commit_policy: if allow_replayed_duplicates {
+                    crate::commands::CopiedLaterStackCommitPolicy::AllowKeepNonSeedDuplicates
+                } else {
+                    crate::commands::CopiedLaterStackCommitPolicy::Block
+                },
+            };
+            crate::commands::absorb_branch_tails(
+                &base,
+                &prefix,
+                &ignore_tag,
+                cli.dry_run,
+                options,
             )?;
         }
         crate::cli::Cmd::Prep {} => {
@@ -301,7 +338,7 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_update_pr_limit;
+    use super::{command_requires_gh, resolve_update_pr_limit};
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, StableHandle};
 
@@ -358,5 +395,17 @@ mod tests {
                 .contains("No outstanding PR group matches stable handle `pr:beta`"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn absorb_is_local_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::Absorb {
+            allow_replayed_duplicates: false,
+        }));
+    }
+
+    #[test]
+    fn status_still_requires_github_cli() {
+        assert!(command_requires_gh(&crate::cli::Cmd::Status {}));
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -31,10 +31,7 @@ pub struct Group {
 impl Group {
     pub fn pr_title(&self) -> Result<String> {
         if let Some(s) = self.subjects.first() {
-            let t = crate::pr_labels::valid_marker_regex()
-                .replace_all(s, "")
-                .trim()
-                .to_string();
+            let t = crate::pr_labels::strip_valid_markers(s).trim().to_string();
             if !t.is_empty() {
                 return Ok(t);
             }
@@ -44,8 +41,7 @@ impl Group {
     pub fn squash_commit_message(&self) -> Result<String> {
         if let Some(full) = &self.first_message {
             // Validate the first commit contains the expected pr:<tag> marker
-            if let Some(cap) = crate::pr_labels::valid_marker_regex().captures(full) {
-                let found = cap.get(1).unwrap().as_str();
+            if let Some(found) = crate::pr_labels::first_valid_marker_label(full) {
                 if !found.eq_ignore_ascii_case(&self.tag) {
                     bail!(
                         "First commit tag mismatch for group `{}`: expected `pr:{}`, found `pr:{}`",
@@ -74,9 +70,7 @@ impl Group {
         } else {
             String::new()
         };
-        let cleaned = crate::pr_labels::valid_marker_regex()
-            .replace_all(&base_body, "")
-            .to_string()
+        let cleaned = crate::pr_labels::strip_valid_markers(&base_body)
             .trim()
             .to_string();
         let sep = if cleaned.is_empty() { "" } else { "\n\n" };
@@ -96,9 +90,7 @@ impl Group {
         } else {
             String::new()
         };
-        Ok(crate::pr_labels::valid_marker_regex()
-            .replace_all(&base_body, "")
-            .to_string()
+        Ok(crate::pr_labels::strip_valid_markers(&base_body)
             .trim()
             .to_string())
     }
@@ -198,10 +190,7 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
         let message = parts.next().unwrap_or_default().to_string();
         let subj = message.lines().next().unwrap_or_default().to_string();
 
-        let tags: Vec<String> = crate::pr_labels::candidate_marker_regex()
-            .captures_iter(&message)
-            .map(|cap| cap.get(1).unwrap().as_str().to_string())
-            .collect();
+        let tags = crate::pr_labels::candidate_marker_labels(&message);
         if tags.len() > 1 {
             bail!("Multiple pr:<tag> markers found in commit {sha}");
         }
@@ -533,6 +522,59 @@ mod tests {
         let message = format!("{err:#}");
         assert!(
             message.contains("Commit a1 has invalid PR tag `pr:1alpha`"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("must start with an ASCII letter"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_groups_accepts_labels_with_trailing_dash_and_dot() {
+        let raw = make_log(&[
+            ("a1", "feat: alpha start pr:alpha-"),
+            ("b1", "feat: beta start pr:beta."),
+        ]);
+
+        let groups = parse_groups(&raw, "ignore").unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].tag, "alpha-");
+        assert_eq!(groups[0].pr_title().unwrap(), "feat: alpha start");
+        assert_eq!(
+            groups[0].squash_commit_message().unwrap(),
+            "feat: alpha start pr:alpha-"
+        );
+        assert_eq!(groups[1].tag, "beta.");
+        assert_eq!(groups[1].pr_title().unwrap(), "feat: beta start");
+    }
+
+    #[test]
+    fn parse_groups_rejects_invalid_trailing_characters() {
+        let raw = make_log(&[("a1", "feat: invalid punctuation pr:alpha!oops")]);
+
+        let err = parse_groups(&raw, "ignore").unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Commit a1 has invalid PR tag `pr:alpha!oops`"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains(
+                "must use only ASCII letters, digits, `.`, `_`, or `-` after the first letter"
+            ),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_groups_rejects_missing_label_after_marker() {
+        let raw = make_log(&[("a1", "feat: missing label pr:")]);
+
+        let err = parse_groups(&raw, "ignore").unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Commit a1 has invalid PR tag `pr:`"),
             "unexpected error: {message}"
         );
         assert!(

--- a/src/pr_labels.rs
+++ b/src/pr_labels.rs
@@ -4,11 +4,11 @@
 //! stable selector inputs. They must start with an ASCII letter and may then
 //! use ASCII letters, digits, `.`, `_`, or `-`.
 
-use regex::Regex;
+use regex::{Captures, Regex};
 use std::sync::OnceLock;
 
-const VALID_MARKER_PATTERN: &str = r"(?i)\bpr:([A-Za-z][A-Za-z0-9._\-]*)\b";
-const CANDIDATE_MARKER_PATTERN: &str = r"(?i)\bpr:([A-Za-z0-9._\-]+)\b";
+const VALID_MARKER_PATTERN: &str = r"(?i)(^|[^A-Za-z0-9_])pr:([A-Za-z][A-Za-z0-9._\-]*)($|\s)";
+const CANDIDATE_MARKER_PATTERN: &str = r"(?i)(^|[^A-Za-z0-9_])pr:(\S*)";
 
 static VALID_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
 static CANDIDATE_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -35,17 +35,55 @@ impl std::fmt::Display for LabelValidationError {
 impl std::error::Error for LabelValidationError {}
 
 /// Returns the regex for valid `pr:<label>` markers in commit messages.
-pub fn valid_marker_regex() -> &'static Regex {
+fn valid_marker_regex() -> &'static Regex {
     VALID_MARKER_REGEX.get_or_init(|| {
         Regex::new(VALID_MARKER_PATTERN).expect("valid PR label regex should compile")
     })
 }
 
 /// Returns the regex used to find candidate `pr:<tag>` markers before validation.
-pub fn candidate_marker_regex() -> &'static Regex {
+fn candidate_marker_regex() -> &'static Regex {
     CANDIDATE_MARKER_REGEX.get_or_init(|| {
         Regex::new(CANDIDATE_MARKER_PATTERN).expect("candidate PR label regex should compile")
     })
+}
+
+fn marker_label<'a>(capture: &'a Captures<'a>) -> &'a str {
+    capture
+        .get(2)
+        .expect("marker regex should capture the label token")
+        .as_str()
+}
+
+/// Returns every `pr:<token>` candidate from `text` using the shared marker tokenizer.
+pub fn candidate_marker_labels(text: &str) -> Vec<String> {
+    candidate_marker_regex()
+        .captures_iter(text)
+        .map(|capture| marker_label(&capture).to_string())
+        .collect()
+}
+
+/// Returns the first valid label found in `text`, if any.
+pub fn first_valid_marker_label(text: &str) -> Option<String> {
+    valid_marker_regex()
+        .captures(text)
+        .map(|capture| marker_label(&capture).to_string())
+}
+
+/// Reports whether `text` contains any `pr:<token>` candidate.
+pub fn contains_candidate_marker(text: &str) -> bool {
+    candidate_marker_regex().is_match(text)
+}
+
+/// Removes valid `pr:<label>` markers from `text` without partially stripping malformed tokens.
+pub fn strip_valid_markers(text: &str) -> String {
+    valid_marker_regex()
+        .replace_all(text, |capture: &Captures<'_>| {
+            let prefix = capture.get(1).map_or("", |value| value.as_str());
+            let suffix = capture.get(3).map_or("", |value| value.as_str());
+            format!("{prefix}{suffix}")
+        })
+        .to_string()
 }
 
 /// Validates one PR-group label against the shared commit-marker and selector grammar.
@@ -61,5 +99,54 @@ pub fn validate_label(label: &str) -> std::result::Result<(), LabelValidationErr
         }
     } else {
         Err(LabelValidationError::MustStartWithLetter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        candidate_marker_labels, first_valid_marker_label, strip_valid_markers, validate_label,
+        LabelValidationError,
+    };
+
+    #[test]
+    fn candidate_markers_capture_full_tokens_until_whitespace() {
+        assert_eq!(
+            candidate_marker_labels("feat: alpha pr:alpha!oops more\npr:beta-\npr:"),
+            vec![
+                "alpha!oops".to_string(),
+                "beta-".to_string(),
+                "".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn first_valid_marker_label_accepts_trailing_dash_and_dot() {
+        assert_eq!(
+            first_valid_marker_label("feat: alpha pr:alpha-"),
+            Some("alpha-".to_string())
+        );
+        assert_eq!(
+            first_valid_marker_label("feat: beta pr:beta."),
+            Some("beta.".to_string())
+        );
+    }
+
+    #[test]
+    fn strip_valid_markers_does_not_partially_strip_invalid_tokens() {
+        assert_eq!(strip_valid_markers("feat: alpha pr:alpha-"), "feat: alpha ");
+        assert_eq!(
+            strip_valid_markers("feat: alpha pr:alpha!oops"),
+            "feat: alpha pr:alpha!oops"
+        );
+    }
+
+    #[test]
+    fn validate_label_rejects_empty_string() {
+        assert_eq!(
+            validate_label("").unwrap_err(),
+            LabelValidationError::MustStartWithLetter
+        );
     }
 }


### PR DESCRIPTION
# Problem Solved

After a stack had already been published, operators could append commits on canonical local per-PR branches like `dank-spr/alpha`, but `spr` had no safe way to pull those commits back into the stack branch. The remaining options were manual rebases or ad hoc cherry-picks, which were easy to get wrong and could lose ignored-block placement or replay duplicate changes later in the stack.

# Mental model

`spr absorb` is the inverse of working directly on the per-PR branches. It scans the current stack on the checked-out branch, looks only at exact local branches named `prefix + tag`, classifies each source branch as skip, absorb, or block, then rebuilds the stack from its current `merge-base(base, HEAD)`. Each absorbable tail is inserted immediately after its owning PR group's real commits and before that group's local-only ignored block. The command is local-only: it rewrites the checked-out stack branch, creates a backup tag first, and leaves GitHub unchanged until a later `spr update`.

# How to use it

Use `spr absorb` when you have already published a stack, then append commits directly to one or more canonical local per-PR branches and want those new commits folded back into the stack before republishing.

Example:

1. `dank/main` contains groups labeled `pr:alpha`, `pr:beta`, and `pr:gamma`.
2. You check out `dank-spr/alpha` and append one or more follow-up commits.
3. You return to the stack branch and inspect the rewrite plan with `spr absorb --dry-run`.
4. When the plan looks right, you run `spr absorb`.
5. You verify the rewritten stack with `spr list commit`.
6. You republish the rewritten per-PR branches with `spr update`.

If you intentionally copied a later non-seed follow-up commit into an earlier per-PR branch and want the earlier copy to win, rerun with `spr absorb --allow-replayed-duplicates`. That override stays narrow: later seed commits still block.

# Non-goals

- Do not infer alternate source branches; only the exact local branch named `prefix + tag` counts.
- Do not reconcile arbitrary divergence or merge-heavy side branches.
- Do not update GitHub automatically as part of absorb.
- Do not silently guess through duplicate ownership across the whole stack; the override only handles the copied-later replay case.

# Tradeoffs

- The command prefers fail-closed classification over trying to rescue ambiguous history.
- Blocking copied later stack commits by default is stricter than a naive cherry-pick-based workflow, but it avoids empty or ambiguous later replays.
- The override intentionally permits only later non-seed duplicates, because dropping a later seed commit would change PR-group identity.
- Post-reset temp-worktree cleanup failures are warnings rather than hard failures once the branch tip has already been rewritten.

# Architecture

- Add a new local-only `spr absorb` command path and typed absorb plan in `src/commands/absorb.rs`.
- Reuse the shared backup-tag, temp-worktree, and cherry-pick machinery from the existing rewrite commands.
- Derive groups with `derive_local_groups_with_ignored` so absorbed commits stay ahead of each group's `ignored_after` block.
- Separate pure plan validation from rewrite execution so blocked or dry-run cases have no git side effects.
- Compute verbatim patch identities for later replayed stack commits to catch copied-later duplicates, and optionally drop later non-seed replays when `--allow-replayed-duplicates` is set.
- Keep local-only commands free of a `gh` requirement so absorb, restack, and fix-pr can run without GitHub tooling.

## Tail selection and guardrails

Absorb decides what to pull in per PR group, starting from the exact local branch named `prefix + tag` for that group and nowhere else. If that branch is missing, unchanged, or behind the stack's current group tip, the group is a no-op. If the branch is a simple append-only descendant of the group's current tip, the absorb candidate is exactly the unmatched tail `group_tip..source_tip`. If the branch was rewritten instead of extended, absorb still accepts it only when the rewritten prefix descends from the same stack merge-base, matches the canonical stack prefix by patch identity, and ends at the same tree at the matched boundary; in that case it absorbs only the unmatched suffix above that proven prefix.

Before any rewrite runs, that candidate tail goes through fail-closed validation. Absorb blocks tails that contain merge commits, embedded `pr:<tag>` markers, or patches already owned by later commits that would still be replayed after this group's insertion point. The `--allow-replayed-duplicates` override is intentionally narrow: it can keep later non-seed duplicate replays, but it still refuses to absorb a commit that would collide with a later group's seed commit. Once a tail passes validation, the rewrite order is deterministic: replay the group's existing stack commits, then the absorbed tail, then that group's `ignored_after` block, so ignored-only local commits stay attached to the same group they followed before the rewrite.

# Observability

- `spr absorb` prints a per-group summary that shows whether each canonical branch will be skipped, absorbed, or blocked.
- `--dry-run` shows the plan without creating backup tags, temp branches, or worktrees.
- Blocking errors name the offending group and why it was rejected, including divergence, stack markers, merge commits, later-owned duplicate patches, and later seed duplicates that still cannot be dropped.
- Successful rewrites keep a local backup tag for recovery and require an explicit follow-up `spr update` to publish anything.

# Tests

Test scope is the new absorb planning and rewrite flow plus the small shared-git changes needed to support it. Coverage includes source-branch classification, ignored-block placement, dry-run side-effect guards, post-reset cleanup behavior, copied-later duplicate blocking, override-time replay dropping, CLI parsing, and end-to-end temp-repo rewrites across multiple PR groups. This change does not expand beyond the absorb-related paths.

<!-- spr-stack:start -->
**Stack**:
-   #120
-   #119
-   #118
-   #115
-   #114
- ➡ #113

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
