### PR TITLE
rewrite: enforce configurable dirty-worktree policies for branch rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ list_order: recent_on_bottom
 # How `spr restack` behaves on cherry-pick conflicts: "rollback" (default) or "halt"
 restack_conflict: rollback
 
+# How branch-rewriting commands handle local changes in the checked-out worktree
+# This applies to `spr restack`, `spr move`, `spr fix-pr`, and `spr absorb`.
+# - `discard` preserves the historical behavior: tracked changes may be lost,
+#   while untracked files remain in place
+# - `stash` stashes tracked, staged, and untracked changes and reapplies them
+#   with `git stash apply --index`
+# - `halt` (default) refuses to rewrite until the worktree is clean
+dirty_worktree: halt
+
 # Blocks PR recreation when the same head branch had a recently merged
 # or closed PR within the configured window. Set to 0 to disable the guard.
 branch_reuse_guard_days: 180
@@ -112,7 +121,7 @@ Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > git discovery (`origin/HEAD`)
 - Base has no built-in fallback; if discovery fails, set `base` explicitly
-- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `restack_conflict = rollback`
+- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `restack_conflict = rollback`, `dirty_worktree = halt`
 
 Global flags
 ------------
@@ -182,6 +191,7 @@ Behavior:
 - Updates the current branch to the rebuilt tip
 - With `--safe`, a backup tag named like `backup/restack/<current-branch>-<short-sha>` is created first
 - Conflict handling is controlled by `restack_conflict` in config.
+- Before rewriting the checked-out branch, `spr restack` follows the `dirty_worktree` config.
 - `rollback` (default) aborts the restack and attempts to clean up the temp restack worktree and branch (cleanup failures may require manual cleanup).
 - `halt` stops on conflict, leaves the temp restack worktree and branch in place, and prints manual rollback/continue instructions.
 - When using `halt`, resolve conflicts inside the printed temp worktree path; resolving in your original worktree will not advance the halted cherry-pick.
@@ -202,6 +212,7 @@ Behavior:
 - Rebuilds the current stack from its existing `merge-base(base, HEAD)` rather than restacking onto the latest base tip
 - Inserts absorbed commits after the group's real commits and before that group's trailing ignored block
 - Creates a local backup tag before rewriting the stack
+- Before rewriting the checked-out branch, `spr absorb` follows the `dirty_worktree` config.
 - Does not update GitHub; inspect the rewritten stack first, then run `spr update`
 
 Typical workflow:
@@ -280,6 +291,7 @@ Aliases:
   - `--after top` is the same as `--after N`
 - `--safe`: create a local backup tag at current `HEAD` before rewriting
 - Ignore blocks (`pr:ignore`) stay attached to the preceding PR group and move with it
+- Before rewriting the checked-out branch, `spr move` follows the `dirty_worktree` config.
 
 Prints an explicit plan, e.g.: `2..3→4: [1,2,3,4,5,6] → [1,4,2,3,5,6]`.
 
@@ -361,6 +373,7 @@ Behavior:
 - Rewrites local history to move the tail M commits after the selected PR group's tail commit
 - `--safe`: create a local backup tag at current `HEAD` before executing
 - Ignore blocks (`pr:ignore`) are preserved and cannot be moved; the command aborts if the tail intersects an ignore block
+- Before rewriting the checked-out branch, `spr fix-pr` follows the `dirty_worktree` config.
 
 ### spr cleanup
 

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -15,6 +15,7 @@ use std::collections::{HashMap, HashSet};
 use tracing::{info, warn};
 
 use crate::commands::common::{self, CherryPickEmptyPolicy, CherryPickOp};
+use crate::config::DirtyWorktreePolicy;
 use crate::git::{
     git_commit_message, git_commit_parent_count, git_commit_tree, git_is_ancestor,
     git_local_branch_tip, git_merge_base, git_patch_ids_for_commits, git_rev_list_range,
@@ -42,6 +43,7 @@ pub fn absorb_branch_tails(
     prefix: &str,
     ignore_tag: &str,
     dry: bool,
+    dirty_worktree_policy: DirtyWorktreePolicy,
     options: AbsorbOptions,
 ) -> Result<()> {
     let (_stack_head, plan) = build_plan_for_current_stack(base, prefix, ignore_tag, options)?;
@@ -62,7 +64,9 @@ pub fn absorb_branch_tails(
             info!("No absorbable branch tails found; nothing to rewrite.");
             Ok(())
         }
-        AbsorbPlanValidation::ReadyToRewrite => execute_absorb_plan(&plan, dry),
+        AbsorbPlanValidation::ReadyToRewrite => {
+            execute_absorb_plan(&plan, dry, dirty_worktree_policy)
+        }
     }
 }
 
@@ -937,40 +941,46 @@ fn cleanup_temp_worktree_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str
 
 /// Executes a validated absorb rewrite plan by rebuilding the current stack in
 /// a temporary worktree and resetting the checked-out branch to the new tip.
