### PR TITLE
cli: route commands through a global working-directory override

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,19 @@ Precedence for defaults:
 Global flags
 ------------
 
- - `--base, -b <BRANCH>`: root base branch (default from config)
+- `--cd <PATH>`: change to `PATH` before loading repo config or running git/gh commands
+- `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
 - `--dry-run` (alias: `--dr`): print state-changing commands instead of executing
 - `--until <N|0|label|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
 - `--exact <I|label|pr:<label>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
+
+Example:
+
+```bash
+spr --cd /path/to/repo status
+```
 
 Commands
 --------

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Extent {
@@ -178,6 +179,9 @@ pub struct Cli {
     /// Verbose output for underlying git/gh commands
     #[arg(long, global = true)]
     pub verbose: bool,
+    /// Change to PATH before loading repo config or running git/gh commands
+    #[arg(long, global = true, value_name = "PATH")]
+    pub cd: Option<PathBuf>,
     /// Global base branch (root of stack)
     #[arg(short = 'b', long, global = true)]
     pub base: Option<String>,
@@ -201,6 +205,7 @@ pub struct Cli {
 mod tests {
     use super::{Cli, Cmd};
     use clap::{CommandFactory, Parser};
+    use std::path::PathBuf;
 
     #[test]
     fn absorb_override_flag_parses() {
@@ -230,5 +235,21 @@ mod tests {
             "Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same."
         ));
         assert!(long_about.contains("skip (rewritten-equivalent prefix)"));
+    }
+
+    #[test]
+    fn global_cd_flag_parses_after_subcommand() {
+        let cli = Cli::try_parse_from(["spr", "status", "--cd", "/tmp/example"]).unwrap();
+
+        assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
+        assert!(matches!(cli.cmd, Cmd::Status {}));
+    }
+
+    #[test]
+    fn global_cd_flag_parses_before_subcommand() {
+        let cli = Cli::try_parse_from(["spr", "--cd", "/tmp/example", "status"]).unwrap();
+
+        assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
+        assert!(matches!(cli.cmd, Cmd::Status {}));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
+use std::path::Path;
 
 mod cli;
 mod commands;
@@ -83,6 +84,15 @@ fn set_dry_run_env(dry_run: bool, assume_existing_prs: bool) {
     }
 }
 
+/// Change to the requested working directory before config discovery or repo-scoped commands.
+fn apply_working_directory_override(path: Option<&Path>) -> Result<()> {
+    if let Some(path) = path {
+        std::env::set_current_dir(path)
+            .with_context(|| format!("failed to change directory to {}", path.display()))?;
+    }
+    Ok(())
+}
+
 /// Resolve the base branch, branch prefix, and ignore tag with explicit precedence.
 ///
 /// Base resolution follows: CLI `--base` → merged config `base` → discovery
@@ -117,6 +127,7 @@ fn resolve_base_prefix(
 
 fn main() -> Result<()> {
     let cli = crate::cli::Cli::parse();
+    apply_working_directory_override(cli.cd.as_deref())?;
     if cli.verbose {
         tracing_subscriber::fmt()
             .with_env_filter("info")
@@ -355,9 +366,32 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_requires_gh, resolve_update_pr_limit};
+    use super::{apply_working_directory_override, command_requires_gh, resolve_update_pr_limit};
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, StableHandle};
+    use crate::test_support::lock_cwd;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    struct CurrentDirGuard {
+        original: PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        fn capture() -> Self {
+            Self {
+                original: std::env::current_dir().unwrap(),
+            }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.original).unwrap();
+        }
+    }
 
     fn group(tag: &str) -> Group {
         Group {
@@ -424,5 +458,30 @@ mod tests {
     #[test]
     fn status_still_requires_github_cli() {
         assert!(command_requires_gh(&crate::cli::Cmd::Status {}));
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let status = Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(repo)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git init failed");
+        dir
+    }
+
+    #[test]
+    fn working_directory_override_changes_repo_context() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_repo();
+
+        apply_working_directory_override(Some(repo.path())).unwrap();
+        let expected_root = fs::canonicalize(repo.path()).unwrap();
+        let actual_root = PathBuf::from(crate::git::repo_root().unwrap().unwrap());
+
+        assert_eq!(fs::canonicalize(actual_root).unwrap(), expected_root);
     }
 }


### PR DESCRIPTION
# Problem Solved

Allow `spr` to target another repository from outside that repository's worktree.
The new global `--cd` flag is resolved before config discovery and before any
Git or GitHub subprocess runs, so every command sees one consistent repo root.

This simplifies usage of spr, e.g. for an agent started in a directory, which then creates a temporary worktree and works in it for a time.

# Mental model

`--cd` selects the repository once at process startup. After that point, config
loading, branch discovery, and child process execution all operate on the
chosen repo instead of the caller's shell cwd.

# Non-goals

This does not change how `spr` picks the active stack branch inside the target
repository, and it does not add per-command path overrides.

# Tradeoffs

The override now threads through early CLI startup instead of living on a
single command path. That adds a small amount of plumbing, but it prevents
split-brain behavior where config comes from one repo while Git commands run in
another.

# Architecture

Add a top-level `--cd` flag, resolve the target repo before loading config, and
use that resolved root for command setup plus Git and GitHub invocations.

# Observability

The global help and subcommand help surface the new flag, and command failures
now point at the targeted repository instead of the caller's current directory.

# Tests

Originally validated with `cargo clippy --tests`, `cargo fmt`, and `cargo test`.

<!-- spr-stack:start -->
**Stack**:
-   #120
-   #119
-   #118
- ➡ #115

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->