-fn execute_absorb_plan(plan: &RewritePlan, dry: bool) -> Result<()> {
+fn execute_absorb_plan(
+    plan: &RewritePlan,
+    dry: bool,
+    dirty_worktree_policy: DirtyWorktreePolicy,
+) -> Result<()> {
     emit_rewrite_plan(plan);
-    if dry {
-        info!("Dry run complete. No local git state or GitHub state was changed.");
-        info!("Run `spr absorb` without `--dry-run` to apply the rewrite.");
-        info!("After inspecting the rewritten stack, run `spr update`.");
-        Ok(())
-    } else {
-        let (cur_branch, short) = common::get_current_branch_and_short()?;
-        let _backup_tag = common::create_backup_tag(dry, "absorb", &cur_branch, &short)?;
-        let (tmp_path, tmp_branch) =
-            common::create_temp_worktree(dry, "absorb", &plan.merge_base, &short)?;
-        for op in &plan.operations {
-            if let Err(err) = op.run(dry, &tmp_path) {
-                return Err(err).with_context(|| {
-                    format!(
-                        "absorb rewrite failed in temp worktree {} on branch {}",
-                        tmp_path, tmp_branch
-                    )
-                });
+    common::with_dirty_worktree_policy(dry, "spr absorb", dirty_worktree_policy, || {
+        if dry {
+            info!("Dry run complete. No local git state or GitHub state was changed.");
+            info!("Run `spr absorb` without `--dry-run` to apply the rewrite.");
+            info!("After inspecting the rewritten stack, run `spr update`.");
+            Ok(())
+        } else {
+            let (cur_branch, short) = common::get_current_branch_and_short()?;
+            let _backup_tag = common::create_backup_tag(dry, "absorb", &cur_branch, &short)?;
+            let (tmp_path, tmp_branch) =
+                common::create_temp_worktree(dry, "absorb", &plan.merge_base, &short)?;
+            for op in &plan.operations {
+                if let Err(err) = op.run(dry, &tmp_path) {
+                    return Err(err).with_context(|| {
+                        format!(
+                            "absorb rewrite failed in temp worktree {} on branch {}",
+                            tmp_path, tmp_branch
+                        )
+                    });
+                }
             }
+            let new_tip = common::tip_of_tmp(&tmp_path)?;
+            info!(
+                "Updating current branch {} to new tip {} (absorbed branch tails)...",
+                cur_branch, new_tip
+            );
+            common::reset_current_branch_to(dry, &new_tip)?;
+            cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
+            info!(
+                "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+            );
+            Ok(())
         }
-        let new_tip = common::tip_of_tmp(&tmp_path)?;
-        info!(
-            "Updating current branch {} to new tip {} (absorbed branch tails)...",
-            cur_branch, new_tip
-        );
-        common::reset_current_branch_to(dry, &new_tip)?;
-        cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
-        info!(
-            "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
-        );
-        Ok(())
-    }
+    })
 }
 
 fn emit_absorb_summary(plan: &RewritePlan) {
@@ -1050,37 +1060,13 @@ mod tests {
     };
     use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
     use crate::parsing::{derive_local_groups_with_ignored, Group};
+    use crate::test_support::{lock_cwd, DirGuard};
     use std::env;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::Command;
-    use std::sync::{Mutex, MutexGuard};
     use tempfile::TempDir;
-
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
-
-    fn lock_cwd() -> MutexGuard<'static, ()> {
-        CWD_LOCK.lock().unwrap_or_else(|err| err.into_inner())
-    }
-
-    struct DirGuard {
-        original: PathBuf,
-    }
-
-    impl DirGuard {
-        fn change_to(path: &Path) -> Self {
-            let original = env::current_dir().expect("current dir available");
-            env::set_current_dir(path).expect("set current dir to temp repo");
-            Self { original }
-        }
-    }
-
-    impl Drop for DirGuard {
-        fn drop(&mut self) {
-            env::set_current_dir(&self.original).expect("restore original current dir");
-        }
-    }
 
     struct EnvVarGuard {
         key: &'static str,
@@ -1902,6 +1888,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 false,
+                crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
         };
@@ -1971,6 +1958,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 false,
+                crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
         };
@@ -2010,6 +1998,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 false,
+                crate::config::DirtyWorktreePolicy::Discard,
                 absorb_override_options(),
             )
             .unwrap();
@@ -2105,6 +2094,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 false,
+                crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
             .unwrap();
@@ -2206,6 +2196,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 false,
+                crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
             .expect("cleanup failure after reset should not fail absorb");
@@ -2242,6 +2233,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 false,
+                crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
             .unwrap();
@@ -2276,6 +2268,7 @@ mod tests {
                 &repo.prefix,
                 &repo.ignore_tag,
                 true,
+                crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
             .unwrap();

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -17,15 +17,21 @@
 //! and uses `git worktree add -B` as a final safeguard when cleanup is skipped
 //! in dry-run mode.
 //!
+//! Branch-rewriting commands also share dirty-worktree handling. Depending on
+//! config, they may preserve current behavior and discard tracked changes,
+//! auto-stash local changes and restore them after the rewrite, or halt before
+//! any destructive step.
+//!
 //! Backup tags are local-only and are intended as an escape hatch for a single
 //! user; callers should not rely on them being immutable.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
-use tracing::info;
+use tracing::{info, warn};
 
+use crate::config::DirtyWorktreePolicy;
 use crate::git::{git_ro, git_rw, normalize_branch_name};
 use crate::parsing::Group;
 
@@ -266,6 +272,189 @@ pub fn cleanup_temp_worktree(dry: bool, tmp_path: &str, tmp_branch: &str) -> Res
     Ok(())
 }
 
+#[derive(Debug)]
+enum DirtyWorktreeRestore {
+    Noop,
+    PlannedStash,
+    Stashed { stash_ref: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RewriteOutcome {
+    Succeeded,
+    Failed,
+}
+
+impl RewriteOutcome {
+    fn verb(self) -> &'static str {
+        if self == Self::Succeeded {
+            "rewrote history"
+        } else {
+            "failed before finishing the rewrite"
+        }
+    }
+}
+
+fn worktree_status_lines() -> Result<Vec<String>> {
+    let out = git_ro(["status", "--porcelain=v1"].as_slice())?;
+    Ok(out.lines().map(|line| line.to_string()).collect::<Vec<_>>())
+}
+
+fn status_line_has_conflict(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    if bytes.len() < 2 {
+        false
+    } else {
+        let x = bytes[0] as char;
+        let y = bytes[1] as char;
+        x == 'U' || y == 'U' || (x == 'A' && y == 'A') || (x == 'D' && y == 'D')
+    }
+}
+
+fn prepare_dirty_worktree(
+    dry: bool,
+    command_name: &str,
+    policy: DirtyWorktreePolicy,
+) -> Result<DirtyWorktreeRestore> {
+    let status_lines = worktree_status_lines()?;
+    if status_lines.is_empty() {
+        Ok(DirtyWorktreeRestore::Noop)
+    } else if status_lines
+        .iter()
+        .any(|line| status_line_has_conflict(line))
+    {
+        bail!(
+            "{} cannot rewrite history with unresolved merge conflicts:\n{}\nResolve the conflicts first.",
+            command_name,
+            status_lines.join("\n")
+        );
+    } else if policy == DirtyWorktreePolicy::Discard {
+        info!(
+            "{} detected local changes and dirty_worktree=discard; proceeding without preserving tracked changes. Untracked files are left in place.",
+            command_name
+        );
+        Ok(DirtyWorktreeRestore::Noop)
+    } else if policy == DirtyWorktreePolicy::Halt {
+        bail!(
+            "{} rewrites the checked-out branch and dirty_worktree=halt found local changes:\n{}\nCommit, stash, or discard them first.",
+            command_name,
+            status_lines.join("\n")
+        );
+    } else if dry {
+        info!(
+            "DRY-RUN: would stash local changes before {} because dirty_worktree=stash",
+            command_name
+        );
+        Ok(DirtyWorktreeRestore::PlannedStash)
+    } else {
+        let message = format!("spr auto-stash before {}", command_name);
+        let stash_ref = "stash@{0}".to_string();
+        let _ = git_rw(
+            false,
+            [
+                "stash",
+                "push",
+                "--include-untracked",
+                "--message",
+                &message,
+            ]
+            .as_slice(),
+        )?;
+        let remaining = worktree_status_lines()?;
+        if remaining.is_empty() {
+            info!(
+                "Stashed local changes before {} because dirty_worktree=stash",
+                command_name
+            );
+            Ok(DirtyWorktreeRestore::Stashed { stash_ref })
+        } else {
+            bail!(
+                "{} stashed local changes but the worktree is still dirty:\n{}",
+                command_name,
+                remaining.join("\n")
+            );
+        }
+    }
+}
+
+impl DirtyWorktreeRestore {
+    fn restore(self, dry: bool, command_name: &str, outcome: RewriteOutcome) -> Result<()> {
+        match self {
+            Self::Noop => Ok(()),
+            Self::PlannedStash => {
+                if dry {
+                    info!(
+                        "DRY-RUN: would restore stashed local changes after {}",
+                        command_name
+                    );
+                }
+                Ok(())
+            }
+            Self::Stashed { stash_ref } => {
+                let _ = git_rw(false, ["stash", "apply", "--index", &stash_ref].as_slice())
+                    .with_context(|| {
+                        format!(
+                            "{} {} but failed to restore stashed changes from {}; the stash entry was kept for manual recovery",
+                            command_name,
+                            outcome.verb(),
+                            stash_ref
+                        )
+                    })?;
+                if let Err(err) = git_rw(false, ["stash", "drop", &stash_ref].as_slice()) {
+                    warn!(
+                        "Restored stashed local changes after {}, but failed to drop {}: {}",
+                        command_name, stash_ref, err
+                    );
+                }
+                if dry {
+                    info!(
+                        "DRY-RUN: restored stashed local changes after {}",
+                        command_name
+                    );
+                } else {
+                    info!("Restored stashed local changes after {}", command_name);
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Run a branch rewrite under the configured dirty-worktree policy.
+///
+/// This is the single source of truth for commands that rebuild the
+/// checked-out branch and then replace it with a rewritten tip.
+pub fn with_dirty_worktree_policy<T, F>(
+    dry: bool,
+    command_name: &str,
+    policy: DirtyWorktreePolicy,
+    rewrite: F,
+) -> Result<T>
+where
+    F: FnOnce() -> Result<T>,
+{
+    let restore = prepare_dirty_worktree(dry, command_name, policy)?;
+    let rewrite_result = rewrite();
+    let outcome = if rewrite_result.is_ok() {
+        RewriteOutcome::Succeeded
+    } else {
+        RewriteOutcome::Failed
+    };
+    let restore_result = restore.restore(dry, command_name, outcome);
+
+    match (rewrite_result, restore_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(restore_err)) => Err(restore_err),
+        (Err(rewrite_err), Ok(())) => Err(rewrite_err),
+        (Err(rewrite_err), Err(restore_err)) => Err(rewrite_err).with_context(|| {
+            format!(
+                "also failed to restore local changes after {}: {restore_err:#}",
+                command_name
+            )
+        }),
+    }
+}
+
 /// A single cherry-pick operation used to rebuild stack history.
 ///
 /// `Range` represents an inclusive `first^..last` cherry-pick over a contiguous
@@ -386,34 +575,11 @@ mod tests {
         cleanup_temp_worktree, create_backup_tag, create_temp_worktree,
         get_current_branch_and_short,
     };
-    use std::env;
+    use crate::test_support::{lock_cwd, DirGuard};
     use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::process::Command;
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    // Tests in this module mutate the process-wide current working directory.
-    // Serialize them to avoid cross-test interference.
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
-
-    struct DirGuard {
-        original: PathBuf,
-    }
-
-    impl DirGuard {
-        fn change_to(path: &Path) -> Self {
-            let original = env::current_dir().expect("current dir available");
-            env::set_current_dir(path).expect("set current dir to temp repo");
-            Self { original }
-        }
-    }
-
-    impl Drop for DirGuard {
-        fn drop(&mut self) {
-            env::set_current_dir(&self.original).expect("restore original current dir");
-        }
-    }
 
     fn git(repo: &Path, args: &[&str]) -> String {
         let out = Command::new("git")
@@ -445,7 +611,7 @@ mod tests {
 
     #[test]
     fn create_backup_tag_overwrites_existing() {
-        let _lock = CWD_LOCK.lock().expect("lock cwd");
+        let _lock = lock_cwd();
         let dir = init_repo();
         let repo = dir.path().to_path_buf();
         let _guard = DirGuard::change_to(&repo);
@@ -473,7 +639,7 @@ mod tests {
 
     #[test]
     fn create_temp_worktree_replaces_existing_temp_branch() {
-        let _lock = CWD_LOCK.lock().expect("lock cwd");
+        let _lock = lock_cwd();
         let dir = init_repo();
         let repo = dir.path().to_path_buf();
         let _guard = DirGuard::change_to(&repo);

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use tracing::info;
 
 use crate::commands::common;
+use crate::config::DirtyWorktreePolicy;
 use crate::git::git_ro;
 use crate::parsing::derive_local_groups_with_ignored;
 use crate::selectors::{resolve_group_ordinal, GroupSelector};
@@ -33,6 +34,7 @@ pub fn fix_pr_tail(
     tail_count: usize,
     safe: bool,
     dry: bool,
+    dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<()> {
     if tail_count == 0 {
         return Ok(());
@@ -132,44 +134,46 @@ pub fn fix_pr_tail(
         new_order.extend(all_commits[insert_pos + 1..].iter().cloned());
     }
 
-    // Optionally create a backup tag at current HEAD (safety)
-    let (cur_branch, short) = common::get_current_branch_and_short()?;
-    if safe {
-        let _ = common::create_backup_tag(dry, "fix-pr", &cur_branch, &short)?;
-    }
+    common::with_dirty_worktree_policy(dry, "spr fix-pr", dirty_worktree_policy, || {
+        let (cur_branch, short) = common::get_current_branch_and_short()?;
+        if safe {
+            let _ = common::create_backup_tag(dry, "fix-pr", &cur_branch, &short)?;
+        }
 
-    // Build the new history in a temporary worktree off merge-base
-    let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "fix", &merge_base, &short)?;
+        let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "fix", &merge_base, &short)?;
 
-    for sha in &new_order {
-        // Cherry-pick the commit onto tmp
-        common::cherry_pick_commit(
-            dry,
-            &tmp_path,
-            sha,
-            common::CherryPickEmptyPolicy::StopOnEmpty,
-        )?;
-    }
+        for sha in &new_order {
+            common::cherry_pick_commit(
+                dry,
+                &tmp_path,
+                sha,
+                common::CherryPickEmptyPolicy::StopOnEmpty,
+            )?;
+        }
 
-    // Point current branch to new tip
-    let new_tip = common::tip_of_tmp(&tmp_path)?;
-    info!(
-        "Updating current branch {} to new tip {} (fix-pr applied)…",
-        cur_branch, new_tip
-    );
-    common::reset_current_branch_to(dry, &new_tip)?;
+        let new_tip = common::tip_of_tmp(&tmp_path)?;
+        info!(
+            "Updating current branch {} to new tip {} (fix-pr applied)…",
+            cur_branch, new_tip
+        );
+        common::reset_current_branch_to(dry, &new_tip)?;
+        common::cleanup_temp_worktree(dry, &tmp_path, &tmp_branch)?;
 
-    // Cleanup temp worktree/branch
-    common::cleanup_temp_worktree(dry, &tmp_path, &tmp_branch)?;
-
-    Ok(())
+        Ok(())
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_fix_pr_target;
+    use super::{fix_pr_tail, resolve_fix_pr_target};
+    use crate::config::DirtyWorktreePolicy;
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, StableHandle};
+    use crate::test_support::{lock_cwd, DirGuard};
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
@@ -191,5 +195,205 @@ mod tests {
         });
 
         assert_eq!(resolve_fix_pr_target(&groups, &target).unwrap(), 2);
+    }
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
+    fn init_fix_pr_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path();
+        git(repo, ["init", "-b", "main"].as_slice());
+        git(repo, ["config", "user.email", "spr@example.com"].as_slice());
+        git(repo, ["config", "user.name", "SPR Tests"].as_slice());
+        fs::write(repo.join("consumer.txt"), "consumer base\n").expect("write consumer");
+        git(repo, ["add", "."].as_slice());
+        git(repo, ["commit", "-m", "init"].as_slice());
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+
+        fs::write(repo.join("alpha.txt"), "alpha 1\n").expect("write alpha seed");
+        git(repo, ["add", "alpha.txt"].as_slice());
+        git(repo, ["commit", "-m", "feat: alpha pr:alpha"].as_slice());
+
+        fs::write(repo.join("alpha.txt"), "alpha 1\nalpha 2\n").expect("write alpha follow-up");
+        git(repo, ["add", "alpha.txt"].as_slice());
+        git(repo, ["commit", "-m", "feat: alpha follow-up"].as_slice());
+
+        fs::write(repo.join("beta.txt"), "beta 1\n").expect("write beta seed");
+        git(repo, ["add", "beta.txt"].as_slice());
+        git(repo, ["commit", "-m", "feat: beta pr:beta"].as_slice());
+
+        fs::write(repo.join("beta.txt"), "beta 1\nbeta 2\n").expect("write beta follow-up");
+        git(repo, ["add", "beta.txt"].as_slice());
+        git(repo, ["commit", "-m", "feat: beta follow-up"].as_slice());
+
+        fs::write(repo.join("review.txt"), "review fix\n").expect("write review");
+        git(repo, ["add", "review.txt"].as_slice());
+        git(repo, ["commit", "-m", "fix review comment"].as_slice());
+
+        dir
+    }
+
+    fn dirty_worktree(repo: &Path) {
+        fs::write(repo.join("consumer.txt"), "consumer dirty\n").expect("dirty tracked file");
+        fs::write(repo.join("scratch.txt"), "scratch local\n").expect("write untracked file");
+    }
+
+    fn log_subjects(repo: &Path) -> Vec<String> {
+        git(repo, ["log", "--format=%s", "-5"].as_slice())
+            .lines()
+            .map(|line| line.to_string())
+            .collect()
+    }
+
+    fn expected_rewritten_subjects() -> Vec<String> {
+        vec![
+            "feat: beta follow-up".to_string(),
+            "feat: beta pr:beta".to_string(),
+            "fix review comment".to_string(),
+            "feat: alpha follow-up".to_string(),
+            "feat: alpha pr:alpha".to_string(),
+        ]
+    }
+
+    #[test]
+    fn fix_pr_discard_policy_preserves_current_tracked_reset_behavior() {
+        let _lock = lock_cwd();
+        let dir = init_fix_pr_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        let original_head = git(&repo, ["rev-parse", "HEAD"].as_slice());
+        dirty_worktree(&repo);
+
+        fix_pr_tail(
+            "main",
+            "ignore",
+            &GroupSelector::LocalPr(1),
+            1,
+            false,
+            false,
+            DirtyWorktreePolicy::Discard,
+        )
+        .expect("fix-pr should rewrite under discard policy");
+
+        let rewritten_head = git(&repo, ["rev-parse", "HEAD"].as_slice());
+        assert_ne!(
+            original_head.trim(),
+            rewritten_head.trim(),
+            "HEAD should move"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("consumer.txt")).expect("read consumer"),
+            "consumer base\n",
+            "discard policy should preserve the current tracked reset behavior"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("scratch.txt")).expect("read scratch"),
+            "scratch local\n",
+            "discard policy should leave untracked files in place"
+        );
+        assert_eq!(log_subjects(&repo), expected_rewritten_subjects());
+    }
+
+    #[test]
+    fn fix_pr_stash_policy_restores_tracked_and_untracked_changes() {
+        let _lock = lock_cwd();
+        let dir = init_fix_pr_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        let original_head = git(&repo, ["rev-parse", "HEAD"].as_slice());
+        dirty_worktree(&repo);
+
+        fix_pr_tail(
+            "main",
+            "ignore",
+            &GroupSelector::LocalPr(1),
+            1,
+            false,
+            false,
+            DirtyWorktreePolicy::Stash,
+        )
+        .expect("fix-pr should rewrite and restore stashed changes");
+
+        let rewritten_head = git(&repo, ["rev-parse", "HEAD"].as_slice());
+        assert_ne!(
+            original_head.trim(),
+            rewritten_head.trim(),
+            "HEAD should move"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("consumer.txt")).expect("read consumer"),
+            "consumer dirty\n",
+            "stash policy should restore tracked changes"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("scratch.txt")).expect("read scratch"),
+            "scratch local\n",
+            "stash policy should restore untracked files"
+        );
+        assert!(
+            git(&repo, ["stash", "list"].as_slice()).trim().is_empty(),
+            "stash policy should drop the temporary stash after a successful restore"
+        );
+        assert_eq!(log_subjects(&repo), expected_rewritten_subjects());
+    }
+
+    #[test]
+    fn fix_pr_halt_policy_refuses_to_rewrite_dirty_worktree() {
+        let _lock = lock_cwd();
+        let dir = init_fix_pr_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        let original_head = git(&repo, ["rev-parse", "HEAD"].as_slice());
+        dirty_worktree(&repo);
+
+        let err = fix_pr_tail(
+            "main",
+            "ignore",
+            &GroupSelector::LocalPr(1),
+            1,
+            false,
+            false,
+            DirtyWorktreePolicy::Halt,
+        )
+        .expect_err("halt policy should refuse a dirty worktree");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("dirty_worktree=halt"),
+            "error should name the blocking policy: {err_text}"
+        );
+
+        let current_head = git(&repo, ["rev-parse", "HEAD"].as_slice());
+        assert_eq!(
+            original_head.trim(),
+            current_head.trim(),
+            "HEAD should not move"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("consumer.txt")).expect("read consumer"),
+            "consumer dirty\n",
+            "halt policy should leave tracked changes untouched"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("scratch.txt")).expect("read scratch"),
+            "scratch local\n",
+            "halt policy should leave untracked files untouched"
+        );
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,7 +17,7 @@ pub use land::{land_flatten_until, land_per_pr_until};
 pub use list::list_commits_display;
 pub use list::list_prs_display;
 pub use prep::prep_squash;
-pub use r#move::move_groups_after;
+pub use r#move::{move_groups_after, MoveExecutionOptions};
 pub use relink_prs::relink_prs;
 pub use restack::{restack_after, restack_after_count};
 pub use update::{build_from_groups, build_from_tags};

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -4,11 +4,20 @@ use anyhow::{anyhow, Result};
 use tracing::info;
 
 use crate::commands::common;
+use crate::config::DirtyWorktreePolicy;
 use crate::github::get_open_pr_automerge_for_head;
 use crate::parsing::derive_local_groups_with_ignored;
 use crate::selectors::{
     resolve_after_count, resolve_group_range, AfterSelector, GroupRangeSelector,
 };
+
+/// Execution controls for `spr move`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MoveExecutionOptions {
+    pub safe: bool,
+    pub dry: bool,
+    pub dirty_worktree_policy: DirtyWorktreePolicy,
+}
 
 fn format_simple_plan(old: &[usize], new: &[usize], a: usize, b: usize, c: usize) -> String {
     let lhs = if a == b {
@@ -128,8 +137,7 @@ pub fn move_groups_after(
     ignore_tag: &str,
     range: &GroupRangeSelector,
     after: &AfterSelector,
-    safe: bool,
-    dry: bool,
+    options: MoveExecutionOptions,
 ) -> Result<()> {
     // Discover groups from local commits bottom→top
     let (merge_base, leading_ignored, groups) = derive_local_groups_with_ignored(base, ignore_tag)?;
@@ -204,44 +212,46 @@ pub fn move_groups_after(
         return Ok(());
     }
 
-    // Optionally create a backup tag at current HEAD
-    let (cur_branch, short) = common::get_current_branch_and_short()?;
-    if safe {
-        let _ = common::create_backup_tag(dry, "move", &cur_branch, &short)?;
-    }
+    common::with_dirty_worktree_policy(
+        options.dry,
+        "spr move",
+        options.dirty_worktree_policy,
+        || {
+            let (cur_branch, short) = common::get_current_branch_and_short()?;
+            if options.safe {
+                let _ = common::create_backup_tag(options.dry, "move", &cur_branch, &short)?;
+            }
 
-    // Build the new history in a temporary worktree off merge-base
-    let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "move", &merge_base, &short)?;
+            let (tmp_path, tmp_branch) =
+                common::create_temp_worktree(options.dry, "move", &merge_base, &short)?;
 
-    // Preserve ignored commits that appear before the first group
-    cherry_pick_block(dry, &tmp_path, &leading_ignored)?;
+            cherry_pick_block(options.dry, &tmp_path, &leading_ignored)?;
 
-    // Cherry-pick commits in the new order, group by group (batched per-group)
-    for idx in &new_order {
-        let g = &groups[*idx - 1];
-        if let (Some(first), Some(last)) = (g.commits.first(), g.commits.last()) {
-            common::cherry_pick_range(
-                dry,
-                &tmp_path,
-                first,
-                last,
-                common::CherryPickEmptyPolicy::StopOnEmpty,
-            )?;
-        }
-        cherry_pick_block(dry, &tmp_path, &g.ignored_after)?;
-    }
+            for idx in &new_order {
+                let g = &groups[*idx - 1];
+                if let (Some(first), Some(last)) = (g.commits.first(), g.commits.last()) {
+                    common::cherry_pick_range(
+                        options.dry,
+                        &tmp_path,
+                        first,
+                        last,
+                        common::CherryPickEmptyPolicy::StopOnEmpty,
+                    )?;
+                }
+                cherry_pick_block(options.dry, &tmp_path, &g.ignored_after)?;
+            }
 
-    let new_tip = common::tip_of_tmp(&tmp_path)?;
-    info!(
-        "Updating current branch {} to new tip {} (stack reordered)…",
-        cur_branch, new_tip
-    );
-    common::reset_current_branch_to(dry, &new_tip)?;
+            let new_tip = common::tip_of_tmp(&tmp_path)?;
+            info!(
+                "Updating current branch {} to new tip {} (stack reordered)…",
+                cur_branch, new_tip
+            );
+            common::reset_current_branch_to(options.dry, &new_tip)?;
+            common::cleanup_temp_worktree(options.dry, &tmp_path, &tmp_branch)?;
 
-    // Cleanup temp worktree/branch
-    common::cleanup_temp_worktree(dry, &tmp_path, &tmp_branch)?;
-
-    Ok(())
+            Ok(())
+        },
+    )
 }
 
 #[cfg(test)]

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -17,10 +17,18 @@ use tracing::{info, warn};
 
 use crate::commands::common;
 use crate::commands::common::CherryPickOp;
-use crate::config::RestackConflictPolicy;
+use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
 use crate::git::git_rw;
 use crate::parsing::{derive_local_groups_with_ignored, Group};
 use crate::selectors::{resolve_after_count, AfterSelector};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RestackExecutionOptions {
+    safe: bool,
+    dry: bool,
+    conflict_policy: RestackConflictPolicy,
+    dirty_worktree_policy: DirtyWorktreePolicy,
+}
 
 fn cherry_pick_head_exists(tmp_path: &str) -> bool {
     Command::new("git")
@@ -159,76 +167,84 @@ fn restack_after_resolved(
     leading_ignored: Vec<String>,
     groups: Vec<Group>,
     after: usize,
-    safe: bool,
-    dry: bool,
-    conflict_policy: RestackConflictPolicy,
+    options: RestackExecutionOptions,
 ) -> Result<()> {
-    let (cur_branch, short) = common::get_current_branch_and_short()?;
     let after = std::cmp::min(after, groups.len());
     let kept_ignored_segments = build_kept_ignored_segments(leading_ignored, &groups, after);
-    let remaining = &groups[after..];
-    if remaining.is_empty() && kept_ignored_segments.is_empty() {
-        if safe {
-            let _ = common::create_backup_tag(dry, "restack", &cur_branch, &short)?;
-        }
-        info!(
-            "Skipping all {} PR(s); syncing current branch {} to {}",
-            groups.len(),
-            cur_branch,
-            base
-        );
-        common::reset_current_branch_to(dry, base)?;
-        Ok(())
-    } else {
-        let backup_tag = if safe {
-            Some(common::create_backup_tag(
-                dry,
-                "restack",
-                &cur_branch,
-                &short,
-            )?)
-        } else {
-            None
-        };
+    let remaining = groups[after..].to_vec();
 
-        let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "restack", base, &short)?;
-        let ops = build_cherry_pick_plan(&kept_ignored_segments, remaining);
-        for (idx, op) in ops.iter().enumerate() {
-            if let Err(err) = op.run(dry, &tmp_path) {
-                let conflict = cherry_pick_head_exists(&tmp_path);
-                if conflict && conflict_policy == RestackConflictPolicy::Halt {
-                    emit_halt_instructions(
+    common::with_dirty_worktree_policy(
+        options.dry,
+        "spr restack",
+        options.dirty_worktree_policy,
+        || {
+            let (cur_branch, short) = common::get_current_branch_and_short()?;
+            if remaining.is_empty() && kept_ignored_segments.is_empty() {
+                if options.safe {
+                    let _ = common::create_backup_tag(options.dry, "restack", &cur_branch, &short)?;
+                }
+                info!(
+                    "Skipping all {} PR(s); syncing current branch {} to {}",
+                    groups.len(),
+                    cur_branch,
+                    base
+                );
+                common::reset_current_branch_to(options.dry, base)?;
+                Ok(())
+            } else {
+                let backup_tag = if options.safe {
+                    Some(common::create_backup_tag(
+                        options.dry,
+                        "restack",
                         &cur_branch,
-                        backup_tag.as_deref(),
-                        base,
-                        &tmp_path,
-                        &tmp_branch,
-                        idx,
-                        &ops,
-                    );
-                    return Err(anyhow!(
-                        "restack halted due to conflict; resolve in temp worktree and continue manually"
-                    ));
+                        &short,
+                    )?)
+                } else {
+                    None
+                };
+
+                let (tmp_path, tmp_branch) =
+                    common::create_temp_worktree(options.dry, "restack", base, &short)?;
+                let ops = build_cherry_pick_plan(&kept_ignored_segments, &remaining);
+                for (idx, op) in ops.iter().enumerate() {
+                    if let Err(err) = op.run(options.dry, &tmp_path) {
+                        let conflict = cherry_pick_head_exists(&tmp_path);
+                        if conflict && options.conflict_policy == RestackConflictPolicy::Halt {
+                            emit_halt_instructions(
+                                &cur_branch,
+                                backup_tag.as_deref(),
+                                base,
+                                &tmp_path,
+                                &tmp_branch,
+                                idx,
+                                &ops,
+                            );
+                            return Err(anyhow!(
+                                "restack halted due to conflict; resolve in temp worktree and continue manually"
+                            ));
+                        }
+
+                        if conflict {
+                            abort_cherry_pick_best_effort(options.dry, &tmp_path);
+                        }
+                        cleanup_temp_worktree_best_effort(options.dry, &tmp_path, &tmp_branch);
+                        return Err(err)
+                            .context("restack failed; temp restack state was cleaned up");
+                    }
                 }
 
-                if conflict {
-                    abort_cherry_pick_best_effort(dry, &tmp_path);
-                }
-                cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
-                return Err(err).context("restack failed; temp restack state was cleaned up");
+                let new_tip = common::tip_of_tmp(&tmp_path)?;
+                info!(
+                    "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
+                    after, cur_branch, base
+                );
+                common::reset_current_branch_to(options.dry, &new_tip)?;
+                cleanup_temp_worktree_best_effort(options.dry, &tmp_path, &tmp_branch);
+
+                Ok(())
             }
-        }
-
-        let new_tip = common::tip_of_tmp(&tmp_path)?;
-        info!(
-            "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
-            after, cur_branch, base
-        );
-        common::reset_current_branch_to(dry, &new_tip)?;
-        cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
-
-        Ok(())
-    }
+        },
+    )
 }
 
 /// Restack the local stack by rebasing commits after the first `after` PRs onto `base`.
@@ -257,6 +273,7 @@ pub fn restack_after(
     safe: bool,
     dry: bool,
     conflict_policy: RestackConflictPolicy,
+    dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<()> {
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
@@ -272,9 +289,12 @@ pub fn restack_after(
             leading_ignored,
             groups,
             after,
-            safe,
-            dry,
-            conflict_policy,
+            RestackExecutionOptions {
+                safe,
+                dry,
+                conflict_policy,
+                dirty_worktree_policy,
+            },
         )
     }
 }
@@ -287,6 +307,7 @@ pub fn restack_after_count(
     safe: bool,
     dry: bool,
     conflict_policy: RestackConflictPolicy,
+    dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<()> {
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
@@ -300,9 +321,12 @@ pub fn restack_after_count(
             leading_ignored,
             groups,
             after,
-            safe,
-            dry,
-            conflict_policy,
+            RestackExecutionOptions {
+                safe,
+                dry,
+                conflict_policy,
+                dirty_worktree_policy,
+            },
         )
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,30 @@ impl Default for RestackConflictPolicy {
     }
 }
 
+/// Behavior when a branch-rewriting command sees local changes.
+///
+/// This applies to commands that rebuild the checked-out branch and then move
+/// it to a rewritten tip, such as `spr restack`, `spr move`, `spr fix-pr`, and
+/// `spr absorb`.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DirtyWorktreePolicy {
+    /// Preserve the historical behavior: proceed and let the rewrite replace
+    /// tracked changes in the checked-out worktree.
+    Discard,
+    /// Stash tracked, staged, and untracked changes before the rewrite, then
+    /// reapply them with `git stash apply --index`.
+    Stash,
+    /// Refuse to rewrite until the worktree is clean.
+    Halt,
+}
+
+impl Default for DirtyWorktreePolicy {
+    fn default() -> Self {
+        Self::Halt
+    }
+}
+
 /// Output ordering for list-style displays.
 ///
 /// The local stack order remains bottom-up and continues to define local PR numbers and
@@ -91,6 +115,13 @@ pub struct FileConfig {
     /// - `rollback` (default): abort and clean up temp restack state
     /// - `halt`: stop and leave the temp worktree for manual resolution
     pub restack_conflict: Option<RestackConflictPolicy>,
+    /// Behavior when a branch-rewriting command sees local changes.
+    ///
+    /// Supported values:
+    /// - `discard`: preserve current behavior and continue the rewrite
+    /// - `stash`: stash tracked, staged, and untracked changes and reapply them
+    /// - `halt`: refuse to rewrite until the worktree is clean
+    pub dirty_worktree: Option<DirtyWorktreePolicy>,
     /// Block `spr update` from recreating a PR when the same branch name had a recently merged
     /// or closed PR within this many days.
     ///
@@ -111,6 +142,8 @@ pub struct Config {
     pub list_order: ListOrder,
     /// Behavior when `spr restack` encounters a cherry-pick conflict.
     pub restack_conflict: RestackConflictPolicy,
+    /// Behavior when a branch-rewriting command sees local changes.
+    pub dirty_worktree: DirtyWorktreePolicy,
     /// Threshold in days for blocking `spr update` from recreating a PR on a branch name that
     /// already had a recently merged or closed PR.
     ///
@@ -139,6 +172,7 @@ fn default_config() -> Config {
         pr_description_mode: PrDescriptionMode::Overwrite,
         list_order: ListOrder::RecentOnTop,
         restack_conflict: RestackConflictPolicy::Rollback,
+        dirty_worktree: DirtyWorktreePolicy::Halt,
         branch_reuse_guard_days: 180,
     }
 }
@@ -165,6 +199,9 @@ fn apply_overrides(config: &Config, overrides: FileConfig) -> Config {
     }
     if let Some(restack_conflict) = overrides.restack_conflict {
         merged.restack_conflict = restack_conflict;
+    }
+    if let Some(dirty_worktree) = overrides.dirty_worktree {
+        merged.dirty_worktree = dirty_worktree;
     }
     if let Some(branch_reuse_guard_days) = overrides.branch_reuse_guard_days {
         merged.branch_reuse_guard_days = branch_reuse_guard_days;
@@ -207,7 +244,10 @@ pub fn load_config() -> Result<Config> {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_overrides, default_config, read_config_file, FileConfig, PrDescriptionMode};
+    use super::{
+        apply_overrides, default_config, read_config_file, DirtyWorktreePolicy, FileConfig,
+        PrDescriptionMode,
+    };
     use std::fs;
     use tempfile::tempdir;
 
@@ -259,6 +299,32 @@ overwrite_pr_description: false
     }
 
     #[test]
+    fn read_config_file_parses_dirty_worktree_policy() {
+        let dir = tempdir().expect("tempdir");
+        let mut path = dir.path().to_path_buf();
+        path.push(".spr_multicommit_cfg.yml");
+        fs::write(
+            &path,
+            r#"
+dirty_worktree: stash
+"#,
+        )
+        .expect("write config");
+
+        let cfg = read_config_file(&path)
+            .expect("parse config")
+            .expect("config exists");
+        assert_eq!(cfg.dirty_worktree, Some(DirtyWorktreePolicy::Stash));
+    }
+
+    #[test]
+    fn default_config_uses_halt_for_dirty_worktree_policy() {
+        let cfg = default_config();
+
+        assert_eq!(cfg.dirty_worktree, DirtyWorktreePolicy::Halt);
+    }
+
+    #[test]
     // Verifies: YAML config parsing accepts an integer value for branch_reuse_guard_days.
     // Catches: regressions where the new config key is rejected or parsed with the wrong type.
     fn read_config_file_parses_branch_reuse_guard_days_integer() {
@@ -286,6 +352,7 @@ overwrite_pr_description: false
                 pr_description_mode: None,
                 list_order: None,
                 restack_conflict: None,
+                dirty_worktree: None,
                 branch_reuse_guard_days: Some(30),
             },
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod limit;
 mod parsing;
 mod pr_labels;
 mod selectors;
+#[cfg(test)]
+mod test_support;
 
 fn resolve_update_pr_limit(
     groups: &[crate::parsing::Group],
@@ -140,6 +142,7 @@ fn main() -> Result<()> {
         resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone())?;
     let pr_description_mode = cfg.pr_description_mode;
     let restack_conflict_policy = cfg.restack_conflict;
+    let dirty_worktree_policy = cfg.dirty_worktree;
     let list_order = cfg.list_order;
     let branch_reuse_guard_days = cfg.branch_reuse_guard_days;
     match cli.cmd {
@@ -206,6 +209,7 @@ fn main() -> Result<()> {
                 safe,
                 cli.dry_run,
                 restack_conflict_policy,
+                dirty_worktree_policy,
             )?;
         }
         crate::cli::Cmd::Absorb {
@@ -224,6 +228,7 @@ fn main() -> Result<()> {
                 &prefix,
                 &ignore_tag,
                 cli.dry_run,
+                dirty_worktree_policy,
                 options,
             )?;
         }
@@ -305,6 +310,7 @@ fn main() -> Result<()> {
                     false,
                     cli.dry_run,
                     restack_conflict_policy,
+                    dirty_worktree_policy,
                 )?;
             }
         }
@@ -318,7 +324,15 @@ fn main() -> Result<()> {
         }
         crate::cli::Cmd::FixPr { target, tail, safe } => {
             set_dry_run_env(cli.dry_run, false);
-            crate::commands::fix_pr_tail(&base, &ignore_tag, &target, tail, safe, cli.dry_run)?;
+            crate::commands::fix_pr_tail(
+                &base,
+                &ignore_tag,
+                &target,
+                tail,
+                safe,
+                cli.dry_run,
+                dirty_worktree_policy,
+            )?;
         }
         crate::cli::Cmd::Move { range, after, safe } => {
             set_dry_run_env(cli.dry_run, false);
@@ -328,8 +342,11 @@ fn main() -> Result<()> {
                 &ignore_tag,
                 &range,
                 &after,
-                safe,
-                cli.dry_run,
+                crate::commands::MoveExecutionOptions {
+                    safe,
+                    dry: cli.dry_run,
+                    dirty_worktree_policy,
+                },
             )?;
         }
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+static PROCESS_CWD_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn lock_cwd() -> MutexGuard<'static, ()> {
+    PROCESS_CWD_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+pub(crate) struct DirGuard {
+    original: PathBuf,
+}
+
+impl DirGuard {
+    pub(crate) fn change_to(path: &Path) -> Self {
+        let original = env::current_dir().expect("current dir available");
+        env::set_current_dir(path).expect("set current dir to temp repo");
+        Self { original }
+    }
+}
+
+impl Drop for DirGuard {
+    fn drop(&mut self) {
+        env::set_current_dir(&self.original).expect("restore original current dir");
+    }
+}


### PR DESCRIPTION
# Problem Solved

`spr fix-pr`, `spr move`, `spr restack`, and `spr absorb` all rebuild the checked-out branch and then move it to a rewritten tip. Before this change, those commands always behaved like `dirty_worktree=discard`: **tracked local edits in the current worktree could be overwritten without warning**. Users had no shared guardrail, no built-in stash-and-restore path, and no way to make the safer behavior the default.

# Mental model

This change adds one `dirty_worktree` policy that every branch-rewriting command uses before it touches history. `halt` is now the default and refuses to rewrite until the current worktree is clean. `stash` snapshots staged, unstaged, and untracked changes, runs the rewrite, then reapplies them with `git stash apply --index`, keeping the stash entry if restore fails. `discard` remains available for users who explicitly prefer the historical destructive behavior.

# Non-goals

- Do not change `spr update`, which does not rewrite the checked-out branch through the same temp-worktree reset path.
- Do not auto-resolve stash reapply conflicts after a rewrite; conflicting restores still require manual recovery.
- Do not remove the `discard` mode, because some current users may still prefer the pre-existing behavior.

# Tradeoffs

- Defaulting to `halt` is safer, but it is backward-incompatible: an unspecified `dirty_worktree` setting no longer behaves like the old discard-on-rewrite path.
- Supporting `stash` adds more git-state transitions and one more failure mode around `git stash apply --index`, but it gives users an opt-in recovery path that preserves local work.
- Keeping `discard` preserves compatibility for explicit opt-in users, even though it remains destructive.

# Architecture

- Add a typed `DirtyWorktreePolicy` enum to config parsing and defaults.
- Thread the resolved policy through `fix-pr`, `move`, `restack`, and `absorb`.
- Centralize dirty-worktree preflight, optional stash/restore handling, and post-rewrite error reporting in `src/commands/common.rs` so every branch rewrite shares the same contract.
- Document the new config key in the README and add shared test support for temp-repo tests that mutate process-wide CWD.

# Observability

- `dirty_worktree=halt` errors name the command and show the dirty entries that blocked the rewrite.
- `dirty_worktree=discard` logs that tracked changes are not preserved and untracked files remain in place.
- `dirty_worktree=stash` logs the stash/restore path and keeps the stash entry if restore fails after the rewrite.

# Tests

Test scope covers config parsing/defaults, the shared dirty-worktree guard, and end-to-end `fix-pr` rewrite behavior under all three policies. Coverage proves that `discard` keeps the historical tracked-reset behavior, `stash` restores tracked and untracked changes and drops the temporary stash on success, `halt` blocks the rewrite without moving `HEAD`, and the default config now resolves to `dirty_worktree = halt`.

<!-- spr-stack:start -->
**Stack**:
-   #120
-   #119
-   #118
-   #115
- ➡ #114

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->