### PR TITLE
rewrite: make local stack rewrites suspend and resume cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ pr_description_mode: overwrite | stack_only
 # one of: "recent_on_bottom" (default) or "recent_on_top"
 list_order: recent_on_bottom
 
-# How `spr restack` behaves on cherry-pick conflicts: "rollback" (default) or "halt"
-restack_conflict: rollback
+# How `spr restack` behaves on cherry-pick conflicts
+# - `halt` (default): suspend, leave the temp worktree in place, and resume
+#   with `spr resume <path>`
+# - `rollback`: abort and clean up temp restack state
+restack_conflict: halt
 
 # How branch-rewriting commands handle local changes in the checked-out worktree
 # This applies to `spr restack`, `spr move`, `spr fix-pr`, and `spr absorb`.
@@ -121,7 +124,7 @@ Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > git discovery (`origin/HEAD`)
 - Base has no built-in fallback; if discovery fails, set `base` explicitly
-- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `restack_conflict = rollback`, `dirty_worktree = halt`
+- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `restack_conflict = halt`, `dirty_worktree = halt`
 
 Global flags
 ------------
@@ -199,9 +202,9 @@ Behavior:
 - With `--safe`, a backup tag named like `backup/restack/<current-branch>-<short-sha>` is created first
 - Conflict handling is controlled by `restack_conflict` in config.
 - Before rewriting the checked-out branch, `spr restack` follows the `dirty_worktree` config.
-- `rollback` (default) aborts the restack and attempts to clean up the temp restack worktree and branch (cleanup failures may require manual cleanup).
-- `halt` stops on conflict, leaves the temp restack worktree and branch in place, and prints manual rollback/continue instructions.
-- When using `halt`, resolve conflicts inside the printed temp worktree path; resolving in your original worktree will not advance the halted cherry-pick.
+- `halt` (default) suspends on conflict, leaves the temp restack worktree and branch in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`.
+- `rollback` preserves the historical cleanup-on-conflict behavior and attempts to remove the temp restack worktree and branch (cleanup failures may require manual cleanup).
+- When restack suspends, resolve conflicts inside the printed temp worktree path, stage the resolution, and run the printed `spr resume <path>` command. Resolving in your original worktree does not advance the suspended cherry-pick.
 
 ### spr absorb
 
@@ -220,6 +223,7 @@ Behavior:
 - Inserts absorbed commits after the group's real commits and before that group's trailing ignored block
 - Creates a local backup tag before rewriting the stack
 - Before rewriting the checked-out branch, `spr absorb` follows the `dirty_worktree` config.
+- On cherry-pick conflict, `spr absorb` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`
 - Does not update GitHub; inspect the rewritten stack first, then run `spr update`
 
 Typical workflow:
@@ -241,6 +245,97 @@ Override example for intentionally keeping both an earlier copied follow-up comm
 ```bash
 spr absorb --allow-replayed-duplicates
 ```
+
+### spr resume
+
+Resume a suspended local rewrite from the exact path printed by `spr restack`,
+`spr absorb`, `spr move`, or `spr fix-pr`.
+
+Behavior:
+
+- Accepts one explicit resume-file path under the repository common Git directory, usually `.git/spr/resume/`
+- Validates that the resume file belongs to the current repository and that the recorded temp worktree still exists
+- The suspend output prints the temp worktree path, temp branch, original branch, and resume-file path so the caller knows exactly which rewrite is paused
+- Supported workflow: resolve conflicts in the printed temp rewrite worktree, stage the resolution, then run the printed `spr resume <path>`
+- Tolerates one accidental manual `git cherry-pick --continue` for the paused step, then resumes the remaining replay under `spr`
+- Rejects broader manual replay edits, unknown resume-file schema versions, missing temp worktrees, or unresolved conflicts that are still staged as unmerged
+
+Machine-readable `--json` mode:
+
+- Supported on `spr restack`, `spr absorb`, `spr move`, `spr fix-pr`, `spr land`, and `spr resume`
+- In `--json` mode, stdout is exactly one JSON object and stderr is normally empty
+- Exit codes are:
+  - `0` for completed
+  - `1` for hard error, including CLI parse failures when `--json` was requested
+  - `2` for suspended rewrite awaiting conflict resolution
+- The suspended JSON payload includes the fields an agent needs to resolve and resume:
+  - `original_worktree_root`
+  - `original_branch`
+  - `temp_branch`
+  - `temp_worktree`
+  - `resume_file`
+  - `resume_argv`
+  - `paused_source_sha`
+  - `conflicted_paths`
+  - `post_success_hint`
+
+Example suspend payload:
+
+```json
+{
+  "schema_version": 1,
+  "result": "suspended",
+  "command": "restack",
+  "rewrite_command_kind": "restack",
+  "original_worktree_root": "/path/to/repo",
+  "original_branch": "stack",
+  "temp_branch": "spr/tmp-restack-717b9d8",
+  "temp_worktree": "/tmp/spr-restack-717b9d8",
+  "resume_file": "/path/to/repo/.git/spr/resume/restack-stack-717b9d8.json",
+  "resume_argv": [
+    "spr",
+    "--cd",
+    "/path/to/repo",
+    "resume",
+    "--json",
+    "/path/to/repo/.git/spr/resume/restack-stack-717b9d8.json"
+  ],
+  "paused_source_sha": "717b9d83bcdbea33286496800c76e65c62f795ed",
+  "conflicted_paths": [
+    "story.txt"
+  ],
+  "post_success_hint": null
+}
+```
+
+Mental model:
+
+- `spr` is not running `git rebase`; it is running a local rewrite engine that replays planned commits as individual cherry-picks in a temp worktree
+- The temp rewrite worktree is the execution sandbox
+- The resume file is a checkpoint for that paused rewrite
+- The original checked-out branch is not updated until the entire replay finishes successfully
+
+Suspend/resume flow:
+
+1. The original command (`spr restack`, `spr absorb`, `spr move`, or `spr fix-pr`) computes a replay plan for the rewritten stack.
+2. `spr` creates a temp branch and temp worktree at the right base commit.
+3. `spr` starts replaying the plan as individual cherry-picks in that temp worktree.
+4. If Git reports a cherry-pick conflict, `spr` records the paused rewrite state in the resume file, including the temp worktree path, the original branch identity, the paused temp-worktree `HEAD`, and the index of the failed replay step.
+5. `spr` prints the temp worktree path, temp branch, original branch, and `spr resume <path>`, then leaves the temp worktree in place. The original branch has still not moved.
+6. The user resolves only the current conflict in the printed temp worktree and stages the resolution with `git add`.
+7. The user runs `spr resume <path>` from any worktree in the same repository.
+8. `spr resume` reloads the checkpoint, validates that it still belongs to the current repository, validates that the temp worktree still exists, and then reconciles the paused step:
+   - If `CHERRY_PICK_HEAD` is still present, `spr` continues that paused cherry-pick itself.
+   - If `CHERRY_PICK_HEAD` is gone and the temp worktree advanced by exactly one commit, `spr` treats that as one accidental manual `git cherry-pick --continue` and resumes the remaining replay.
+9. `spr` then continues the remaining replay steps under `spr` control. If another conflict happens, it rewrites the same resume file with the new paused step and suspends again.
+10. Only after all replay steps succeed does `spr` reset the original branch to the rebuilt temp tip, remove the temp worktree and temp branch, and delete the resume file.
+
+Operator rules:
+
+- Resolve conflicts in the printed temp worktree, not in your original worktree.
+- Stage the resolution before running `spr resume <path>`.
+- Hand control back to `spr` after resolving the current conflict instead of manually replaying the rest of the rewrite.
+- One accidental manual `git cherry-pick --continue` is recoverable. Broader manual replay edits are intentionally rejected instead of being guessed through.
 
 ### spr list pr
 
@@ -299,6 +394,7 @@ Aliases:
 - `--safe`: create a local backup tag at current `HEAD` before rewriting
 - Ignore blocks (`pr:ignore`) stay attached to the preceding PR group and move with it
 - Before rewriting the checked-out branch, `spr move` follows the `dirty_worktree` config.
+- On cherry-pick conflict, `spr move` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`
 
 Prints an explicit plan, e.g.: `2..3→4: [1,2,3,4,5,6] → [1,4,2,3,5,6]`.
 
@@ -324,6 +420,7 @@ Mode selection:
 Default follow-up behavior:
 
 - After a successful land, `spr` will automatically run `spr restack --after N` using the resolved group count from `--until`, so `spr land --until pr:beta` still restacks the correct remaining groups after `beta` disappears from the outstanding stack. Pass `--no-restack` to skip this.
+- If that follow-on restack suspends, the GitHub land already succeeded. Resolve the local restack conflict and run the printed `spr resume <path>` command instead of rerunning `spr land`.
 
 #### Mode: flatten
 
@@ -381,6 +478,7 @@ Behavior:
 - `--safe`: create a local backup tag at current `HEAD` before executing
 - Ignore blocks (`pr:ignore`) are preserved and cannot be moved; the command aborts if the tail intersects an ignore block
 - Before rewriting the checked-out branch, `spr fix-pr` follows the `dirty_worktree` config.
+- On cherry-pick conflict, `spr fix-pr` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`
 
 ### spr cleanup
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,9 @@ pub enum Cmd {
     },
 
     /// Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base
+    #[command(
+        long_about = "Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base.\n\nWhen `restack_conflict` is `halt`, `spr restack` leaves the temp rewrite worktree in place on conflict, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and hand control back to `spr` with the printed resume command.\n\nWhen `restack_conflict` is `rollback`, `spr restack` preserves the historical cleanup-on-conflict behavior and removes the temp rewrite state instead."
+    )]
     Restack {
         /// Keep groups through this selector in place and rebuild only the groups above it
         #[arg(long, value_name = "N|0|bottom|top|last|all|label|pr:<label>")]
@@ -80,6 +83,10 @@ pub enum Cmd {
         /// Create a local backup tag at current HEAD before rebasing
         #[arg(long)]
         safe: bool,
+
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
     },
 
     /// Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch
@@ -90,11 +97,29 @@ pub enum Cmd {
         /// Allow replayed duplicates and keep both copies when the later replay is non-seed
         #[arg(long)]
         allow_replayed_duplicates: bool,
+
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
     },
 
     /// Prepare PRs for landing (e.g., squash)
     Prep {
         // selection is provided via global --until/--exact flags
+    },
+
+    /// Resume a suspended local rewrite from a resume-state file
+    #[command(
+        long_about = "Resume a suspended local rewrite from a resume-state file.\n\nRun `spr resume <path>` with the exact path printed by `spr restack`, `spr absorb`, `spr move`, or `spr fix-pr` after a cherry-pick conflict. The supported workflow is: resolve the conflict in the printed temp rewrite worktree, stage the resolution, and then run the printed `spr resume <path>` command from any worktree in the same repository.\n\nThe resume file lives under the repository common Git directory, usually `.git/spr/resume/`. `spr resume` tolerates one accidental manual `git cherry-pick --continue` for the paused step, but broader manual replay edits are rejected."
+    )]
+    Resume {
+        /// Explicit path to the suspended rewrite's resume-state JSON file
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
     },
 
     /// List entities
@@ -121,6 +146,9 @@ pub enum Cmd {
         /// Skip automatic restack after landing (default: restack remaining commits with `--after N`)
         #[arg(long = "no-restack")]
         no_restack: bool,
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
     },
 
     /// Relink PR stack to match local commit stack
@@ -145,6 +173,9 @@ pub enum Cmd {
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
     },
 
     /// Reorder local PR groups by moving one or a range to come after a target PR
@@ -158,7 +189,29 @@ pub enum Cmd {
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
     },
+}
+
+impl Cmd {
+    pub fn json_mode(&self) -> bool {
+        match self {
+            Self::Restack { json, .. }
+            | Self::Absorb { json, .. }
+            | Self::Resume { json, .. }
+            | Self::Land { json, .. }
+            | Self::FixPr { json, .. }
+            | Self::Move { json, .. } => *json,
+            Self::Update { .. }
+            | Self::Prep {}
+            | Self::List { .. }
+            | Self::Status {}
+            | Self::RelinkPrs {}
+            | Self::Cleanup {} => false,
+        }
+    }
 }
 
 #[derive(Subcommand, Debug, Clone, Copy)]
@@ -214,6 +267,7 @@ mod tests {
         match cli.cmd {
             Cmd::Absorb {
                 allow_replayed_duplicates,
+                json: _,
             } => assert!(allow_replayed_duplicates),
             other => panic!("unexpected command: {:?}", other),
         }
@@ -235,6 +289,50 @@ mod tests {
             "Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same."
         ));
         assert!(long_about.contains("skip (rewritten-equivalent prefix)"));
+        assert!(long_about.contains("spr resume <path>"));
+        assert!(long_about.contains("skip (rewritten-equivalent prefix)"));
+    }
+
+    #[test]
+    fn resume_command_parses_explicit_path() {
+        let cli = Cli::try_parse_from([
+            "spr",
+            "resume",
+            "--json",
+            ".git/spr/resume/restack-example.json",
+        ])
+        .unwrap();
+
+        match cli.cmd {
+            Cmd::Resume { path, json } => {
+                assert_eq!(path, PathBuf::from(".git/spr/resume/restack-example.json"));
+                assert!(json);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resume_help_text_mentions_supported_workflow() {
+        let mut cli = Cli::command();
+        let resume = cli.find_subcommand_mut("resume").unwrap();
+        let long_about = resume.get_long_about().unwrap().to_string();
+
+        assert!(long_about.contains("resolve the conflict"));
+        assert!(long_about.contains("spr resume <path>"));
+        assert!(long_about.contains("common Git directory"));
+    }
+
+    #[test]
+    fn rewrite_commands_report_json_mode() {
+        let restack = Cli::try_parse_from(["spr", "restack", "--after", "1", "--json"]).unwrap();
+        assert!(restack.cmd.json_mode());
+
+        let land = Cli::try_parse_from(["spr", "land", "--json"]).unwrap();
+        assert!(land.cmd.json_mode());
+
+        let list = Cli::try_parse_from(["spr", "list", "pr"]).unwrap();
+        assert!(!list.cmd.json_mode());
     }
 
     #[test]

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -10,11 +10,14 @@
 //! from the same stack merge-base and reach the same pre-tail tree as the
 //! canonical stack prefix.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use std::collections::{HashMap, HashSet};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::commands::common::{self, CherryPickEmptyPolicy, CherryPickOp};
+use crate::commands::rewrite_resume::{
+    self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
+};
 use crate::config::DirtyWorktreePolicy;
 use crate::git::{
     git_commit_message, git_commit_parent_count, git_commit_tree, git_is_ancestor,
@@ -45,7 +48,7 @@ pub fn absorb_branch_tails(
     dry: bool,
     dirty_worktree_policy: DirtyWorktreePolicy,
     options: AbsorbOptions,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     let (_stack_head, plan) = build_plan_for_current_stack(base, prefix, ignore_tag, options)?;
     let validation = validate_absorb_plan(&plan);
     if !matches!(validation, AbsorbPlanValidation::NoGroups) {
@@ -54,7 +57,7 @@ pub fn absorb_branch_tails(
     match validation {
         AbsorbPlanValidation::NoGroups => {
             info!("No local PR groups found; nothing to absorb.");
-            Ok(())
+            Ok(RewriteCommandOutcome::Completed)
         }
         AbsorbPlanValidation::Blocked { lines } => Err(anyhow!(
             "Refusing to absorb branch tails until blocking branches are fixed:\n{}",
@@ -62,7 +65,7 @@ pub fn absorb_branch_tails(
         )),
         AbsorbPlanValidation::NoAbsorbableGroups => {
             info!("No absorbable branch tails found; nothing to rewrite.");
-            Ok(())
+            Ok(RewriteCommandOutcome::Completed)
         }
         AbsorbPlanValidation::ReadyToRewrite => {
             execute_absorb_plan(&plan, dry, dirty_worktree_policy)
@@ -441,8 +444,7 @@ fn build_preliminary_group_rewrite_plan(
     stack_merge_base: &str,
     stack_head: &str,
 ) -> Result<PreliminaryGroupRewritePlan> {
-    let source =
-        classify_source_branch_preliminary(&group, prefix, stack_merge_base, stack_head)?;
+    let source = classify_source_branch_preliminary(&group, prefix, stack_merge_base, stack_head)?;
     Ok(PreliminaryGroupRewritePlan { group, source })
 }
 
@@ -930,57 +932,60 @@ fn build_replay_ops_for_commits(
     ops
 }
 
-fn cleanup_temp_worktree_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str) {
-    if let Err(err) = common::cleanup_temp_worktree(dry, tmp_path, tmp_branch) {
-        warn!(
-            "Failed to clean up temp absorb state ({} / {}): {}",
-            tmp_path, tmp_branch, err
-        );
-    }
-}
-
 /// Executes a validated absorb rewrite plan by rebuilding the current stack in
 /// a temporary worktree and resetting the checked-out branch to the new tip.
 fn execute_absorb_plan(
     plan: &RewritePlan,
     dry: bool,
     dirty_worktree_policy: DirtyWorktreePolicy,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     emit_rewrite_plan(plan);
-    common::with_dirty_worktree_policy(dry, "spr absorb", dirty_worktree_policy, || {
-        if dry {
-            info!("Dry run complete. No local git state or GitHub state was changed.");
-            info!("Run `spr absorb` without `--dry-run` to apply the rewrite.");
-            info!("After inspecting the rewritten stack, run `spr update`.");
-            Ok(())
-        } else {
-            let (cur_branch, short) = common::get_current_branch_and_short()?;
-            let _backup_tag = common::create_backup_tag(dry, "absorb", &cur_branch, &short)?;
-            let (tmp_path, tmp_branch) =
-                common::create_temp_worktree(dry, "absorb", &plan.merge_base, &short)?;
-            for op in &plan.operations {
-                if let Err(err) = op.run(dry, &tmp_path) {
-                    return Err(err).with_context(|| {
-                        format!(
-                            "absorb rewrite failed in temp worktree {} on branch {}",
-                            tmp_path, tmp_branch
-                        )
-                    });
-                }
+    common::with_dirty_worktree_policy(
+        dry,
+        "spr absorb",
+        dirty_worktree_policy,
+        |deferred_dirty_worktree_restore| {
+            if dry {
+                info!("Dry run complete. No local git state or GitHub state was changed.");
+                info!("Run `spr absorb` without `--dry-run` to apply the rewrite.");
+                info!("After inspecting the rewritten stack, run `spr update`.");
+                Ok(RewriteCommandOutcome::Completed)
+            } else {
+                let (cur_branch, short) = common::get_current_branch_and_short()?;
+                let original_head = git_rev_parse("HEAD")?;
+                let original_worktree_root = rewrite_resume::current_repo_root()?;
+                let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
+                    dry,
+                    RewriteCommandKind::Absorb,
+                    &cur_branch,
+                    &original_head,
+                )?;
+                let backup_tag = common::create_backup_tag(dry, "absorb", &cur_branch, &short)?;
+                let (tmp_path, tmp_branch) =
+                    common::create_temp_worktree(dry, "absorb", &plan.merge_base, &short)?;
+                rewrite_resume::run_rewrite_session(
+                dry,
+                RewriteSession {
+                    command_kind: RewriteCommandKind::Absorb,
+                    conflict_policy: RewriteConflictPolicy::Suspend,
+                    original_worktree_root,
+                    original_branch: cur_branch,
+                    original_head,
+                    resume_path,
+                    temp_branch: tmp_branch,
+                    temp_worktree_path: tmp_path,
+                    backup_tag: Some(backup_tag),
+                    operations: plan.operations.clone(),
+                    deferred_dirty_worktree_restore,
+                    post_success_hint: Some(
+                        "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+                            .to_string(),
+                    ),
+                },
+            )
             }
-            let new_tip = common::tip_of_tmp(&tmp_path)?;
-            info!(
-                "Updating current branch {} to new tip {} (absorbed branch tails)...",
-                cur_branch, new_tip
-            );
-            common::reset_current_branch_to(dry, &new_tip)?;
-            cleanup_temp_worktree_best_effort(dry, &tmp_path, &tmp_branch);
-            info!(
-                "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
-            );
-            Ok(())
-        }
-    })
+        },
+    )
 }
 
 fn emit_absorb_summary(plan: &RewritePlan) {
@@ -1059,6 +1064,9 @@ mod tests {
         SourceBranchRecord,
     };
     use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
+    use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
+    use crate::commands::RewriteCommandOutcome;
+    use crate::config::DirtyWorktreePolicy;
     use crate::parsing::{derive_local_groups_with_ignored, Group};
     use crate::test_support::{lock_cwd, DirGuard};
     use std::env;
@@ -1422,6 +1430,39 @@ mod tests {
             alpha_tip,
             beta_tip: Some(beta_tip),
             gamma_tip: Some(gamma_tip),
+        }
+    }
+
+    fn setup_absorb_conflict_stack() -> StackRepo {
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let base_branch = "main".to_string();
+        let stack_branch = "stack".to_string();
+        let prefix = "dank-spr/".to_string();
+        let ignore_tag = "ignore".to_string();
+
+        git(&repo, ["checkout", "-b", &stack_branch].as_slice());
+        let alpha_tip = commit_file(
+            &repo,
+            "story.txt",
+            "alpha-1\n",
+            "feat: alpha seed\n\npr:alpha",
+        );
+        let beta_tip = commit_file(&repo, "story.txt", "beta-1\n", "feat: beta seed\n\npr:beta");
+
+        git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        git(&repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
+
+        StackRepo {
+            dir,
+            repo,
+            stack_branch,
+            base_branch,
+            prefix,
+            ignore_tag,
+            alpha_tip,
+            beta_tip: Some(beta_tip),
+            gamma_tip: None,
         }
     }
 
@@ -2287,6 +2328,75 @@ mod tests {
             branches_with_pattern(&repo.repo, "spr/tmp-absorb-*").is_empty(),
             "dry-run absorb should not leave temp absorb branches behind"
         );
+    }
+
+    #[test]
+    fn absorb_suspends_and_resumes_conflict() {
+        let _lock = lock_cwd();
+        let repo = setup_absorb_conflict_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "story.txt",
+            "alpha-1\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let outcome = {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                false,
+                DirtyWorktreePolicy::Halt,
+                default_absorb_options(),
+            )
+            .expect("absorb should suspend")
+        };
+        let resume_path = match outcome {
+            RewriteCommandOutcome::Completed => panic!("expected suspended absorb"),
+            RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
+        };
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        fs::write(
+            Path::new(&resume_state.temp_worktree_path).join("story.txt"),
+            "alpha-1\nalpha-branch\nbeta-1\n",
+        )
+        .expect("resolve absorb conflict");
+        git(
+            Path::new(&resume_state.temp_worktree_path),
+            ["add", "story.txt"].as_slice(),
+        );
+
+        {
+            let _guard = DirGuard::change_to(&repo.repo);
+            let resumed = resume_rewrite(false, &resume_path).expect("resume absorb");
+            assert_eq!(resumed, RewriteCommandOutcome::Completed);
+        }
+
+        assert!(
+            !resume_path.exists(),
+            "successful absorb resume should delete the resume file"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.repo.join("story.txt")).expect("read final file"),
+            "alpha-1\nalpha-branch\nbeta-1\n"
+        );
+        let _guard = DirGuard::change_to(&repo.repo);
+        let (_merge_base, _leading_ignored, groups) =
+            derive_local_groups_with_ignored(&repo.base_branch, &repo.ignore_tag).unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(
+            groups[0].commits.len(),
+            2,
+            "alpha should absorb its branch tail"
+        );
+        assert_eq!(groups[1].commits.len(), 1, "beta should remain one group");
     }
 
     #[test]

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -26,6 +26,7 @@
 //! user; callers should not rely on them being immutable.
 
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -249,7 +250,7 @@ pub fn cherry_pick_range(
     last: &str,
     empty_policy: CherryPickEmptyPolicy,
 ) -> Result<()> {
-    let range = format!("{}^..{}", first, last);
+    let range = format!("{first}^..{last}");
     let args = cherry_pick_args(tmp_path, empty_policy, &[range.as_str()]);
     let _ = git_rw(dry, args.as_slice())?;
     Ok(())
@@ -272,11 +273,61 @@ pub fn cleanup_temp_worktree(dry: bool, tmp_path: &str, tmp_branch: &str) -> Res
     Ok(())
 }
 
+/// Deferred dirty-worktree restoration that can survive a suspended rewrite.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum DeferredDirtyWorktreeRestore {
+    #[default]
+    Noop,
+    Stash {
+        stash_commit: String,
+    },
+}
+
+impl DeferredDirtyWorktreeRestore {
+    pub fn restore_after_success(
+        self,
+        dry: bool,
+        command_name: &str,
+        worktree_root: &str,
+    ) -> Result<()> {
+        match self {
+            Self::Noop => Ok(()),
+            Self::Stash { stash_commit } => restore_stash_in_worktree(
+                dry,
+                command_name,
+                worktree_root,
+                &stash_commit,
+                RewriteOutcome::Succeeded,
+            ),
+        }
+    }
+
+    pub fn discard_instruction_lines(&self, worktree_root: &str) -> Vec<String> {
+        match self {
+            Self::Noop => Vec::new(),
+            Self::Stash { stash_commit } => vec![
+                "  # optional: restore the deferred auto-stash before deleting the resume file"
+                    .to_string(),
+                format!(
+                    "  git -C {} stash apply --index {}",
+                    worktree_root, stash_commit
+                ),
+                "  # optional: drop the matching stash entry from `git stash list` after recovery"
+                    .to_string(),
+            ],
+        }
+    }
+}
+
+pub trait DirtyWorktreeOutcome {
+    fn keeps_dirty_worktree_restore_deferred(&self) -> bool;
+}
+
 #[derive(Debug)]
 enum DirtyWorktreeRestore {
     Noop,
     PlannedStash,
-    Stashed { stash_ref: String },
+    Stashed { stash_commit: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -348,7 +399,6 @@ fn prepare_dirty_worktree(
         Ok(DirtyWorktreeRestore::PlannedStash)
     } else {
         let message = format!("spr auto-stash before {}", command_name);
-        let stash_ref = "stash@{0}".to_string();
         let _ = git_rw(
             false,
             [
@@ -360,13 +410,16 @@ fn prepare_dirty_worktree(
             ]
             .as_slice(),
         )?;
+        let stash_commit = git_ro(["rev-parse", "stash@{0}"].as_slice())?
+            .trim()
+            .to_string();
         let remaining = worktree_status_lines()?;
         if remaining.is_empty() {
             info!(
                 "Stashed local changes before {} because dirty_worktree=stash",
                 command_name
             );
-            Ok(DirtyWorktreeRestore::Stashed { stash_ref })
+            Ok(DirtyWorktreeRestore::Stashed { stash_commit })
         } else {
             bail!(
                 "{} stashed local changes but the worktree is still dirty:\n{}",
@@ -378,6 +431,15 @@ fn prepare_dirty_worktree(
 }
 
 impl DirtyWorktreeRestore {
+    fn deferred_restore(&self) -> DeferredDirtyWorktreeRestore {
+        match self {
+            Self::Noop | Self::PlannedStash => DeferredDirtyWorktreeRestore::Noop,
+            Self::Stashed { stash_commit } => DeferredDirtyWorktreeRestore::Stash {
+                stash_commit: stash_commit.clone(),
+            },
+        }
+    }
+
     fn restore(self, dry: bool, command_name: &str, outcome: RewriteOutcome) -> Result<()> {
         match self {
             Self::Noop => Ok(()),
@@ -390,34 +452,83 @@ impl DirtyWorktreeRestore {
                 }
                 Ok(())
             }
-            Self::Stashed { stash_ref } => {
-                let _ = git_rw(false, ["stash", "apply", "--index", &stash_ref].as_slice())
-                    .with_context(|| {
-                        format!(
-                            "{} {} but failed to restore stashed changes from {}; the stash entry was kept for manual recovery",
-                            command_name,
-                            outcome.verb(),
-                            stash_ref
-                        )
-                    })?;
-                if let Err(err) = git_rw(false, ["stash", "drop", &stash_ref].as_slice()) {
-                    warn!(
-                        "Restored stashed local changes after {}, but failed to drop {}: {}",
-                        command_name, stash_ref, err
-                    );
-                }
-                if dry {
-                    info!(
-                        "DRY-RUN: restored stashed local changes after {}",
-                        command_name
-                    );
-                } else {
-                    info!("Restored stashed local changes after {}", command_name);
-                }
-                Ok(())
+            Self::Stashed { stash_commit } => {
+                restore_stash_in_worktree(dry, command_name, ".", &stash_commit, outcome)
             }
         }
     }
+}
+
+fn restore_stash_in_worktree(
+    dry: bool,
+    command_name: &str,
+    worktree_root: &str,
+    stash_commit: &str,
+    outcome: RewriteOutcome,
+) -> Result<()> {
+    let _ = git_rw(
+        false,
+        [
+            "-C",
+            worktree_root,
+            "stash",
+            "apply",
+            "--index",
+            stash_commit,
+        ]
+        .as_slice(),
+    )
+    .with_context(|| {
+        format!(
+            "{} {} but failed to restore stashed changes from {}; the stash entry was kept for manual recovery",
+            command_name,
+            outcome.verb(),
+            stash_commit
+        )
+    })?;
+    match stash_ref_for_commit_in_worktree(worktree_root, stash_commit)? {
+        Some(stash_ref) => {
+            if let Err(err) = git_rw(
+                false,
+                ["-C", worktree_root, "stash", "drop", &stash_ref].as_slice(),
+            ) {
+                warn!(
+                    "Restored stashed local changes after {}, but failed to drop {}: {}",
+                    command_name, stash_ref, err
+                );
+            }
+        }
+        None => {
+            warn!(
+                "Restored stashed local changes after {}, but could not find a live stash ref for {}; leaving any matching stash entry in place",
+                command_name, stash_commit
+            );
+        }
+    }
+    if dry {
+        info!(
+            "DRY-RUN: restored stashed local changes after {}",
+            command_name
+        );
+    } else {
+        info!("Restored stashed local changes after {}", command_name);
+    }
+    Ok(())
+}
+
+fn stash_ref_for_commit_in_worktree(
+    worktree_root: &str,
+    stash_commit: &str,
+) -> Result<Option<String>> {
+    let out = git_ro(["-C", worktree_root, "stash", "list", "--format=%H%x00%gd"].as_slice())?;
+    Ok(out.lines().find_map(|line| {
+        let (sha, stash_ref) = line.split_once('\0')?;
+        if sha.trim() == stash_commit {
+            Some(stash_ref.trim().to_string())
+        } else {
+            None
+        }
+    }))
 }
 
 /// Run a branch rewrite under the configured dirty-worktree policy.
@@ -431,16 +542,25 @@ pub fn with_dirty_worktree_policy<T, F>(
     rewrite: F,
 ) -> Result<T>
 where
-    F: FnOnce() -> Result<T>,
+    T: DirtyWorktreeOutcome,
+    F: FnOnce(DeferredDirtyWorktreeRestore) -> Result<T>,
 {
     let restore = prepare_dirty_worktree(dry, command_name, policy)?;
-    let rewrite_result = rewrite();
-    let outcome = if rewrite_result.is_ok() {
-        RewriteOutcome::Succeeded
+    let deferred_restore = restore.deferred_restore();
+    let rewrite_result = rewrite(deferred_restore);
+    let restore_result = if rewrite_result
+        .as_ref()
+        .is_ok_and(DirtyWorktreeOutcome::keeps_dirty_worktree_restore_deferred)
+    {
+        Ok(())
     } else {
-        RewriteOutcome::Failed
+        let outcome = if rewrite_result.is_ok() {
+            RewriteOutcome::Succeeded
+        } else {
+            RewriteOutcome::Failed
+        };
+        restore.restore(dry, command_name, outcome)
     };
-    let restore_result = restore.restore(dry, command_name, outcome);
 
     match (rewrite_result, restore_result) {
         (Ok(value), Ok(())) => Ok(value),
@@ -460,7 +580,7 @@ where
 /// `Range` represents an inclusive `first^..last` cherry-pick over a contiguous
 /// commit interval. Callers must supply commits that already reflect the
 /// intended replay order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CherryPickEmptyPolicy {
     /// Stop when a replay becomes empty because earlier history already applied it.
     StopOnEmpty,
@@ -512,47 +632,6 @@ impl CherryPickOp {
             }
         } else {
             None
-        }
-    }
-
-    /// Executes the operation in the temp worktree at `tmp_path`.
-    pub fn run(&self, dry: bool, tmp_path: &str) -> Result<()> {
-        match self {
-            Self::Commit { sha, empty_policy } => {
-                cherry_pick_commit(dry, tmp_path, sha, *empty_policy)
-            }
-            Self::Range {
-                first,
-                last,
-                empty_policy,
-            } => cherry_pick_range(dry, tmp_path, first, last, *empty_policy),
-        }
-    }
-
-    /// Renders the matching `git cherry-pick` command for human continuation.
-    pub fn command_for_user(&self, tmp_path: &str) -> String {
-        match self {
-            Self::Commit { sha, empty_policy } => {
-                if *empty_policy == CherryPickEmptyPolicy::KeepRedundantCommits {
-                    format!("git -C {} cherry-pick --empty=keep {}", tmp_path, sha)
-                } else {
-                    format!("git -C {} cherry-pick {}", tmp_path, sha)
-                }
-            }
-            Self::Range {
-                first,
-                last,
-                empty_policy,
-            } => {
-                if *empty_policy == CherryPickEmptyPolicy::KeepRedundantCommits {
-                    format!(
-                        "git -C {} cherry-pick --empty=keep {}^..{}",
-                        tmp_path, first, last
-                    )
-                } else {
-                    format!("git -C {} cherry-pick {}^..{}", tmp_path, first, last)
-                }
-            }
         }
     }
 }

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -5,7 +5,12 @@ use std::collections::HashSet;
 use tracing::info;
 
 use crate::commands::common;
+use crate::commands::common::CherryPickOp;
+use crate::commands::rewrite_resume::{
+    self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
+};
 use crate::config::DirtyWorktreePolicy;
+use crate::git::git_rev_parse;
 use crate::git::git_ro;
 use crate::parsing::derive_local_groups_with_ignored;
 use crate::selectors::{resolve_group_ordinal, GroupSelector};
@@ -17,7 +22,21 @@ fn resolve_fix_pr_target(
     resolve_group_ordinal(groups, target)
 }
 
-/// Move the last `tail_count` commits (top-of-stack) to the tail of a selected PR group.
+fn build_fix_pr_operations(
+    all_commits: &[String],
+    top_commits: &[String],
+    insert_pos: usize,
+) -> Vec<CherryPickOp> {
+    let mut operations = Vec::new();
+    operations.extend(CherryPickOp::from_commits(&all_commits[..=insert_pos]));
+    operations.extend(CherryPickOp::from_commits(top_commits));
+    if insert_pos + 1 < all_commits.len() {
+        operations.extend(CherryPickOp::from_commits(&all_commits[insert_pos + 1..]));
+    }
+    operations
+}
+
+/// Move the last `tail_count` commits (top-of-stack) to become the tail of PR `n` (1-based, bottom→top).
 ///
 /// Ignore blocks are treated as part of the preceding group and are never moved.
 /// If the selected tail commits intersect an ignore block, the operation aborts.
@@ -35,16 +54,16 @@ pub fn fix_pr_tail(
     safe: bool,
     dry: bool,
     dirty_worktree_policy: DirtyWorktreePolicy,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     if tail_count == 0 {
-        return Ok(());
+        return Ok(RewriteCommandOutcome::Completed);
     }
 
     let (merge_base, leading_ignored, groups) = derive_local_groups_with_ignored(base, ignore_tag)?;
     let total_groups = groups.len();
     if total_groups == 0 {
         info!("No local PR groups found; nothing to fix.");
-        return Ok(());
+        return Ok(RewriteCommandOutcome::Completed);
     }
 
     let target_n = resolve_fix_pr_target(&groups, target)?;
@@ -58,7 +77,7 @@ pub fn fix_pr_tail(
     }
     if all_commits.is_empty() {
         info!("No commits found; nothing to fix.");
-        return Ok(());
+        return Ok(RewriteCommandOutcome::Completed);
     }
 
     // Determine top M commits (trim if M > total)
@@ -126,46 +145,63 @@ pub fn fix_pr_tail(
         .position(|sha| sha == &last_of_n)
         .ok_or_else(|| anyhow!("Could not locate last commit of PR {} in stream", target_n))?;
 
-    // Build new order: remainder with top commits inserted after PR N's tail
-    let mut new_order: Vec<String> = Vec::with_capacity(all_commits.len() + top_commits.len());
-    new_order.extend(all_commits[..=insert_pos].iter().cloned());
-    new_order.extend(top_commits.iter().cloned());
-    if insert_pos + 1 < all_commits.len() {
-        new_order.extend(all_commits[insert_pos + 1..].iter().cloned());
-    }
-
-    common::with_dirty_worktree_policy(dry, "spr fix-pr", dirty_worktree_policy, || {
-        let (cur_branch, short) = common::get_current_branch_and_short()?;
-        if safe {
-            let _ = common::create_backup_tag(dry, "fix-pr", &cur_branch, &short)?;
-        }
-
-        let (tmp_path, tmp_branch) = common::create_temp_worktree(dry, "fix", &merge_base, &short)?;
-
-        for sha in &new_order {
-            common::cherry_pick_commit(
+    common::with_dirty_worktree_policy(
+        dry,
+        "spr fix-pr",
+        dirty_worktree_policy,
+        |deferred_dirty_worktree_restore| {
+            let (cur_branch, short) = common::get_current_branch_and_short()?;
+            let original_head = git_rev_parse("HEAD")?;
+            let original_worktree_root = rewrite_resume::current_repo_root()?;
+            let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
                 dry,
-                &tmp_path,
-                sha,
-                common::CherryPickEmptyPolicy::StopOnEmpty,
+                RewriteCommandKind::FixPr,
+                &cur_branch,
+                &original_head,
             )?;
-        }
+            let backup_tag = if safe {
+                Some(common::create_backup_tag(
+                    dry,
+                    "fix-pr",
+                    &cur_branch,
+                    &short,
+                )?)
+            } else {
+                None
+            };
 
-        let new_tip = common::tip_of_tmp(&tmp_path)?;
-        info!(
-            "Updating current branch {} to new tip {} (fix-pr applied)…",
-            cur_branch, new_tip
-        );
-        common::reset_current_branch_to(dry, &new_tip)?;
-        common::cleanup_temp_worktree(dry, &tmp_path, &tmp_branch)?;
-
-        Ok(())
-    })
+            let (tmp_path, tmp_branch) =
+                common::create_temp_worktree(dry, "fix", &merge_base, &short)?;
+            let operations = build_fix_pr_operations(&all_commits, &top_commits, insert_pos);
+            rewrite_resume::run_rewrite_session(
+            dry,
+            RewriteSession {
+                command_kind: RewriteCommandKind::FixPr,
+                conflict_policy: RewriteConflictPolicy::Suspend,
+                original_worktree_root,
+                original_branch: cur_branch,
+                original_head,
+                resume_path,
+                temp_branch: tmp_branch,
+                temp_worktree_path: tmp_path,
+                backup_tag,
+                operations,
+                deferred_dirty_worktree_restore,
+                post_success_hint: Some(
+                    "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+                        .to_string(),
+                ),
+            },
+        )
+        },
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::{fix_pr_tail, resolve_fix_pr_target};
+    use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
+    use crate::commands::RewriteCommandOutcome;
     use crate::config::DirtyWorktreePolicy;
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, StableHandle};
@@ -244,6 +280,29 @@ mod tests {
         git(repo, ["add", "review.txt"].as_slice());
         git(repo, ["commit", "-m", "fix review comment"].as_slice());
 
+        dir
+    }
+
+    fn init_fix_pr_conflict_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path();
+        git(repo, ["init", "-b", "main"].as_slice());
+        git(repo, ["config", "user.email", "spr@example.com"].as_slice());
+        git(repo, ["config", "user.name", "SPR Tests"].as_slice());
+        fs::write(repo.join("story.txt"), "base\n").expect("write base");
+        fs::write(repo.join("consumer.txt"), "consumer base\n").expect("write consumer");
+        git(repo, ["add", "."].as_slice());
+        git(repo, ["commit", "-m", "init"].as_slice());
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        fs::write(repo.join("story.txt"), "alpha-1\n").expect("write alpha");
+        git(repo, ["add", "story.txt"].as_slice());
+        git(repo, ["commit", "-m", "feat: alpha pr:alpha"].as_slice());
+        fs::write(repo.join("story.txt"), "beta-1\n").expect("write beta");
+        git(repo, ["add", "story.txt"].as_slice());
+        git(repo, ["commit", "-m", "feat: beta pr:beta"].as_slice());
+        fs::write(repo.join("story.txt"), "review-fix\n").expect("write review");
+        git(repo, ["add", "story.txt"].as_slice());
+        git(repo, ["commit", "-m", "fix review comment"].as_slice());
         dir
     }
 
@@ -354,6 +413,84 @@ mod tests {
     }
 
     #[test]
+    fn fix_pr_stash_policy_defers_restore_until_resumed_rewrite_completes() {
+        let _lock = lock_cwd();
+        let dir = init_fix_pr_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        dirty_worktree(&repo);
+
+        let mut current = fix_pr_tail(
+            "main",
+            "ignore",
+            &GroupSelector::LocalPr(1),
+            1,
+            false,
+            false,
+            DirtyWorktreePolicy::Stash,
+        )
+        .expect("fix-pr should suspend under stash policy");
+
+        assert_eq!(
+            fs::read_to_string(repo.join("consumer.txt")).expect("read tracked file"),
+            "consumer base\n",
+            "tracked changes should remain stashed while the rewrite is suspended"
+        );
+        assert!(
+            !repo.join("scratch.txt").exists(),
+            "untracked changes should remain stashed while the rewrite is suspended"
+        );
+        assert!(
+            !git(&repo, ["stash", "list"].as_slice()).trim().is_empty(),
+            "the auto-stash should remain live until the resumed rewrite finishes"
+        );
+
+        while let RewriteCommandOutcome::Suspended(state) = current {
+            let resume_path = state.resume_path.clone();
+            let resume_state: RewriteResumeState =
+                serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                    .expect("parse resume state");
+            let paused_step = &resume_state.steps[resume_state.suspended_step_index];
+            let paused_subject = git(
+                &repo,
+                ["log", "-n", "1", "--format=%s", &paused_step.source_sha].as_slice(),
+            );
+            let resolved_contents = if paused_subject.trim() == "fix review comment" {
+                "review-fix\n"
+            } else {
+                "review-fix\nbeta-1\n"
+            };
+            fs::write(
+                Path::new(&resume_state.temp_worktree_path).join("story.txt"),
+                resolved_contents,
+            )
+            .expect("resolve fix-pr conflict");
+            git(
+                Path::new(&resume_state.temp_worktree_path),
+                ["add", "story.txt"].as_slice(),
+            );
+            current = resume_rewrite(false, &resume_path).expect("resume fix-pr");
+        }
+
+        assert_eq!(current, RewriteCommandOutcome::Completed);
+        assert_eq!(
+            fs::read_to_string(repo.join("consumer.txt")).expect("read restored tracked file"),
+            "consumer dirty\n",
+            "tracked changes should be restored only after the resumed rewrite completes"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("scratch.txt")).expect("read restored untracked file"),
+            "scratch local\n",
+            "untracked changes should be restored only after the resumed rewrite completes"
+        );
+        assert!(
+            git(&repo, ["stash", "list"].as_slice()).trim().is_empty(),
+            "the deferred stash should be dropped after the final restore"
+        );
+    }
+
+    #[test]
     fn fix_pr_halt_policy_refuses_to_rewrite_dirty_worktree() {
         let _lock = lock_cwd();
         let dir = init_fix_pr_repo();
@@ -394,6 +531,75 @@ mod tests {
             fs::read_to_string(repo.join("scratch.txt")).expect("read scratch"),
             "scratch local\n",
             "halt policy should leave untracked files untouched"
+        );
+    }
+
+    #[test]
+    fn fix_pr_suspends_and_resumes_conflict() {
+        let _lock = lock_cwd();
+        let dir = init_fix_pr_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        let outcome = fix_pr_tail(
+            "main",
+            "ignore",
+            &GroupSelector::LocalPr(1),
+            1,
+            false,
+            false,
+            DirtyWorktreePolicy::Halt,
+        )
+        .expect("fix-pr should suspend");
+        let mut current = outcome;
+        let mut last_resume_path = None;
+        while let RewriteCommandOutcome::Suspended(state) = current {
+            let resume_path = state.resume_path.clone();
+            let resume_state: RewriteResumeState =
+                serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                    .expect("parse resume state");
+            let paused_step = &resume_state.steps[resume_state.suspended_step_index];
+            let paused_subject = git(
+                &repo,
+                ["log", "-n", "1", "--format=%s", &paused_step.source_sha].as_slice(),
+            );
+            let resolved_contents = if paused_subject.trim() == "fix review comment" {
+                "review-fix\n"
+            } else {
+                "review-fix\nbeta-1\n"
+            };
+            fs::write(
+                Path::new(&resume_state.temp_worktree_path).join("story.txt"),
+                resolved_contents,
+            )
+            .expect("resolve fix-pr conflict");
+            git(
+                Path::new(&resume_state.temp_worktree_path),
+                ["add", "story.txt"].as_slice(),
+            );
+            last_resume_path = Some(resume_path.clone());
+            current = resume_rewrite(false, &resume_path).expect("resume fix-pr");
+        }
+
+        assert_eq!(current, RewriteCommandOutcome::Completed);
+        if let Some(resume_path) = last_resume_path {
+            assert!(
+                !resume_path.exists(),
+                "successful fix-pr resume should delete the resume file"
+            );
+        }
+        assert_eq!(
+            fs::read_to_string(repo.join("story.txt")).expect("read final file"),
+            "review-fix\nbeta-1\n"
+        );
+        assert_eq!(
+            log_subjects(&repo),
+            vec![
+                "feat: beta pr:beta".to_string(),
+                "fix review comment".to_string(),
+                "feat: alpha pr:alpha".to_string(),
+                "init".to_string(),
+            ]
         );
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod r#move;
 pub mod prep;
 pub mod relink_prs;
 pub mod restack;
+pub mod rewrite_resume;
 pub mod update;
 
 pub use absorb::{absorb_branch_tails, AbsorbOptions, CopiedLaterStackCommitPolicy};
@@ -20,4 +21,7 @@ pub use prep::prep_squash;
 pub use r#move::{move_groups_after, MoveExecutionOptions};
 pub use relink_prs::relink_prs;
 pub use restack::{restack_after, restack_after_count};
+pub use rewrite_resume::{
+    resume_rewrite, RewriteCommandKind, RewriteCommandOutcome, RewriteSuspendedState,
+};
 pub use update::{build_from_groups, build_from_tags};

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -4,7 +4,12 @@ use anyhow::{anyhow, Result};
 use tracing::info;
 
 use crate::commands::common;
+use crate::commands::common::CherryPickOp;
+use crate::commands::rewrite_resume::{
+    self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
+};
 use crate::config::DirtyWorktreePolicy;
+use crate::git::git_rev_parse;
 use crate::github::get_open_pr_automerge_for_head;
 use crate::parsing::derive_local_groups_with_ignored;
 use crate::selectors::{
@@ -40,29 +45,19 @@ fn format_simple_plan(old: &[usize], new: &[usize], a: usize, b: usize, c: usize
     )
 }
 
-/// Cherry-pick a contiguous block of commits, preserving local-only history.
-fn cherry_pick_block(dry: bool, tmp_path: &str, commits: &[String]) -> Result<()> {
-    if commits.is_empty() {
-        return Ok(());
+fn build_move_operations(
+    leading_ignored: &[String],
+    groups: &[crate::parsing::Group],
+    new_order: &[usize],
+) -> Vec<CherryPickOp> {
+    let mut operations = Vec::new();
+    operations.extend(CherryPickOp::from_commits(leading_ignored));
+    for idx in new_order {
+        let group = &groups[*idx - 1];
+        operations.extend(CherryPickOp::from_commits(&group.commits));
+        operations.extend(CherryPickOp::from_commits(&group.ignored_after));
     }
-    let first = commits.first().expect("commits not empty");
-    let last = commits.last().expect("commits not empty");
-    if commits.len() == 1 {
-        common::cherry_pick_commit(
-            dry,
-            tmp_path,
-            first,
-            common::CherryPickEmptyPolicy::StopOnEmpty,
-        )
-    } else {
-        common::cherry_pick_range(
-            dry,
-            tmp_path,
-            first,
-            last,
-            common::CherryPickEmptyPolicy::StopOnEmpty,
-        )
-    }
+    operations
 }
 
 fn resolve_move_targets(
@@ -138,13 +133,13 @@ pub fn move_groups_after(
     range: &GroupRangeSelector,
     after: &AfterSelector,
     options: MoveExecutionOptions,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     // Discover groups from local commits bottom→top
     let (merge_base, leading_ignored, groups) = derive_local_groups_with_ignored(base, ignore_tag)?;
     let n = groups.len();
     if n == 0 {
         info!("No local PR groups found; nothing to move.");
-        return Ok(());
+        return Ok(RewriteCommandOutcome::Completed);
     }
 
     let (a, b, c) = resolve_move_targets(&groups, range, after)?;
@@ -163,7 +158,7 @@ pub fn move_groups_after(
     if a == b {
         if a == c {
             info!("Already in desired position: {}", a);
-            return Ok(());
+            return Ok(RewriteCommandOutcome::Completed);
         }
     } else if a >= b {
         return Err(anyhow!("Invalid range: require A<B (got {}..{})", a, b));
@@ -209,47 +204,57 @@ pub fn move_groups_after(
 
     if new_order == (1..=n).collect::<Vec<_>>() {
         info!("Order unchanged; nothing to do.");
-        return Ok(());
+        return Ok(RewriteCommandOutcome::Completed);
     }
 
     common::with_dirty_worktree_policy(
         options.dry,
         "spr move",
         options.dirty_worktree_policy,
-        || {
+        |deferred_dirty_worktree_restore| {
             let (cur_branch, short) = common::get_current_branch_and_short()?;
-            if options.safe {
-                let _ = common::create_backup_tag(options.dry, "move", &cur_branch, &short)?;
-            }
+            let original_head = git_rev_parse("HEAD")?;
+            let original_worktree_root = rewrite_resume::current_repo_root()?;
+            let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
+                options.dry,
+                RewriteCommandKind::Move,
+                &cur_branch,
+                &original_head,
+            )?;
+            let backup_tag = if options.safe {
+                Some(common::create_backup_tag(
+                    options.dry,
+                    "move",
+                    &cur_branch,
+                    &short,
+                )?)
+            } else {
+                None
+            };
 
             let (tmp_path, tmp_branch) =
                 common::create_temp_worktree(options.dry, "move", &merge_base, &short)?;
-
-            cherry_pick_block(options.dry, &tmp_path, &leading_ignored)?;
-
-            for idx in &new_order {
-                let g = &groups[*idx - 1];
-                if let (Some(first), Some(last)) = (g.commits.first(), g.commits.last()) {
-                    common::cherry_pick_range(
-                        options.dry,
-                        &tmp_path,
-                        first,
-                        last,
-                        common::CherryPickEmptyPolicy::StopOnEmpty,
-                    )?;
-                }
-                cherry_pick_block(options.dry, &tmp_path, &g.ignored_after)?;
-            }
-
-            let new_tip = common::tip_of_tmp(&tmp_path)?;
-            info!(
-                "Updating current branch {} to new tip {} (stack reordered)…",
-                cur_branch, new_tip
-            );
-            common::reset_current_branch_to(options.dry, &new_tip)?;
-            common::cleanup_temp_worktree(options.dry, &tmp_path, &tmp_branch)?;
-
-            Ok(())
+            let operations = build_move_operations(&leading_ignored, &groups, &new_order);
+            rewrite_resume::run_rewrite_session(
+                options.dry,
+                RewriteSession {
+                    command_kind: RewriteCommandKind::Move,
+                    conflict_policy: RewriteConflictPolicy::Suspend,
+                    original_worktree_root,
+                    original_branch: cur_branch,
+                    original_head,
+                    resume_path,
+                    temp_branch: tmp_branch,
+                    temp_worktree_path: tmp_path,
+                    backup_tag,
+                    operations,
+                    deferred_dirty_worktree_restore,
+                    post_success_hint: Some(
+                        "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+                            .to_string(),
+                    ),
+                },
+            )
         },
     )
 }
@@ -257,8 +262,15 @@ pub fn move_groups_after(
 #[cfg(test)]
 mod tests {
     use super::{changes_stack_bottom, resolve_move_targets, should_block_for_bottom_pr_automerge};
+    use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
+    use crate::commands::{move_groups_after, MoveExecutionOptions, RewriteCommandOutcome};
+    use crate::config::DirtyWorktreePolicy;
     use crate::parsing::Group;
     use crate::selectors::{AfterSelector, GroupRangeSelector, GroupSelector, StableHandle};
+    use crate::test_support::{commit_file, git, lock_cwd, log_subjects, write_file, DirGuard};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
@@ -304,5 +316,92 @@ mod tests {
         assert!(should_block_for_bottom_pr_automerge(true, &[2, 1, 3]));
         assert!(!should_block_for_bottom_pr_automerge(true, &[1, 3, 2]));
         assert!(!should_block_for_bottom_pr_automerge(false, &[2, 1, 3]));
+    }
+
+    fn init_move_conflict_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path();
+        git(repo, ["init", "-b", "main"].as_slice());
+        git(repo, ["config", "user.email", "spr@example.com"].as_slice());
+        git(repo, ["config", "user.name", "SPR Tests"].as_slice());
+        write_file(repo, "story.txt", "base\n");
+        git(repo, ["add", "story.txt"].as_slice());
+        git(repo, ["commit", "-m", "init"].as_slice());
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "alpha-1\n", "feat: alpha pr:alpha");
+        commit_file(repo, "story.txt", "beta-1\n", "feat: beta pr:beta");
+        commit_file(repo, "story.txt", "gamma-1\n", "feat: gamma pr:gamma");
+        dir
+    }
+
+    #[test]
+    fn move_suspends_and_resumes_conflict_without_github_lookup() {
+        let _lock = lock_cwd();
+        let dir = init_move_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        let outcome = move_groups_after(
+            "main",
+            "dank-spr/",
+            "ignore",
+            &GroupRangeSelector::Single(GroupSelector::LocalPr(3)),
+            &AfterSelector::Group(GroupSelector::LocalPr(1)),
+            MoveExecutionOptions {
+                safe: false,
+                dry: false,
+                dirty_worktree_policy: DirtyWorktreePolicy::Halt,
+            },
+        )
+        .expect("move should suspend");
+        let mut current = outcome;
+        let mut last_resume_path = None;
+        while let RewriteCommandOutcome::Suspended(state) = current {
+            let resume_path = state.resume_path.clone();
+            let resume_state: RewriteResumeState =
+                serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                    .expect("parse resume state");
+            let paused_step = &resume_state.steps[resume_state.suspended_step_index];
+            let paused_subject = git(
+                &repo,
+                ["log", "-n", "1", "--format=%s", &paused_step.source_sha].as_slice(),
+            );
+            let resolved_contents = if paused_subject.trim() == "feat: gamma pr:gamma" {
+                "gamma-1\n"
+            } else {
+                "gamma-1\nbeta-1\n"
+            };
+            fs::write(
+                Path::new(&resume_state.temp_worktree_path).join("story.txt"),
+                resolved_contents,
+            )
+            .expect("resolve move conflict");
+            git(
+                Path::new(&resume_state.temp_worktree_path),
+                ["add", "story.txt"].as_slice(),
+            );
+            last_resume_path = Some(resume_path.clone());
+            current = resume_rewrite(false, &resume_path).expect("resume move");
+        }
+
+        assert_eq!(current, RewriteCommandOutcome::Completed);
+        if let Some(resume_path) = last_resume_path {
+            assert!(
+                !resume_path.exists(),
+                "successful move resume should delete the resume file"
+            );
+        }
+        assert_eq!(
+            fs::read_to_string(repo.join("story.txt")).expect("read final file"),
+            "gamma-1\nbeta-1\n"
+        );
+        assert_eq!(
+            log_subjects(&repo, 3),
+            vec![
+                "feat: beta pr:beta".to_string(),
+                "feat: gamma pr:gamma".to_string(),
+                "feat: alpha pr:alpha".to_string(),
+            ]
+        );
     }
 }

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -6,18 +6,20 @@
 //! branch is hard-reset to the rebuilt tip and the temp state is removed.
 //!
 //! Conflict handling is policy-driven via the `restack_conflict` config key.
-//! The default `rollback` behavior cleans up the temp state on conflict; the
-//! `halt` behavior leaves the temp worktree and branch in place and prints the
-//! exact commands needed to either roll back or continue manually.
+//! The default `halt` behavior suspends the replay, leaves the temp worktree
+//! in place, and writes a resume file for `spr resume <path>`. The `rollback`
+//! behavior preserves the historical cleanup-on-conflict path.
 
-use std::process::Command;
-
-use anyhow::{anyhow, Context, Result};
-use tracing::{info, warn};
+use anyhow::Result;
+use tracing::info;
 
 use crate::commands::common;
 use crate::commands::common::CherryPickOp;
+use crate::commands::rewrite_resume::{
+    self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
+};
 use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+use crate::git::git_rev_parse;
 use crate::git::git_rw;
 use crate::parsing::{derive_local_groups_with_ignored, Group};
 use crate::selectors::{resolve_after_count, AfterSelector};
@@ -28,36 +30,6 @@ struct RestackExecutionOptions {
     dry: bool,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
-}
-
-fn cherry_pick_head_exists(tmp_path: &str) -> bool {
-    Command::new("git")
-        .args([
-            "-C",
-            tmp_path,
-            "rev-parse",
-            "-q",
-            "--verify",
-            "CHERRY_PICK_HEAD",
-        ])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-fn abort_cherry_pick_best_effort(dry: bool, tmp_path: &str) {
-    if let Err(e) = git_rw(dry, ["-C", tmp_path, "cherry-pick", "--abort"].as_slice()) {
-        warn!("Failed to abort cherry-pick in {}: {}", tmp_path, e);
-    }
-}
-
-fn cleanup_temp_worktree_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str) {
-    if let Err(e) = common::cleanup_temp_worktree(dry, tmp_path, tmp_branch) {
-        warn!(
-            "Failed to clean up temp restack state ({} / {}): {}",
-            tmp_path, tmp_branch, e
-        );
-    }
 }
 
 /// Build the ordered cherry-pick plan that reconstructs the restacked history.
@@ -110,54 +82,6 @@ fn build_kept_ignored_segments(
 /// The instructions are explicit about the temp worktree location because a
 /// common mistake is to resolve conflicts in the original worktree, which does
 /// not affect the halted cherry-pick sequence.
-fn emit_halt_instructions(
-    cur_branch: &str,
-    backup_tag: Option<&str>,
-    base: &str,
-    tmp_path: &str,
-    tmp_branch: &str,
-    op_index: usize,
-    ops: &[CherryPickOp],
-) {
-    info!("Restack halted due to a cherry-pick conflict.");
-    info!("Base: {}", base);
-    info!("Temp worktree: {}", tmp_path);
-    info!("Temp branch: {}", tmp_branch);
-    info!("You remain on branch: {}", cur_branch);
-
-    info!("To roll back and clean up temp restack state:");
-    info!("  # if a cherry-pick is in progress, abort it first");
-    info!("  git -C {} cherry-pick --abort", tmp_path);
-    info!("  git worktree remove -f {}", tmp_path);
-    info!("  git branch -D {}", tmp_branch);
-    info!("  git checkout {}", cur_branch);
-    if let Some(backup) = backup_tag {
-        info!("  # Optional: restore the --safe backup tag onto your current branch");
-        info!("  git reset --hard refs/tags/{}", backup);
-    }
-
-    info!("To resolve and continue the restack manually:");
-    info!("  cd {}", tmp_path);
-    info!("  git status");
-    info!("  # resolve conflicts, then stage the resolutions");
-    info!("  git add <paths>");
-    info!("  git cherry-pick --continue");
-
-    let remaining_ops = ops.iter().skip(op_index + 1).collect::<Vec<_>>();
-    if !remaining_ops.is_empty() {
-        info!("  # then apply the remaining cherry-picks:");
-        for op in remaining_ops {
-            info!("  {}", op.command_for_user(tmp_path));
-        }
-    }
-
-    info!("  # finalize by moving your branch to the temp restack tip:");
-    info!("  git reset --hard {}", tmp_branch);
-    info!("  git worktree remove -f {}", tmp_path);
-    info!("  git branch -D {}", tmp_branch);
-    info!("  spr update");
-}
-
 fn resolve_restack_after_count(groups: &[Group], after: &AfterSelector) -> Result<usize> {
     resolve_after_count(groups, after)
 }
@@ -168,7 +92,7 @@ fn restack_after_resolved(
     groups: Vec<Group>,
     after: usize,
     options: RestackExecutionOptions,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     let after = std::cmp::min(after, groups.len());
     let kept_ignored_segments = build_kept_ignored_segments(leading_ignored, &groups, after);
     let remaining = groups[after..].to_vec();
@@ -177,8 +101,10 @@ fn restack_after_resolved(
         options.dry,
         "spr restack",
         options.dirty_worktree_policy,
-        || {
+        |deferred_dirty_worktree_restore| {
             let (cur_branch, short) = common::get_current_branch_and_short()?;
+            let original_head = git_rev_parse("HEAD")?;
+            let original_worktree_root = rewrite_resume::current_repo_root()?;
             if remaining.is_empty() && kept_ignored_segments.is_empty() {
                 if options.safe {
                     let _ = common::create_backup_tag(options.dry, "restack", &cur_branch, &short)?;
@@ -190,8 +116,14 @@ fn restack_after_resolved(
                     base
                 );
                 common::reset_current_branch_to(options.dry, base)?;
-                Ok(())
+                Ok(RewriteCommandOutcome::Completed)
             } else {
+                let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
+                    options.dry,
+                    RewriteCommandKind::Restack,
+                    &cur_branch,
+                    &original_head,
+                )?;
                 let backup_tag = if options.safe {
                     Some(common::create_backup_tag(
                         options.dry,
@@ -206,42 +138,36 @@ fn restack_after_resolved(
                 let (tmp_path, tmp_branch) =
                     common::create_temp_worktree(options.dry, "restack", base, &short)?;
                 let ops = build_cherry_pick_plan(&kept_ignored_segments, &remaining);
-                for (idx, op) in ops.iter().enumerate() {
-                    if let Err(err) = op.run(options.dry, &tmp_path) {
-                        let conflict = cherry_pick_head_exists(&tmp_path);
-                        if conflict && options.conflict_policy == RestackConflictPolicy::Halt {
-                            emit_halt_instructions(
-                                &cur_branch,
-                                backup_tag.as_deref(),
-                                base,
-                                &tmp_path,
-                                &tmp_branch,
-                                idx,
-                                &ops,
-                            );
-                            return Err(anyhow!(
-                                "restack halted due to conflict; resolve in temp worktree and continue manually"
-                            ));
-                        }
-
-                        if conflict {
-                            abort_cherry_pick_best_effort(options.dry, &tmp_path);
-                        }
-                        cleanup_temp_worktree_best_effort(options.dry, &tmp_path, &tmp_branch);
-                        return Err(err)
-                            .context("restack failed; temp restack state was cleaned up");
-                    }
+                let outcome = rewrite_resume::run_rewrite_session(
+                    options.dry,
+                    RewriteSession {
+                        command_kind: RewriteCommandKind::Restack,
+                        conflict_policy: if options.conflict_policy
+                            == RestackConflictPolicy::Rollback
+                        {
+                            RewriteConflictPolicy::Rollback
+                        } else {
+                            RewriteConflictPolicy::Suspend
+                        },
+                        original_worktree_root,
+                        original_branch: cur_branch.clone(),
+                        original_head,
+                        resume_path,
+                        temp_branch: tmp_branch,
+                        temp_worktree_path: tmp_path,
+                        backup_tag,
+                        operations: ops,
+                        deferred_dirty_worktree_restore,
+                        post_success_hint: None,
+                    },
+                )?;
+                if outcome == RewriteCommandOutcome::Completed {
+                    info!(
+                        "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
+                        after, cur_branch, base
+                    );
                 }
-
-                let new_tip = common::tip_of_tmp(&tmp_path)?;
-                info!(
-                    "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
-                    after, cur_branch, base
-                );
-                common::reset_current_branch_to(options.dry, &new_tip)?;
-                cleanup_temp_worktree_best_effort(options.dry, &tmp_path, &tmp_branch);
-
-                Ok(())
+                Ok(outcome)
             }
         },
     )
@@ -253,15 +179,13 @@ fn restack_after_resolved(
 /// rebuilt history. Ignored commits that appear between dropped PR groups are kept
 /// before the remaining stack.
 ///
-/// With the default `Rollback` conflict policy, any cherry-pick conflict aborts
-/// the restack attempt and `spr` *attempts* to clean up the temporary worktree
-/// and branch. Cleanup failures are logged as warnings and may require manual
-/// cleanup.
+/// With the default `Halt` conflict policy, any cherry-pick conflict suspends
+/// the restack, leaves the temporary worktree and branch in place, and writes
+/// a resume file for `spr resume <path>`.
 ///
-/// With the `Halt` conflict policy, restack stops at the first conflict and
-/// prints step-by-step instructions for resolving the conflict in the temp
-/// worktree and finishing the cherry-pick sequence manually before resetting
-/// the original branch to the rebuilt tip.
+/// With the `Rollback` conflict policy, restack preserves the historical
+/// cleanup-on-conflict behavior and attempts to remove the temp worktree and
+/// branch after aborting the failed cherry-pick.
 ///
 /// # Errors
 ///
@@ -274,14 +198,14 @@ pub fn restack_after(
     dry: bool,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
     let (_merge_base, leading_ignored, groups) =
         derive_local_groups_with_ignored(base, ignore_tag)?;
     if groups.is_empty() {
         info!("No local PR groups found; nothing to restack.");
-        Ok(())
+        Ok(RewriteCommandOutcome::Completed)
     } else {
         let after = resolve_restack_after_count(&groups, after)?;
         restack_after_resolved(
@@ -308,13 +232,13 @@ pub fn restack_after_count(
     dry: bool,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
-) -> Result<()> {
+) -> Result<RewriteCommandOutcome> {
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
     let (_merge_base, leading_ignored, groups) =
         derive_local_groups_with_ignored(base, ignore_tag)?;
     if groups.is_empty() {
-        Ok(())
+        Ok(RewriteCommandOutcome::Completed)
     } else {
         restack_after_resolved(
             base,
@@ -335,8 +259,15 @@ pub fn restack_after_count(
 mod tests {
     use super::{build_cherry_pick_plan, build_kept_ignored_segments, resolve_restack_after_count};
     use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
+    use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
+    use crate::commands::RewriteCommandOutcome;
+    use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
     use crate::parsing::Group;
     use crate::selectors::{AfterSelector, GroupSelector, StableHandle};
+    use crate::test_support::{commit_file, git, lock_cwd, write_file, DirGuard};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
@@ -416,6 +347,91 @@ mod tests {
                     sha: "gamma1".to_string(),
                     empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
                 },
+            ]
+        );
+    }
+
+    fn init_restack_conflict_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path().join("repo");
+        fs::create_dir(&repo).expect("create repo dir");
+        git(&repo, ["init", "-b", "main"].as_slice());
+        git(
+            &repo,
+            ["config", "user.email", "spr@example.com"].as_slice(),
+        );
+        git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        write_file(&repo, "story.txt", "base\n");
+        git(&repo, ["add", "story.txt"].as_slice());
+        git(&repo, ["commit", "-m", "init"].as_slice());
+
+        let origin = dir.path().join("origin.git");
+        git(
+            &repo,
+            ["init", "--bare", origin.to_str().unwrap()].as_slice(),
+        );
+        git(
+            &repo,
+            ["remote", "add", "origin", origin.to_str().unwrap()].as_slice(),
+        );
+        git(&repo, ["push", "-u", "origin", "main"].as_slice());
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(&repo, "alpha.txt", "alpha-1\n", "feat: alpha pr:alpha");
+        commit_file(&repo, "story.txt", "stack-beta\n", "feat: beta pr:beta");
+        git(&repo, ["checkout", "main"].as_slice());
+        commit_file(&repo, "story.txt", "base-updated\n", "feat: base update");
+        git(&repo, ["checkout", "stack"].as_slice());
+        dir
+    }
+
+    fn resolve_restack_conflict(temp_repo: &Path) {
+        fs::write(temp_repo.join("story.txt"), "base-updated\nstack-beta\n")
+            .expect("resolve restack conflict");
+        git(temp_repo, ["add", "story.txt"].as_slice());
+    }
+
+    #[test]
+    fn restack_halt_policy_suspends_and_resumes_conflict() {
+        let _lock = lock_cwd();
+        let dir = init_restack_conflict_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+
+        let outcome = super::restack_after(
+            "main",
+            "ignore",
+            &AfterSelector::Group(GroupSelector::LocalPr(1)),
+            false,
+            false,
+            RestackConflictPolicy::Halt,
+            DirtyWorktreePolicy::Halt,
+        )
+        .expect("restack should suspend");
+        let resume_path = match outcome {
+            RewriteCommandOutcome::Completed => panic!("expected suspended restack"),
+            RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
+        };
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        resolve_restack_conflict(Path::new(&resume_state.temp_worktree_path));
+
+        let resumed = resume_rewrite(false, &resume_path).expect("resume restack");
+        assert_eq!(resumed, RewriteCommandOutcome::Completed);
+        assert!(
+            !resume_path.exists(),
+            "successful restack resume should delete the resume file"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("story.txt")).expect("read final file"),
+            "base-updated\nstack-beta\n"
+        );
+        assert_eq!(
+            crate::test_support::log_subjects(&repo, 2),
+            vec![
+                "feat: beta pr:beta".to_string(),
+                "feat: base update".to_string(),
             ]
         );
     }

--- a/src/commands/rewrite_resume.rs
+++ b/src/commands/rewrite_resume.rs
@@ -1,0 +1,1640 @@
+//! Shared suspend/resume engine for local history rewrites.
+//!
+//! Rewrite-style commands build a temporary worktree, replay commit-level
+//! cherry-picks there, and only move the original branch after the replay
+//! succeeds. When a replay hits a cherry-pick conflict, this module can either
+//! clean up immediately or persist a local resume file under the repository's
+//! common Git directory so the operator can resolve the conflict and hand
+//! control back to `spr`.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::commands::common::{
+    self, CherryPickEmptyPolicy, CherryPickOp, DeferredDirtyWorktreeRestore, DirtyWorktreeOutcome,
+};
+use crate::git::{git_rev_list_range, git_ro, git_rw, repo_root};
+
+const REWRITE_RESUME_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewriteConflictPolicy {
+    Rollback,
+    Suspend,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RewriteCommandOutcome {
+    Completed,
+    Suspended(Box<RewriteSuspendedState>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteSuspendedState {
+    pub command_kind: RewriteCommandKind,
+    pub original_worktree_root: String,
+    pub original_branch: String,
+    pub temp_branch: String,
+    pub temp_worktree_path: String,
+    pub resume_path: PathBuf,
+    pub paused_source_sha: String,
+    pub conflicted_paths: Vec<String>,
+    pub post_success_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RewriteCommandKind {
+    Restack,
+    Absorb,
+    Move,
+    FixPr,
+}
+
+impl RewriteCommandKind {
+    fn resume_slug(self) -> &'static str {
+        match self {
+            Self::Restack => "restack",
+            Self::Absorb => "absorb",
+            Self::Move => "move",
+            Self::FixPr => "fix-pr",
+        }
+    }
+
+    fn command_name(self) -> &'static str {
+        match self {
+            Self::Restack => "spr restack",
+            Self::Absorb => "spr absorb",
+            Self::Move => "spr move",
+            Self::FixPr => "spr fix-pr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewriteReplayStep {
+    pub source_sha: String,
+    pub empty_policy: CherryPickEmptyPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewritePausedStepProof {
+    pub source_sha: String,
+    pub expected_parent: String,
+    pub expected_message: String,
+    pub expected_author_name: String,
+    pub expected_author_email: String,
+    pub expected_author_date: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewriteResumeState {
+    pub schema_version: u32,
+    pub command_kind: RewriteCommandKind,
+    pub git_common_dir: String,
+    pub original_worktree_root: String,
+    pub original_branch: String,
+    pub original_head: String,
+    pub temp_branch: String,
+    pub temp_worktree_path: String,
+    pub backup_tag: Option<String>,
+    pub paused_head: String,
+    #[serde(default)]
+    pub paused_step_proof: Option<RewritePausedStepProof>,
+    pub suspended_step_index: usize,
+    pub steps: Vec<RewriteReplayStep>,
+    #[serde(default)]
+    pub deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore,
+    pub post_success_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteSession {
+    pub command_kind: RewriteCommandKind,
+    pub conflict_policy: RewriteConflictPolicy,
+    pub original_worktree_root: String,
+    pub original_branch: String,
+    pub original_head: String,
+    pub resume_path: PathBuf,
+    pub temp_branch: String,
+    pub temp_worktree_path: String,
+    pub backup_tag: Option<String>,
+    pub operations: Vec<CherryPickOp>,
+    pub deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore,
+    pub post_success_hint: Option<String>,
+}
+
+impl DirtyWorktreeOutcome for RewriteCommandOutcome {
+    fn keeps_dirty_worktree_restore_deferred(&self) -> bool {
+        matches!(self, Self::Suspended { .. })
+    }
+}
+
+pub fn build_replay_steps(ops: &[CherryPickOp]) -> Result<Vec<RewriteReplayStep>> {
+    let mut steps = Vec::new();
+    for op in ops {
+        match op {
+            CherryPickOp::Commit { sha, empty_policy } => steps.push(RewriteReplayStep {
+                source_sha: sha.clone(),
+                empty_policy: *empty_policy,
+            }),
+            CherryPickOp::Range {
+                first,
+                last,
+                empty_policy,
+            } => {
+                let commits = git_rev_list_range(&format!("{first}^"), last)?;
+                steps.extend(commits.into_iter().map(|source_sha| RewriteReplayStep {
+                    source_sha,
+                    empty_policy: *empty_policy,
+                }));
+            }
+        }
+    }
+    Ok(steps)
+}
+
+pub fn current_repo_root() -> Result<String> {
+    repo_root()?.ok_or_else(|| anyhow!("`spr` must run from inside a git worktree"))
+}
+
+pub fn prepare_resume_path_for_new_session(
+    dry: bool,
+    command_kind: RewriteCommandKind,
+    original_branch: &str,
+    original_head: &str,
+) -> Result<PathBuf> {
+    let git_common_dir = current_common_git_dir()?;
+    let resume_path = default_resume_path(
+        &git_common_dir,
+        command_kind,
+        original_branch,
+        original_head,
+    );
+    if !resume_path.exists() {
+        return Ok(resume_path);
+    }
+
+    let existing_state = read_resume_state(&resume_path).with_context(|| {
+        format!(
+            "existing resume file {} must be resumed, discarded, or repaired before starting a new {} session",
+            resume_path.display(),
+            command_kind.command_name()
+        )
+    })?;
+    if Path::new(&existing_state.temp_worktree_path).exists() {
+        bail!(
+            "an active suspended {} session already exists at {}; run `spr resume {}` or discard that session first",
+            command_kind.command_name(),
+            resume_path.display(),
+            resume_path.display()
+        );
+    }
+
+    if dry {
+        bail!(
+            "stale resume file {} exists for {}, but `--dry-run` will not remove it; delete the file or rerun without `--dry-run`",
+            resume_path.display(),
+            command_kind.command_name()
+        );
+    }
+
+    info!(
+        "Removing stale resume file {} because its temp worktree {} no longer exists.",
+        resume_path.display(),
+        existing_state.temp_worktree_path
+    );
+    remove_resume_file_if_exists(false, &resume_path)?;
+    Ok(resume_path)
+}
+
+pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<RewriteCommandOutcome> {
+    let git_common_dir = current_common_git_dir()?;
+    let state = RewriteResumeState {
+        schema_version: REWRITE_RESUME_SCHEMA_VERSION,
+        command_kind: session.command_kind,
+        git_common_dir: git_common_dir.display().to_string(),
+        original_worktree_root: session.original_worktree_root,
+        original_branch: session.original_branch,
+        original_head: session.original_head,
+        temp_branch: session.temp_branch,
+        temp_worktree_path: session.temp_worktree_path.clone(),
+        backup_tag: session.backup_tag,
+        paused_head: head_at(&session.temp_worktree_path)?,
+        paused_step_proof: None,
+        suspended_step_index: 0,
+        steps: Vec::new(),
+        deferred_dirty_worktree_restore: session.deferred_dirty_worktree_restore,
+        post_success_hint: session.post_success_hint,
+    };
+    continue_rewrite_operations(
+        dry,
+        state,
+        session.conflict_policy,
+        &session.resume_path,
+        &session.operations,
+        false,
+    )
+}
+
+pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
+    if dry {
+        bail!("`spr resume` does not support `--dry-run`");
+    }
+
+    let resume_path = absolute_path(path)?;
+    let mut state = read_resume_state(&resume_path)?;
+    validate_resume_state_against_current_repo(&resume_path, &state)?;
+    validate_temp_worktree_exists(&state)?;
+
+    if state.suspended_step_index >= state.steps.len() {
+        bail!(
+            "resume file {} refers to step {} but only records {} replay steps",
+            resume_path.display(),
+            state.suspended_step_index,
+            state.steps.len()
+        );
+    }
+
+    if cherry_pick_head_exists(&state.temp_worktree_path) {
+        if head_at(&state.temp_worktree_path)? != state.paused_head {
+            bail!(
+                "temp worktree {} no longer points at the paused HEAD {}; abort or discard this suspended rewrite",
+                state.temp_worktree_path,
+                state.paused_head
+            );
+        }
+        ensure_no_unmerged_paths(&state.temp_worktree_path)?;
+        let continue_result = git_rw(
+            false,
+            [
+                "-C",
+                state.temp_worktree_path.as_str(),
+                "cherry-pick",
+                "--continue",
+            ]
+            .as_slice(),
+        )
+        .with_context(|| {
+            format!(
+                "{} could not continue the staged conflict resolution in {}",
+                state.command_kind.command_name(),
+                state.temp_worktree_path
+            )
+        });
+        let mut skipped_current_step = false;
+        if let Err(err) = continue_result {
+            if cherry_pick_head_exists(&state.temp_worktree_path)
+                && worktree_status_lines(&state.temp_worktree_path)?.is_empty()
+            {
+                info!(
+                    "The paused cherry-pick in {} became empty after conflict resolution; skipping it.",
+                    state.temp_worktree_path
+                );
+                let skip_result = git_rw(
+                    false,
+                    [
+                        "-C",
+                        state.temp_worktree_path.as_str(),
+                        "cherry-pick",
+                        "--skip",
+                    ]
+                    .as_slice(),
+                )
+                .with_context(|| {
+                    format!(
+                        "{} could not skip the now-empty cherry-pick in {}",
+                        state.command_kind.command_name(),
+                        state.temp_worktree_path
+                    )
+                });
+                if let Err(skip_err) = skip_result {
+                    if cherry_pick_head_exists(&state.temp_worktree_path) {
+                        let consumed_steps = validated_advanced_step_count(&state)? + 1;
+                        state.suspended_step_index += consumed_steps;
+                        state.paused_head = head_at(&state.temp_worktree_path)?;
+                        state.paused_step_proof = state
+                            .steps
+                            .get(state.suspended_step_index)
+                            .map(|step| build_paused_step_proof(&state.paused_head, step))
+                            .transpose()?;
+                        write_resume_state(&resume_path, &state)?;
+                        emit_suspend_instructions(&resume_path, &state);
+                        return Ok(RewriteCommandOutcome::Suspended(Box::new(
+                            suspended_state_from_resume_state(&resume_path, &state)?,
+                        )));
+                    }
+                    return Err(skip_err);
+                }
+                skipped_current_step = true;
+            } else if cherry_pick_head_exists(&state.temp_worktree_path) {
+                let consumed_steps = validated_advanced_step_count(&state)?;
+                if consumed_steps == 0 {
+                    return Err(err);
+                }
+                state.suspended_step_index += consumed_steps;
+                state.paused_head = head_at(&state.temp_worktree_path)?;
+                state.paused_step_proof = state
+                    .steps
+                    .get(state.suspended_step_index)
+                    .map(|step| build_paused_step_proof(&state.paused_head, step))
+                    .transpose()?;
+                write_resume_state(&resume_path, &state)?;
+                emit_suspend_instructions(&resume_path, &state);
+                return Ok(RewriteCommandOutcome::Suspended(Box::new(
+                    suspended_state_from_resume_state(&resume_path, &state)?,
+                )));
+            } else {
+                return Err(err);
+            }
+        }
+        let mut consumed_steps = validated_advanced_step_count(&state)?;
+        if skipped_current_step {
+            consumed_steps += 1;
+        }
+        state.suspended_step_index += consumed_steps;
+        state.paused_step_proof = None;
+        persist_resume_progress(&resume_path, &state)?;
+    } else {
+        let consumed_steps = validated_advanced_step_count(&state)?;
+        if consumed_steps == 0 {
+            bail!(
+                "resume file {} expects an in-progress cherry-pick in {}, but `CHERRY_PICK_HEAD` is missing and HEAD did not advance from {}",
+                resume_path.display(),
+                state.temp_worktree_path,
+                state.paused_head
+            );
+        } else {
+            validate_manual_continue_commit(&state)?;
+            info!(
+                "Detected manual cherry-pick progress of {} step(s) in {}; resuming remaining replay steps.",
+                consumed_steps,
+                state.temp_worktree_path
+            );
+            state.suspended_step_index += consumed_steps;
+            state.paused_step_proof = None;
+            persist_resume_progress(&resume_path, &state)?;
+        }
+    }
+
+    continue_rewrite_steps(
+        false,
+        state,
+        RewriteConflictPolicy::Suspend,
+        &resume_path,
+        true,
+    )
+}
+
+fn continue_rewrite_operations(
+    dry: bool,
+    mut state: RewriteResumeState,
+    conflict_policy: RewriteConflictPolicy,
+    resume_path: &Path,
+    operations: &[CherryPickOp],
+    restore_dirty_worktree_on_success: bool,
+) -> Result<RewriteCommandOutcome> {
+    for (op_index, op) in operations.iter().enumerate() {
+        if let Err(err) = run_cherry_pick_op(dry, &state.temp_worktree_path, op) {
+            let conflict = cherry_pick_head_exists(&state.temp_worktree_path);
+            if conflict && conflict_policy == RewriteConflictPolicy::Suspend {
+                state.paused_head = head_at(&state.temp_worktree_path)?;
+                state.steps = remaining_steps_after_conflicted_operation(
+                    &state.temp_worktree_path,
+                    op,
+                    &operations[op_index + 1..],
+                )?;
+                state.suspended_step_index = 0;
+                state.paused_step_proof = Some(build_paused_step_proof(
+                    &state.paused_head,
+                    state.steps.first().ok_or_else(|| {
+                        anyhow!(
+                            "{} suspended without recording a paused replay step",
+                            state.command_kind.command_name()
+                        )
+                    })?,
+                )?);
+                write_resume_state(resume_path, &state)?;
+                emit_suspend_instructions(resume_path, &state);
+                return Ok(RewriteCommandOutcome::Suspended(Box::new(
+                    suspended_state_from_resume_state(resume_path, &state)?,
+                )));
+            }
+
+            if conflict {
+                abort_cherry_pick_best_effort(dry, &state.temp_worktree_path);
+            }
+            cleanup_temp_state_best_effort(dry, &state.temp_worktree_path, &state.temp_branch);
+            return Err(err).with_context(|| {
+                format!(
+                    "{} failed; temp rewrite state was cleaned up",
+                    state.command_kind.command_name()
+                )
+            });
+        }
+    }
+
+    finish_rewrite(dry, state, resume_path, restore_dirty_worktree_on_success)
+}
+
+fn continue_rewrite_steps(
+    dry: bool,
+    mut state: RewriteResumeState,
+    conflict_policy: RewriteConflictPolicy,
+    resume_path: &Path,
+    restore_dirty_worktree_on_success: bool,
+) -> Result<RewriteCommandOutcome> {
+    let mut next_index = state.suspended_step_index;
+    while next_index < state.steps.len() {
+        let step = &state.steps[next_index];
+        if let Err(err) = common::cherry_pick_commit(
+            dry,
+            &state.temp_worktree_path,
+            &step.source_sha,
+            step.empty_policy,
+        ) {
+            let conflict = cherry_pick_head_exists(&state.temp_worktree_path);
+            if conflict && conflict_policy == RewriteConflictPolicy::Suspend {
+                state.paused_head = head_at(&state.temp_worktree_path)?;
+                state.suspended_step_index = next_index;
+                state.paused_step_proof = Some(build_paused_step_proof(&state.paused_head, step)?);
+                write_resume_state(resume_path, &state)?;
+                emit_suspend_instructions(resume_path, &state);
+                return Ok(RewriteCommandOutcome::Suspended(Box::new(
+                    suspended_state_from_resume_state(resume_path, &state)?,
+                )));
+            }
+
+            if conflict {
+                abort_cherry_pick_best_effort(dry, &state.temp_worktree_path);
+            }
+            cleanup_temp_state_best_effort(dry, &state.temp_worktree_path, &state.temp_branch);
+            return Err(err).with_context(|| {
+                format!(
+                    "{} failed; temp rewrite state was cleaned up",
+                    state.command_kind.command_name()
+                )
+            });
+        }
+        next_index += 1;
+        state.suspended_step_index = next_index;
+        state.paused_step_proof = None;
+        persist_resume_progress(resume_path, &state)?;
+    }
+
+    finish_rewrite(dry, state, resume_path, restore_dirty_worktree_on_success)
+}
+
+fn finish_rewrite(
+    dry: bool,
+    state: RewriteResumeState,
+    resume_path: &Path,
+    restore_dirty_worktree_on_success: bool,
+) -> Result<RewriteCommandOutcome> {
+    validate_original_worktree_target(&state)?;
+    let new_tip = common::tip_of_tmp(&state.temp_worktree_path)?;
+    info!(
+        "Updating original branch {} in {} to new tip {}...",
+        state.original_branch, state.original_worktree_root, new_tip
+    );
+    let _ = git_rw(
+        dry,
+        [
+            "-C",
+            state.original_worktree_root.as_str(),
+            "reset",
+            "--hard",
+            &new_tip,
+        ]
+        .as_slice(),
+    )?;
+    let restore_result = if restore_dirty_worktree_on_success {
+        state
+            .deferred_dirty_worktree_restore
+            .clone()
+            .restore_after_success(
+                dry,
+                state.command_kind.command_name(),
+                &state.original_worktree_root,
+            )
+    } else {
+        Ok(())
+    };
+    cleanup_temp_state_best_effort(dry, &state.temp_worktree_path, &state.temp_branch);
+    remove_resume_file_if_exists(dry, resume_path)?;
+    if let Some(post_success_hint) = &state.post_success_hint {
+        info!("{post_success_hint}");
+    }
+    restore_result?;
+    Ok(RewriteCommandOutcome::Completed)
+}
+
+fn emit_suspend_instructions(resume_path: &Path, state: &RewriteResumeState) {
+    for line in suspend_instruction_lines(resume_path, state) {
+        info!("{line}");
+    }
+}
+
+fn suspended_state_from_resume_state(
+    resume_path: &Path,
+    state: &RewriteResumeState,
+) -> Result<RewriteSuspendedState> {
+    let conflicted_paths =
+        conflicted_paths_from_status_lines(&worktree_status_lines(&state.temp_worktree_path)?);
+    let paused_source_sha = state
+        .steps
+        .get(state.suspended_step_index)
+        .map(|step| step.source_sha.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "resume state refers to missing step {} out of {} replay steps",
+                state.suspended_step_index,
+                state.steps.len()
+            )
+        })?;
+    Ok(RewriteSuspendedState {
+        command_kind: state.command_kind,
+        original_worktree_root: state.original_worktree_root.clone(),
+        original_branch: state.original_branch.clone(),
+        temp_branch: state.temp_branch.clone(),
+        temp_worktree_path: state.temp_worktree_path.clone(),
+        resume_path: resume_path.to_path_buf(),
+        paused_source_sha,
+        conflicted_paths,
+        post_success_hint: state.post_success_hint.clone(),
+    })
+}
+
+fn suspend_instruction_lines(resume_path: &Path, state: &RewriteResumeState) -> Vec<String> {
+    let mut lines = vec![
+        format!(
+            "{} suspended due to a cherry-pick conflict.",
+            state.command_kind.command_name()
+        ),
+        format!("Temp worktree: {}", state.temp_worktree_path),
+        format!("Temp branch: {}", state.temp_branch),
+        format!("Original branch: {}", state.original_branch),
+        format!("Resume file: {}", resume_path.display()),
+        "Resolve the conflict in the temp worktree, stage the resolution, and run:".to_string(),
+        format!("  spr resume {}", resume_path.display()),
+        "To discard this suspended rewrite and clean up its temp state:".to_string(),
+        format!("  git -C {} cherry-pick --abort", state.temp_worktree_path),
+    ];
+    lines.extend(
+        state
+            .deferred_dirty_worktree_restore
+            .discard_instruction_lines(&state.original_worktree_root),
+    );
+    lines.extend([
+        format!("  rm {}", resume_path.display()),
+        format!("  git worktree remove -f {}", state.temp_worktree_path),
+        format!("  git branch -D {}", state.temp_branch),
+    ]);
+    if let Some(backup_tag) = &state.backup_tag {
+        lines.extend([
+            "  # optional: restore the backup tag onto the original worktree".to_string(),
+            format!(
+                "  git -C {} reset --hard refs/tags/{}",
+                state.original_worktree_root, backup_tag
+            ),
+        ]);
+    }
+    lines
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommitIdentity {
+    parents: Vec<String>,
+    message: String,
+    author_name: String,
+    author_email: String,
+    author_date: String,
+}
+
+fn run_cherry_pick_op(dry: bool, tmp_path: &str, op: &CherryPickOp) -> Result<()> {
+    match op {
+        CherryPickOp::Commit { sha, empty_policy } => {
+            common::cherry_pick_commit(dry, tmp_path, sha, *empty_policy)
+        }
+        CherryPickOp::Range {
+            first,
+            last,
+            empty_policy,
+        } => common::cherry_pick_range(dry, tmp_path, first, last, *empty_policy),
+    }
+}
+
+fn remaining_steps_after_conflicted_operation(
+    tmp_path: &str,
+    op: &CherryPickOp,
+    later_operations: &[CherryPickOp],
+) -> Result<Vec<RewriteReplayStep>> {
+    let mut steps = match op {
+        CherryPickOp::Commit { sha, empty_policy } => vec![RewriteReplayStep {
+            source_sha: sha.clone(),
+            empty_policy: *empty_policy,
+        }],
+        CherryPickOp::Range {
+            first,
+            last,
+            empty_policy,
+        } => {
+            let commits = git_rev_list_range(&format!("{first}^"), last)?;
+            let paused_source_sha = cherry_pick_head_at(tmp_path)?;
+            let paused_index = commits
+                .iter()
+                .position(|sha| sha == &paused_source_sha)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "paused cherry-pick commit {} was not found inside range {}^..{}",
+                        paused_source_sha,
+                        first,
+                        last
+                    )
+                })?;
+            commits[paused_index..]
+                .iter()
+                .map(|source_sha| RewriteReplayStep {
+                    source_sha: source_sha.clone(),
+                    empty_policy: *empty_policy,
+                })
+                .collect()
+        }
+    };
+    steps.extend(build_replay_steps(later_operations)?);
+    Ok(steps)
+}
+
+fn build_paused_step_proof(
+    paused_head: &str,
+    step: &RewriteReplayStep,
+) -> Result<RewritePausedStepProof> {
+    let identity = commit_identity(&step.source_sha)?;
+    Ok(RewritePausedStepProof {
+        source_sha: step.source_sha.clone(),
+        expected_parent: paused_head.to_string(),
+        expected_message: identity.message,
+        expected_author_name: identity.author_name,
+        expected_author_email: identity.author_email,
+        expected_author_date: identity.author_date,
+    })
+}
+
+fn validate_manual_continue_commit(state: &RewriteResumeState) -> Result<()> {
+    let consumed_steps = validated_advanced_step_count(state)?;
+    if consumed_steps == 0 {
+        bail!(
+            "temp worktree {} did not advance any validated replay steps beyond paused HEAD {}",
+            state.temp_worktree_path,
+            state.paused_head
+        );
+    } else {
+        Ok(())
+    }
+}
+
+fn persist_resume_progress(resume_path: &Path, state: &RewriteResumeState) -> Result<()> {
+    if resume_path.exists() {
+        write_resume_state(resume_path, state)?;
+    }
+    Ok(())
+}
+
+fn commit_identity(sha: &str) -> Result<CommitIdentity> {
+    commit_identity_from_args(
+        ["show", "-s", "--format=%P%x00%an%x00%ae%x00%aI%x00%B", sha].as_slice(),
+    )
+}
+
+fn commit_identity_at(tmp_path: &str, sha: &str) -> Result<CommitIdentity> {
+    commit_identity_from_args(
+        [
+            "-C",
+            tmp_path,
+            "show",
+            "-s",
+            "--format=%P%x00%an%x00%ae%x00%aI%x00%B",
+            sha,
+        ]
+        .as_slice(),
+    )
+}
+
+fn commit_identity_from_args(args: &[&str]) -> Result<CommitIdentity> {
+    let raw = git_ro(args)?;
+    let mut parts = raw.splitn(5, '\0');
+    let parents_raw = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing parent list in commit identity"))?;
+    let author_name = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing author name in commit identity"))?
+        .to_string();
+    let author_email = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing author email in commit identity"))?
+        .to_string();
+    let author_date = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing author date in commit identity"))?
+        .to_string();
+    let message = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing commit message in commit identity"))?
+        .to_string();
+    let parents = parents_raw
+        .split_whitespace()
+        .map(ToOwned::to_owned)
+        .collect();
+    Ok(CommitIdentity {
+        parents,
+        message,
+        author_name,
+        author_email,
+        author_date,
+    })
+}
+
+fn validated_advanced_step_count(state: &RewriteResumeState) -> Result<usize> {
+    let advanced_commits =
+        advanced_commits_since_paused_head(&state.temp_worktree_path, &state.paused_head)?;
+    let remaining_steps = &state.steps[state.suspended_step_index..];
+    if advanced_commits.len() > remaining_steps.len() {
+        bail!(
+            "temp worktree {} advanced by {} commits beyond paused HEAD {}, but only {} replay step(s) remain",
+            state.temp_worktree_path,
+            advanced_commits.len(),
+            state.paused_head,
+            remaining_steps.len()
+        );
+    }
+
+    let mut expected_parent = state.paused_head.clone();
+    for (advanced_commit, step) in advanced_commits.iter().zip(remaining_steps.iter()) {
+        validate_replayed_commit_matches_step(
+            &state.temp_worktree_path,
+            advanced_commit,
+            step,
+            &expected_parent,
+        )?;
+        expected_parent = advanced_commit.clone();
+    }
+    Ok(advanced_commits.len())
+}
+
+fn validate_replayed_commit_matches_step(
+    tmp_path: &str,
+    actual_sha: &str,
+    step: &RewriteReplayStep,
+    expected_parent: &str,
+) -> Result<()> {
+    let actual = commit_identity_at(tmp_path, actual_sha)?;
+    let expected = commit_identity(&step.source_sha)?;
+    if actual.parents.len() != 1 {
+        bail!(
+            "temp worktree {} advanced to {}, but that commit has {} parents instead of the expected one-parent cherry-pick result for {}",
+            tmp_path,
+            actual_sha,
+            actual.parents.len(),
+            step.source_sha
+        );
+    } else if actual.parents[0] != expected_parent {
+        bail!(
+            "temp worktree {} advanced to {}, but its parent {} does not match the expected replay parent {} for {}",
+            tmp_path,
+            actual_sha,
+            actual.parents[0],
+            expected_parent,
+            step.source_sha
+        );
+    } else if actual.message != expected.message {
+        bail!(
+            "temp worktree {} advanced to {}, but its commit message no longer matches the paused source {}",
+            tmp_path,
+            actual_sha,
+            step.source_sha
+        );
+    } else if actual.author_name != expected.author_name
+        || actual.author_email != expected.author_email
+        || actual.author_date != expected.author_date
+    {
+        bail!(
+            "temp worktree {} advanced to {}, but its author metadata no longer matches the paused source {}",
+            tmp_path,
+            actual_sha,
+            step.source_sha
+        );
+    } else {
+        Ok(())
+    }
+}
+
+fn abort_cherry_pick_best_effort(dry: bool, tmp_path: &str) {
+    if let Err(err) = git_rw(dry, ["-C", tmp_path, "cherry-pick", "--abort"].as_slice()) {
+        warn!("Failed to abort cherry-pick in {}: {}", tmp_path, err);
+    }
+}
+
+fn cleanup_temp_state_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str) {
+    if let Err(err) = common::cleanup_temp_worktree(dry, tmp_path, tmp_branch) {
+        warn!(
+            "Failed to clean up temp rewrite state ({} / {}): {}",
+            tmp_path, tmp_branch, err
+        );
+    }
+}
+
+fn write_resume_state(path: &Path, state: &RewriteResumeState) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create resume-state directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    let json = serde_json::to_string_pretty(state).context("failed to encode resume-state JSON")?;
+    fs::write(path, json)
+        .with_context(|| format!("failed to write resume-state file {}", path.display()))
+}
+
+fn read_resume_state(path: &Path) -> Result<RewriteResumeState> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read resume-state file {}", path.display()))?;
+    let state: RewriteResumeState = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse resume-state file {}", path.display()))?;
+    if state.schema_version != REWRITE_RESUME_SCHEMA_VERSION {
+        bail!(
+            "resume file {} uses schema version {}, but this `spr` expects {}",
+            path.display(),
+            state.schema_version,
+            REWRITE_RESUME_SCHEMA_VERSION
+        );
+    }
+    Ok(state)
+}
+
+fn validate_resume_state_against_current_repo(
+    path: &Path,
+    state: &RewriteResumeState,
+) -> Result<()> {
+    let current_common_dir = current_common_git_dir()?;
+    let expected_common_dir = canonicalize_existing_path(Path::new(&state.git_common_dir))
+        .with_context(|| {
+            format!(
+                "resume file {} points at missing git-common-dir {}",
+                path.display(),
+                state.git_common_dir
+            )
+        })?;
+    if current_common_dir != expected_common_dir {
+        bail!(
+            "resume file {} belongs to git-common-dir {}, but the current repository uses {}",
+            path.display(),
+            expected_common_dir.display(),
+            current_common_dir.display()
+        );
+    }
+
+    let expected_prefix = expected_common_dir.join("spr").join("resume");
+    let actual_parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "resume file path {} has no parent directory",
+            path.display()
+        )
+    })?;
+    let canonical_parent = canonicalize_existing_path(actual_parent)?;
+    if canonical_parent != expected_prefix {
+        bail!(
+            "resume file {} is not located under the expected resume directory {}",
+            path.display(),
+            expected_prefix.display()
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_temp_worktree_exists(state: &RewriteResumeState) -> Result<()> {
+    if Path::new(&state.temp_worktree_path).exists() {
+        Ok(())
+    } else {
+        bail!(
+            "temp worktree {} recorded in the resume file no longer exists",
+            state.temp_worktree_path
+        );
+    }
+}
+
+fn validate_original_worktree_target(state: &RewriteResumeState) -> Result<()> {
+    if !Path::new(&state.original_worktree_root).exists() {
+        bail!(
+            "original worktree root {} no longer exists",
+            state.original_worktree_root
+        );
+    }
+
+    let current_branch = branch_at(&state.original_worktree_root)?;
+    if current_branch != state.original_branch {
+        bail!(
+            "original worktree {} is now on branch {} instead of recorded branch {}",
+            state.original_worktree_root,
+            current_branch,
+            state.original_branch
+        );
+    }
+
+    let current_head = head_at(&state.original_worktree_root)?;
+    if current_head != state.original_head {
+        bail!(
+            "original branch {} moved from recorded tip {} to {}; resume refuses to reset it",
+            state.original_branch,
+            state.original_head,
+            current_head
+        );
+    }
+
+    Ok(())
+}
+
+fn current_common_git_dir() -> Result<PathBuf> {
+    let raw = git_ro(["rev-parse", "--git-common-dir"].as_slice())?;
+    canonicalize_existing_path(&absolute_path(Path::new(raw.trim()))?)
+}
+
+fn default_resume_path(
+    git_common_dir: &Path,
+    command_kind: RewriteCommandKind,
+    original_branch: &str,
+    original_head: &str,
+) -> PathBuf {
+    let sanitized_branch = sanitize_branch_for_filename(original_branch);
+    let short = short_head(original_head);
+    git_common_dir.join("spr").join("resume").join(format!(
+        "{}-{}-{}.json",
+        command_kind.resume_slug(),
+        sanitized_branch,
+        short
+    ))
+}
+
+fn sanitize_branch_for_filename(branch: &str) -> String {
+    let sanitized: String = branch
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect();
+    if sanitized.is_empty() {
+        "HEAD".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn short_head(head: &str) -> &str {
+    let limit = std::cmp::min(7, head.len());
+    &head[..limit]
+}
+
+fn remove_resume_file_if_exists(dry: bool, path: &Path) -> Result<()> {
+    if dry {
+        Ok(())
+    } else if path.exists() {
+        fs::remove_file(path)
+            .with_context(|| format!("failed to remove stale resume file {}", path.display()))
+    } else {
+        Ok(())
+    }
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(env::current_dir()
+            .context("current directory is unavailable")?
+            .join(path))
+    }
+}
+
+fn canonicalize_existing_path(path: &Path) -> Result<PathBuf> {
+    fs::canonicalize(path)
+        .with_context(|| format!("failed to canonicalize path {}", path.display()))
+}
+
+fn branch_at(path: &str) -> Result<String> {
+    Ok(
+        git_ro(["-C", path, "rev-parse", "--abbrev-ref", "HEAD"].as_slice())?
+            .trim()
+            .to_string(),
+    )
+}
+
+fn head_at(path: &str) -> Result<String> {
+    Ok(git_ro(["-C", path, "rev-parse", "HEAD"].as_slice())?
+        .trim()
+        .to_string())
+}
+
+fn cherry_pick_head_exists(tmp_path: &str) -> bool {
+    Command::new("git")
+        .args([
+            "-C",
+            tmp_path,
+            "rev-parse",
+            "-q",
+            "--verify",
+            "CHERRY_PICK_HEAD",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn cherry_pick_head_at(tmp_path: &str) -> Result<String> {
+    Ok(
+        git_ro(["-C", tmp_path, "rev-parse", "--verify", "CHERRY_PICK_HEAD"].as_slice())?
+            .trim()
+            .to_string(),
+    )
+}
+
+fn ensure_no_unmerged_paths(tmp_path: &str) -> Result<()> {
+    let conflict_lines = worktree_status_lines(tmp_path)?
+        .into_iter()
+        .filter(|line| status_line_has_conflict(line))
+        .collect::<Vec<_>>();
+    if conflict_lines.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "temp worktree {} still has unresolved conflicts:\n{}\nResolve them and stage the result before running `spr resume`.",
+            tmp_path,
+            conflict_lines.join("\n")
+        );
+    }
+}
+
+fn worktree_status_lines(tmp_path: &str) -> Result<Vec<String>> {
+    Ok(
+        git_ro(["-C", tmp_path, "status", "--porcelain=v1"].as_slice())?
+            .lines()
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn conflicted_paths_from_status_lines(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter(|line| status_line_has_conflict(line))
+        .filter_map(|line| line.get(3..).map(str::trim))
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn status_line_has_conflict(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    if bytes.len() < 2 {
+        false
+    } else {
+        let x = bytes[0] as char;
+        let y = bytes[1] as char;
+        x == 'U' || y == 'U' || (x == 'A' && y == 'A') || (x == 'D' && y == 'D')
+    }
+}
+
+fn advanced_commits_since_paused_head(tmp_path: &str, paused_head: &str) -> Result<Vec<String>> {
+    let current_head = head_at(tmp_path)?;
+    let is_ancestor = Command::new("git")
+        .args([
+            "-C",
+            tmp_path,
+            "merge-base",
+            "--is-ancestor",
+            paused_head,
+            &current_head,
+        ])
+        .status()
+        .with_context(|| {
+            format!(
+                "failed to compare paused HEAD {} with current HEAD {} in {}",
+                paused_head, current_head, tmp_path
+            )
+        })?;
+    if !is_ancestor.success() {
+        bail!(
+            "paused HEAD {} is not an ancestor of current HEAD {} in {}",
+            paused_head,
+            current_head,
+            tmp_path
+        );
+    }
+    Ok(git_ro(
+        [
+            "-C",
+            tmp_path,
+            "rev-list",
+            "--reverse",
+            &format!("{paused_head}..{current_head}"),
+        ]
+        .as_slice(),
+    )?
+    .lines()
+    .map(str::trim)
+    .filter(|line| !line.is_empty())
+    .map(ToOwned::to_owned)
+    .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    use super::{
+        build_replay_steps, conflicted_paths_from_status_lines, default_resume_path,
+        prepare_resume_path_for_new_session, resume_rewrite, run_rewrite_session,
+        sanitize_branch_for_filename, suspend_instruction_lines, RewriteCommandKind,
+        RewriteCommandOutcome, RewriteConflictPolicy, RewriteResumeState, RewriteSession,
+        REWRITE_RESUME_SCHEMA_VERSION,
+    };
+    use crate::commands::common::{
+        CherryPickEmptyPolicy, CherryPickOp, DeferredDirtyWorktreeRestore,
+    };
+    use crate::test_support::{lock_cwd, DirGuard};
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
+    fn init_conflict_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path();
+        git(repo, ["init", "-b", "main"].as_slice());
+        git(repo, ["config", "user.email", "spr@example.com"].as_slice());
+        git(repo, ["config", "user.name", "SPR Tests"].as_slice());
+        fs::write(repo.join("story.txt"), "base\n").expect("write base file");
+        git(repo, ["add", "story.txt"].as_slice());
+        git(repo, ["commit", "-m", "init"].as_slice());
+        dir
+    }
+
+    fn commit_file(repo: &Path, file: &str, contents: &str, message: &str) -> String {
+        fs::write(repo.join(file), contents).expect("write file");
+        git(repo, ["add", file].as_slice());
+        git(repo, ["commit", "-m", message].as_slice());
+        git(repo, ["rev-parse", "HEAD"].as_slice())
+            .trim()
+            .to_string()
+    }
+
+    fn current_common_git_dir(repo: &Path) -> PathBuf {
+        let raw = git(repo, ["rev-parse", "--git-common-dir"].as_slice());
+        let path = PathBuf::from(raw.trim());
+        if path.is_absolute() {
+            fs::canonicalize(path).expect("canonicalize git common dir")
+        } else {
+            fs::canonicalize(repo.join(path)).expect("canonicalize git common dir")
+        }
+    }
+
+    fn resolve_keep_both(repo: &Path, contents: &str) {
+        fs::write(repo.join("story.txt"), contents).expect("resolve conflict");
+        git(repo, ["add", "story.txt"].as_slice());
+    }
+
+    fn suspended_session_repo() -> (TempDir, PathBuf, PathBuf) {
+        let dir = init_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        let original_head = commit_file(&repo, "story.txt", "stack-change\n", "feat: stack change");
+
+        git(&repo, ["checkout", "main"].as_slice());
+        let base_head = commit_file(&repo, "story.txt", "base-updated\n", "feat: base update");
+        git(&repo, ["checkout", "stack"].as_slice());
+        let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        let (tmp_path, tmp_branch) =
+            crate::commands::common::create_temp_worktree(false, "restack", &base_head, &short)
+                .expect("create temp worktree");
+        let resume_path = prepare_resume_path_for_new_session(
+            false,
+            RewriteCommandKind::Restack,
+            "stack",
+            &original_head,
+        )
+        .expect("prepare resume path");
+
+        let session = RewriteSession {
+            command_kind: RewriteCommandKind::Restack,
+            conflict_policy: RewriteConflictPolicy::Suspend,
+            original_worktree_root: repo.display().to_string(),
+            original_branch: "stack".to_string(),
+            original_head: original_head.clone(),
+            resume_path,
+            temp_branch: tmp_branch.clone(),
+            temp_worktree_path: tmp_path.clone(),
+            backup_tag: None,
+            operations: vec![CherryPickOp::Commit {
+                sha: original_head.clone(),
+                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+            }],
+            deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
+            post_success_hint: None,
+        };
+
+        let outcome = run_rewrite_session(false, session).expect("run rewrite session");
+        let resume_path = match outcome {
+            RewriteCommandOutcome::Completed => panic!("expected suspended rewrite"),
+            RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
+        };
+
+        (dir, repo, resume_path)
+    }
+
+    #[test]
+    fn build_replay_steps_expands_ranges_to_single_commits() {
+        let _lock = lock_cwd();
+        let dir = init_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        let first = commit_file(&repo, "alpha.txt", "alpha-1\n", "feat: alpha");
+        let second = commit_file(&repo, "alpha.txt", "alpha-1\nalpha-2\n", "feat: alpha 2");
+        let steps = build_replay_steps(&[
+            CherryPickOp::Commit {
+                sha: first.clone(),
+                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+            },
+            CherryPickOp::Range {
+                first,
+                last: second.clone(),
+                empty_policy: CherryPickEmptyPolicy::KeepRedundantCommits,
+            },
+        ])
+        .expect("flatten replay steps");
+
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[1].source_sha, steps[0].source_sha);
+        assert_eq!(steps[2].source_sha, second);
+        assert_eq!(
+            steps[2].empty_policy,
+            CherryPickEmptyPolicy::KeepRedundantCommits
+        );
+    }
+
+    #[test]
+    fn run_rewrite_session_uses_range_replay_before_first_conflict() {
+        let _lock = lock_cwd();
+        let dir = init_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        let first = commit_file(&repo, "story.txt", "stack-1\n", "feat: first");
+        let second = commit_file(&repo, "extra.txt", "stack-2\n", "feat: second");
+        let original_head = second.clone();
+
+        git(&repo, ["checkout", "main"].as_slice());
+        let base_head = commit_file(&repo, "story.txt", "base-updated\n", "feat: base update");
+        git(&repo, ["checkout", "stack"].as_slice());
+
+        let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        let (tmp_path, tmp_branch) =
+            crate::commands::common::create_temp_worktree(false, "restack", &base_head, &short)
+                .expect("create temp worktree");
+        let resume_path = prepare_resume_path_for_new_session(
+            false,
+            RewriteCommandKind::Restack,
+            "stack",
+            &original_head,
+        )
+        .expect("prepare resume path");
+
+        let outcome = run_rewrite_session(
+            false,
+            RewriteSession {
+                command_kind: RewriteCommandKind::Restack,
+                conflict_policy: RewriteConflictPolicy::Suspend,
+                original_worktree_root: repo.display().to_string(),
+                original_branch: "stack".to_string(),
+                original_head,
+                resume_path: resume_path.clone(),
+                temp_branch: tmp_branch,
+                temp_worktree_path: tmp_path.clone(),
+                backup_tag: None,
+                operations: vec![CherryPickOp::Range {
+                    first: first.clone(),
+                    last: second.clone(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                }],
+                deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
+                post_success_hint: None,
+            },
+        )
+        .expect("run rewrite session");
+
+        assert!(
+            matches!(outcome, RewriteCommandOutcome::Suspended(_)),
+            "expected range replay to suspend"
+        );
+        let git_dir_raw = git(Path::new(&tmp_path), ["rev-parse", "--git-dir"].as_slice());
+        let git_dir = PathBuf::from(git_dir_raw.trim());
+        let git_dir = if git_dir.is_absolute() {
+            git_dir
+        } else {
+            Path::new(&tmp_path).join(git_dir)
+        };
+        let sequencer_todo =
+            fs::read_to_string(git_dir.join("sequencer").join("todo")).expect("read todo");
+        assert!(
+            sequencer_todo.contains("feat: second") && sequencer_todo.contains(&second[..7]),
+            "expected the range sequencer todo to mention the later commit: {sequencer_todo}"
+        );
+    }
+
+    #[test]
+    fn sanitize_branch_for_filename_replaces_separators() {
+        assert_eq!(sanitize_branch_for_filename("dank/main"), "dank_main");
+    }
+
+    #[test]
+    fn resume_rewrite_completes_after_staged_resolution() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        resolve_keep_both(
+            Path::new(&resume_state.temp_worktree_path),
+            "base-updated\nstack-change\n",
+        );
+
+        let outcome = resume_rewrite(false, &resume_path).expect("resume rewrite");
+        assert_eq!(outcome, RewriteCommandOutcome::Completed);
+        assert!(
+            !resume_path.exists(),
+            "successful resume should delete the resume file"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("story.txt")).expect("read final file"),
+            "base-updated\nstack-change\n"
+        );
+    }
+
+    #[test]
+    fn resume_rewrite_tolerates_one_manual_continue() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        let temp_repo = Path::new(&resume_state.temp_worktree_path);
+        resolve_keep_both(temp_repo, "base-updated\nstack-change\n");
+        git(temp_repo, ["cherry-pick", "--continue"].as_slice());
+
+        let outcome = resume_rewrite(false, &resume_path).expect("resume after manual continue");
+        assert_eq!(outcome, RewriteCommandOutcome::Completed);
+        assert!(
+            !resume_path.exists(),
+            "resume file should be removed after the resumed replay finishes"
+        );
+    }
+
+    #[test]
+    fn resume_rewrite_rejects_unrelated_single_manual_commit() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        let temp_repo = Path::new(&resume_state.temp_worktree_path);
+        git(temp_repo, ["cherry-pick", "--abort"].as_slice());
+        commit_file(
+            temp_repo,
+            "manual.txt",
+            "manual unrelated\n",
+            "manual unrelated commit",
+        );
+
+        let err = resume_rewrite(false, &resume_path)
+            .expect_err("unrelated one-commit manual history should fail");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("no longer matches the paused source")
+                || err_text.contains("does not match the paused HEAD"),
+            "unexpected error: {err_text}"
+        );
+    }
+
+    #[test]
+    fn resume_rewrite_rejects_wrong_repository() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let wrong_repo = init_conflict_repo();
+        let _guard = DirGuard::change_to(wrong_repo.path());
+        let err = resume_rewrite(false, &resume_path).expect_err("wrong repo should fail");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("belongs to git-common-dir"),
+            "unexpected error: {err_text}"
+        );
+        drop(repo);
+    }
+
+    #[test]
+    fn resume_rewrite_rejects_unresolved_conflicts() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let err = resume_rewrite(false, &resume_path).expect_err("unresolved conflict should fail");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("still has unresolved conflicts"),
+            "unexpected error: {err_text}"
+        );
+    }
+
+    #[test]
+    fn resume_rewrite_rejects_unknown_schema_version() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let mut state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        state.schema_version = REWRITE_RESUME_SCHEMA_VERSION + 1;
+        fs::write(
+            &resume_path,
+            serde_json::to_string_pretty(&state).expect("encode modified state"),
+        )
+        .expect("overwrite resume state");
+
+        let err = resume_rewrite(false, &resume_path).expect_err("unknown schema should fail");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("schema version"),
+            "unexpected error: {err_text}"
+        );
+    }
+
+    #[test]
+    fn resume_rewrite_rejects_multiple_manual_commits() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        let temp_repo = Path::new(&resume_state.temp_worktree_path);
+        resolve_keep_both(temp_repo, "base-updated\nstack-change\n");
+        git(temp_repo, ["cherry-pick", "--continue"].as_slice());
+        commit_file(
+            temp_repo,
+            "extra.txt",
+            "extra\n",
+            "feat: unsupported manual edit",
+        );
+
+        let err = resume_rewrite(false, &resume_path).expect_err("extra manual commit should fail");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("only 1 replay step(s) remain")
+                || err_text.contains("only one accidental manual continue is supported"),
+            "unexpected error: {err_text}"
+        );
+    }
+
+    #[test]
+    fn prepare_resume_path_for_new_session_rejects_active_session() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path) = suspended_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        let err = prepare_resume_path_for_new_session(
+            false,
+            RewriteCommandKind::Restack,
+            &resume_state.original_branch,
+            &resume_state.original_head,
+        )
+        .expect_err("active suspended session should block replacement");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text.contains("active suspended")
+                || err_text.contains("discard that session first"),
+            "unexpected error: {err_text}"
+        );
+    }
+
+    #[test]
+    fn default_resume_path_uses_common_git_directory() {
+        let dir = init_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let common_dir = current_common_git_dir(&repo);
+        let path = default_resume_path(
+            &common_dir,
+            RewriteCommandKind::Restack,
+            "dank/main",
+            "2b613d8f7076641755b8137a320c8b9c881a5469",
+        );
+
+        assert_eq!(
+            path,
+            common_dir
+                .join("spr")
+                .join("resume")
+                .join("restack-dank_main-2b613d8.json")
+        );
+    }
+
+    #[test]
+    fn suspend_instruction_lines_include_original_branch() {
+        let state = RewriteResumeState {
+            schema_version: REWRITE_RESUME_SCHEMA_VERSION,
+            command_kind: RewriteCommandKind::Restack,
+            git_common_dir: "/tmp/repo/.git".to_string(),
+            original_worktree_root: "/tmp/repo".to_string(),
+            original_branch: "stack".to_string(),
+            original_head: "abcdef0123456789".to_string(),
+            temp_branch: "spr/tmp-restack-abcdef0".to_string(),
+            temp_worktree_path: "/tmp/spr-restack-abcdef0".to_string(),
+            backup_tag: None,
+            paused_head: "abcdef0123456789".to_string(),
+            paused_step_proof: None,
+            suspended_step_index: 0,
+            steps: vec![],
+            deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
+            post_success_hint: None,
+        };
+
+        let lines =
+            suspend_instruction_lines(Path::new("/tmp/repo/.git/spr/resume/state.json"), &state);
+
+        assert!(
+            lines.contains(&"Original branch: stack".to_string()),
+            "expected original branch in suspend output: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn conflicted_paths_from_status_lines_filters_conflicts() {
+        let lines = vec![
+            "UU story.txt".to_string(),
+            " M untouched.txt".to_string(),
+            "AA both-added.txt".to_string(),
+        ];
+
+        assert_eq!(
+            conflicted_paths_from_status_lines(&lines),
+            vec!["story.txt".to_string(), "both-added.txt".to_string()]
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,15 +25,15 @@ pub enum PrDescriptionMode {
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum RestackConflictPolicy {
-    /// Abort and clean up temp restack state (default).
+    /// Abort and clean up temp restack state.
     Rollback,
-    /// Halt and leave the temp worktree/branch for manual resolution.
+    /// Suspend, leave the temp worktree in place, and resume with `spr resume`.
     Halt,
 }
 
 impl Default for RestackConflictPolicy {
     fn default() -> Self {
-        Self::Rollback
+        Self::Halt
     }
 }
 
@@ -112,8 +112,8 @@ pub struct FileConfig {
     /// Behavior when `spr restack` encounters a cherry-pick conflict.
     ///
     /// Supported values:
-    /// - `rollback` (default): abort and clean up temp restack state
-    /// - `halt`: stop and leave the temp worktree for manual resolution
+    /// - `halt` (default): suspend, leave the temp worktree in place, and use `spr resume`
+    /// - `rollback`: abort and clean up temp restack state
     pub restack_conflict: Option<RestackConflictPolicy>,
     /// Behavior when a branch-rewriting command sees local changes.
     ///
@@ -171,7 +171,7 @@ fn default_config() -> Config {
         ignore_tag: "ignore".to_string(),
         pr_description_mode: PrDescriptionMode::Overwrite,
         list_order: ListOrder::RecentOnTop,
-        restack_conflict: RestackConflictPolicy::Rollback,
+        restack_conflict: RestackConflictPolicy::Halt,
         dirty_worktree: DirtyWorktreePolicy::Halt,
         branch_reuse_guard_days: 180,
     }
@@ -246,7 +246,7 @@ pub fn load_config() -> Result<Config> {
 mod tests {
     use super::{
         apply_overrides, default_config, read_config_file, DirtyWorktreePolicy, FileConfig,
-        PrDescriptionMode,
+        PrDescriptionMode, RestackConflictPolicy,
     };
     use std::fs;
     use tempfile::tempdir;
@@ -315,6 +315,32 @@ dirty_worktree: stash
             .expect("parse config")
             .expect("config exists");
         assert_eq!(cfg.dirty_worktree, Some(DirtyWorktreePolicy::Stash));
+    }
+
+    #[test]
+    fn read_config_file_parses_restack_conflict_policy() {
+        let dir = tempdir().expect("tempdir");
+        let mut path = dir.path().to_path_buf();
+        path.push(".spr_multicommit_cfg.yml");
+        fs::write(
+            &path,
+            r#"
+restack_conflict: rollback
+"#,
+        )
+        .expect("write config");
+
+        let cfg = read_config_file(&path)
+            .expect("parse config")
+            .expect("config exists");
+        assert_eq!(cfg.restack_conflict, Some(RestackConflictPolicy::Rollback));
+    }
+
+    #[test]
+    fn default_config_uses_halt_for_restack_conflict_policy() {
+        let cfg = default_config();
+
+        assert_eq!(cfg.restack_conflict, RestackConflictPolicy::Halt);
     }
 
     #[test]

--- a/src/machine_output.rs
+++ b/src/machine_output.rs
@@ -1,0 +1,218 @@
+//! Machine-readable command results for resumable rewrite workflows.
+//!
+//! This module defines the `--json` contract used by rewrite-style commands
+//! and `spr land` when a follow-on restack can suspend. The contract is
+//! intentionally separate from the human-oriented tracing output: in JSON mode
+//! callers should read stdout only and avoid scraping stderr.
+
+use serde::Serialize;
+
+use crate::commands::{RewriteCommandKind, RewriteSuspendedState};
+
+pub const MACHINE_OUTPUT_SCHEMA_VERSION: u32 = 1;
+pub const EXIT_SUCCESS: i32 = 0;
+pub const EXIT_FAILURE: i32 = 1;
+pub const EXIT_SUSPENDED: i32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MachineCommand {
+    Cli,
+    Restack,
+    Absorb,
+    Move,
+    FixPr,
+    Resume,
+    Land,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MachineRewriteCommandKind {
+    Restack,
+    Absorb,
+    Move,
+    FixPr,
+}
+
+impl From<RewriteCommandKind> for MachineRewriteCommandKind {
+    fn from(value: RewriteCommandKind) -> Self {
+        match value {
+            RewriteCommandKind::Restack => Self::Restack,
+            RewriteCommandKind::Absorb => Self::Absorb,
+            RewriteCommandKind::Move => Self::Move,
+            RewriteCommandKind::FixPr => Self::FixPr,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MachineOutput {
+    pub schema_version: u32,
+    #[serde(flatten)]
+    pub payload: MachinePayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MachineSuspendedPayload {
+    pub command: MachineCommand,
+    pub rewrite_command_kind: MachineRewriteCommandKind,
+    pub original_worktree_root: String,
+    pub original_branch: String,
+    pub temp_branch: String,
+    pub temp_worktree: String,
+    pub resume_file: String,
+    pub resume_argv: Vec<String>,
+    pub paused_source_sha: String,
+    pub conflicted_paths: Vec<String>,
+    pub post_success_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum MachinePayload {
+    Completed {
+        command: MachineCommand,
+    },
+    Suspended {
+        #[serde(flatten)]
+        details: Box<MachineSuspendedPayload>,
+    },
+    Error {
+        command: MachineCommand,
+        message: String,
+    },
+}
+
+impl MachineOutput {
+    pub fn completed(command: MachineCommand) -> Self {
+        Self {
+            schema_version: MACHINE_OUTPUT_SCHEMA_VERSION,
+            payload: MachinePayload::Completed { command },
+        }
+    }
+
+    pub fn suspended(
+        command: MachineCommand,
+        suspended: RewriteSuspendedState,
+        post_success_hint: Option<String>,
+    ) -> Self {
+        let RewriteSuspendedState {
+            command_kind,
+            original_worktree_root,
+            original_branch,
+            temp_branch,
+            temp_worktree_path,
+            resume_path,
+            paused_source_sha,
+            conflicted_paths,
+            post_success_hint: suspended_post_success_hint,
+        } = suspended;
+        let resume_file = resume_path.display().to_string();
+        let resume_argv = vec![
+            "spr".to_string(),
+            "--cd".to_string(),
+            original_worktree_root.clone(),
+            "resume".to_string(),
+            "--json".to_string(),
+            resume_file.clone(),
+        ];
+        let post_success_hint = if let Some(post_success_hint) = post_success_hint {
+            Some(post_success_hint)
+        } else {
+            suspended_post_success_hint
+        };
+        Self {
+            schema_version: MACHINE_OUTPUT_SCHEMA_VERSION,
+            payload: MachinePayload::Suspended {
+                details: Box::new(MachineSuspendedPayload {
+                    command,
+                    rewrite_command_kind: command_kind.into(),
+                    original_worktree_root,
+                    original_branch,
+                    temp_branch,
+                    temp_worktree: temp_worktree_path,
+                    resume_file: resume_file.clone(),
+                    resume_argv,
+                    paused_source_sha,
+                    conflicted_paths,
+                    post_success_hint,
+                }),
+            },
+        }
+    }
+
+    pub fn error(command: MachineCommand, message: String) -> Self {
+        Self {
+            schema_version: MACHINE_OUTPUT_SCHEMA_VERSION,
+            payload: MachinePayload::Error { command, message },
+        }
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        if matches!(self.payload, MachinePayload::Suspended { .. }) {
+            EXIT_SUSPENDED
+        } else if matches!(self.payload, MachinePayload::Error { .. }) {
+            EXIT_FAILURE
+        } else {
+            EXIT_SUCCESS
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{
+        MachineCommand, MachineOutput, MachinePayload, MachineRewriteCommandKind,
+        MachineSuspendedPayload,
+    };
+    use crate::commands::{RewriteCommandKind, RewriteSuspendedState};
+
+    #[test]
+    fn suspended_output_carries_resume_contract() {
+        let output = MachineOutput::suspended(
+            MachineCommand::Restack,
+            RewriteSuspendedState {
+                command_kind: RewriteCommandKind::Restack,
+                original_worktree_root: "/tmp/repo".to_string(),
+                original_branch: "stack".to_string(),
+                temp_branch: "spr/tmp-restack-abc1234".to_string(),
+                temp_worktree_path: "/tmp/spr-restack-abc1234".to_string(),
+                resume_path: PathBuf::from("/tmp/repo/.git/spr/resume/restack-stack-abc1234.json"),
+                paused_source_sha: "abc1234".to_string(),
+                conflicted_paths: vec!["story.txt".to_string()],
+                post_success_hint: None,
+            },
+            None,
+        );
+
+        match output.payload {
+            MachinePayload::Suspended { details } => {
+                let MachineSuspendedPayload {
+                    command,
+                    rewrite_command_kind,
+                    resume_argv,
+                    conflicted_paths,
+                    ..
+                } = *details;
+                assert_eq!(command, MachineCommand::Restack);
+                assert_eq!(rewrite_command_kind, MachineRewriteCommandKind::Restack);
+                assert_eq!(
+                    resume_argv,
+                    vec![
+                        "spr".to_string(),
+                        "--cd".to_string(),
+                        "/tmp/repo".to_string(),
+                        "resume".to_string(),
+                        "--json".to_string(),
+                        "/tmp/repo/.git/spr/resume/restack-stack-abc1234.json".to_string()
+                    ]
+                );
+                assert_eq!(conflicted_paths, vec!["story.txt".to_string()]);
+            }
+            other => panic!("unexpected machine payload: {:?}", other),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{error::ErrorKind, Parser};
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 mod cli;
@@ -9,6 +10,7 @@ mod format;
 mod git;
 mod github;
 mod limit;
+mod machine_output;
 mod parsing;
 mod pr_labels;
 mod selectors;
@@ -55,6 +57,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
     match cmd {
         crate::cli::Cmd::Restack { .. }
         | crate::cli::Cmd::Absorb { .. }
+        | crate::cli::Cmd::Resume { .. }
         | crate::cli::Cmd::FixPr { .. } => false,
         crate::cli::Cmd::Update { .. }
         | crate::cli::Cmd::Prep {}
@@ -65,6 +68,12 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
         | crate::cli::Cmd::Cleanup {}
         | crate::cli::Cmd::Move { .. } => true,
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OutputMode {
+    Human,
+    Json,
 }
 
 fn init_tools(needs_gh: bool) -> Result<()> {
@@ -125,29 +134,78 @@ fn resolve_base_prefix(
     Ok((base, prefix, ignore_tag))
 }
 
-fn main() -> Result<()> {
-    let cli = crate::cli::Cli::parse();
-    apply_working_directory_override(cli.cd.as_deref())?;
-    if cli.verbose {
-        tracing_subscriber::fmt()
-            .with_env_filter("info")
-            .with_target(false)
-            .with_level(false)
-            .compact()
-            .init();
+fn ensure_rewrite_completed(
+    mode: OutputMode,
+    command_name: &str,
+    machine_command: crate::machine_output::MachineCommand,
+    outcome: crate::commands::RewriteCommandOutcome,
+) -> Result<crate::machine_output::MachineOutput> {
+    if outcome == crate::commands::RewriteCommandOutcome::Completed {
+        Ok(crate::machine_output::MachineOutput::completed(
+            machine_command,
+        ))
+    } else if let crate::commands::RewriteCommandOutcome::Suspended(state) = outcome {
+        if mode == OutputMode::Json {
+            Ok(crate::machine_output::MachineOutput::suspended(
+                machine_command,
+                *state,
+                None,
+            ))
+        } else {
+            Err(anyhow::anyhow!(
+                "{} suspended due to a cherry-pick conflict. Resolve the conflict in the temp worktree, stage the resolution, and run `spr resume {}`.",
+                command_name,
+                state.resume_path.display()
+            ))
+        }
     } else {
-        tracing_subscriber::fmt()
-            .with_env_filter("info")
-            .with_target(false)
-            .with_level(false)
-            .without_time()
-            .compact()
-            .init();
+        Ok(crate::machine_output::MachineOutput::completed(
+            machine_command,
+        ))
     }
-    if cli.verbose {
-        std::env::set_var("SPR_VERBOSE", "1");
+}
+
+fn ensure_resume_completed(
+    mode: OutputMode,
+    outcome: crate::commands::RewriteCommandOutcome,
+) -> Result<crate::machine_output::MachineOutput> {
+    if outcome == crate::commands::RewriteCommandOutcome::Completed {
+        Ok(crate::machine_output::MachineOutput::completed(
+            crate::machine_output::MachineCommand::Resume,
+        ))
+    } else if let crate::commands::RewriteCommandOutcome::Suspended(state) = outcome {
+        if mode == OutputMode::Json {
+            Ok(crate::machine_output::MachineOutput::suspended(
+                crate::machine_output::MachineCommand::Resume,
+                *state,
+                None,
+            ))
+        } else {
+            Err(anyhow::anyhow!(
+                "`spr resume` hit another cherry-pick conflict. Resolve the next conflict in the temp worktree, stage the resolution, and rerun `spr resume {}`.",
+                state.resume_path.display()
+            ))
+        }
+    } else {
+        Ok(crate::machine_output::MachineOutput::completed(
+            crate::machine_output::MachineCommand::Resume,
+        ))
     }
+}
+
+fn run_cli(
+    cli: crate::cli::Cli,
+    output_mode: OutputMode,
+) -> Result<crate::machine_output::MachineOutput> {
+    apply_working_directory_override(cli.cd.as_deref())?;
     init_tools(command_requires_gh(&cli.cmd))?;
+    if let crate::cli::Cmd::Resume { path, .. } = &cli.cmd {
+        return ensure_resume_completed(
+            output_mode,
+            crate::commands::resume_rewrite(cli.dry_run, path)?,
+        );
+    }
+
     let cfg = crate::config::load_config()?;
     let (base, prefix, ignore_tag) =
         resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone())?;
@@ -169,9 +227,9 @@ fn main() -> Result<()> {
             set_dry_run_env(cli.dry_run, assume_existing_prs);
             let pr_description_mode = pr_description_mode_override.unwrap_or(pr_description_mode);
             if restack {
-                return Err(anyhow::anyhow!(
+                Err(anyhow::anyhow!(
                     "`spr update --restack` is deprecated. Use `spr restack --after N` instead."
-                ));
+                ))
             } else {
                 let (_merge_base, leading_ignored, all_groups) =
                     crate::parsing::derive_groups_between_with_ignored(&base, &from, &ignore_tag)?;
@@ -209,22 +267,35 @@ fn main() -> Result<()> {
                     allow_branch_reuse,
                     branch_reuse_guard_days,
                 )?;
+                Ok(crate::machine_output::MachineOutput::completed(
+                    crate::machine_output::MachineCommand::Restack,
+                ))
             }
         }
-        crate::cli::Cmd::Restack { after, safe } => {
+        crate::cli::Cmd::Restack {
+            after,
+            safe,
+            json: _,
+        } => {
             set_dry_run_env(cli.dry_run, false);
-            crate::commands::restack_after(
-                &base,
-                &ignore_tag,
-                &after,
-                safe,
-                cli.dry_run,
-                restack_conflict_policy,
-                dirty_worktree_policy,
-            )?;
+            ensure_rewrite_completed(
+                output_mode,
+                "spr restack",
+                crate::machine_output::MachineCommand::Restack,
+                crate::commands::restack_after(
+                    &base,
+                    &ignore_tag,
+                    &after,
+                    safe,
+                    cli.dry_run,
+                    restack_conflict_policy,
+                    dirty_worktree_policy,
+                )?,
+            )
         }
         crate::cli::Cmd::Absorb {
             allow_replayed_duplicates,
+            json: _,
         } => {
             set_dry_run_env(cli.dry_run, false);
             let options = crate::commands::AbsorbOptions {
@@ -234,14 +305,19 @@ fn main() -> Result<()> {
                     crate::commands::CopiedLaterStackCommitPolicy::Block
                 },
             };
-            crate::commands::absorb_branch_tails(
-                &base,
-                &prefix,
-                &ignore_tag,
-                cli.dry_run,
-                dirty_worktree_policy,
-                options,
-            )?;
+            ensure_rewrite_completed(
+                output_mode,
+                "spr absorb",
+                crate::machine_output::MachineCommand::Absorb,
+                crate::commands::absorb_branch_tails(
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                    cli.dry_run,
+                    dirty_worktree_policy,
+                    options,
+                )?,
+            )
         }
         crate::cli::Cmd::Prep {} => {
             set_dry_run_env(cli.dry_run, false);
@@ -268,23 +344,35 @@ fn main() -> Result<()> {
                 selection,
                 cli.dry_run,
             )?;
+            Ok(crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineCommand::Restack,
+            ))
         }
-        crate::cli::Cmd::List { what } => match what {
-            crate::cli::ListWhat::Pr => {
-                crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?
+        crate::cli::Cmd::List { what } => {
+            match what {
+                crate::cli::ListWhat::Pr => {
+                    crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
+                }
+                crate::cli::ListWhat::Commit => {
+                    crate::commands::list_commits_display(&base, &prefix, &ignore_tag, list_order)?;
+                }
             }
-            crate::cli::ListWhat::Commit => {
-                crate::commands::list_commits_display(&base, &prefix, &ignore_tag, list_order)?
-            }
-        },
+            Ok(crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineCommand::Restack,
+            ))
+        }
         crate::cli::Cmd::Status {} => {
             // alias for `spr list pr`
-            crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?
+            crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
+            Ok(crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineCommand::Restack,
+            ))
         }
         crate::cli::Cmd::Land {
             which,
             r#unsafe,
             no_restack,
+            json: _,
         } => {
             set_dry_run_env(cli.dry_run, false);
             let mode = which.unwrap_or(match cfg.land.as_str() {
@@ -314,7 +402,7 @@ fn main() -> Result<()> {
             };
             if !no_restack {
                 // After landing the first N PRs, restack the remaining commits onto the latest base
-                crate::commands::restack_after_count(
+                let outcome = crate::commands::restack_after_count(
                     &base,
                     &ignore_tag,
                     landed_count,
@@ -323,53 +411,246 @@ fn main() -> Result<()> {
                     restack_conflict_policy,
                     dirty_worktree_policy,
                 )?;
+                if let crate::commands::RewriteCommandOutcome::Suspended(state) = outcome {
+                    let post_success_hint = Some(
+                        "GitHub landing already succeeded; resolve the local restack conflict and run the printed `spr resume <path>` command instead of rerunning `spr land`."
+                            .to_string(),
+                    );
+                    if output_mode == OutputMode::Json {
+                        return Ok(crate::machine_output::MachineOutput::suspended(
+                            crate::machine_output::MachineCommand::Land,
+                            *state,
+                            post_success_hint,
+                        ));
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "GitHub landing already succeeded, but the follow-on restack suspended due to a cherry-pick conflict. Resolve the conflict in the temp worktree, stage the resolution, and run `spr resume {}` instead of rerunning `spr land`.",
+                            state.resume_path.display()
+                        ));
+                    }
+                }
             }
+            Ok(crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineCommand::Land,
+            ))
         }
         crate::cli::Cmd::RelinkPrs {} => {
             set_dry_run_env(cli.dry_run, false);
             crate::commands::relink_prs(&base, &prefix, &ignore_tag, cli.dry_run)?;
+            Ok(crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineCommand::Restack,
+            ))
         }
         crate::cli::Cmd::Cleanup {} => {
             set_dry_run_env(cli.dry_run, false);
             crate::commands::cleanup_remote_branches(&prefix, cli.dry_run)?;
+            Ok(crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineCommand::Restack,
+            ))
         }
-        crate::cli::Cmd::FixPr { target, tail, safe } => {
+        crate::cli::Cmd::FixPr {
+            target,
+            tail,
+            safe,
+            json: _,
+        } => {
             set_dry_run_env(cli.dry_run, false);
-            crate::commands::fix_pr_tail(
-                &base,
-                &ignore_tag,
-                &target,
-                tail,
-                safe,
-                cli.dry_run,
-                dirty_worktree_policy,
-            )?;
-        }
-        crate::cli::Cmd::Move { range, after, safe } => {
-            set_dry_run_env(cli.dry_run, false);
-            crate::commands::move_groups_after(
-                &base,
-                &prefix,
-                &ignore_tag,
-                &range,
-                &after,
-                crate::commands::MoveExecutionOptions {
+            ensure_rewrite_completed(
+                output_mode,
+                "spr fix-pr",
+                crate::machine_output::MachineCommand::FixPr,
+                crate::commands::fix_pr_tail(
+                    &base,
+                    &ignore_tag,
+                    &target,
+                    tail,
                     safe,
-                    dry: cli.dry_run,
+                    cli.dry_run,
                     dirty_worktree_policy,
-                },
-            )?;
+                )?,
+            )
+        }
+        crate::cli::Cmd::Move {
+            range,
+            after,
+            safe,
+            json: _,
+        } => {
+            set_dry_run_env(cli.dry_run, false);
+            ensure_rewrite_completed(
+                output_mode,
+                "spr move",
+                crate::machine_output::MachineCommand::Move,
+                crate::commands::move_groups_after(
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                    &range,
+                    &after,
+                    crate::commands::MoveExecutionOptions {
+                        safe,
+                        dry: cli.dry_run,
+                        dirty_worktree_policy,
+                    },
+                )?,
+            )
+        }
+        crate::cli::Cmd::Resume { .. } => unreachable!("handled before config loading"),
+    }
+}
+
+fn init_logging(verbose: bool, output_mode: OutputMode) {
+    if output_mode == OutputMode::Json {
+        return;
+    }
+    if verbose {
+        tracing_subscriber::fmt()
+            .with_env_filter("info")
+            .with_target(false)
+            .with_level(false)
+            .compact()
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter("info")
+            .with_target(false)
+            .with_level(false)
+            .without_time()
+            .compact()
+            .init();
+    }
+    if verbose {
+        std::env::set_var("SPR_VERBOSE", "1");
+    }
+}
+
+fn raw_args_request_json(args: &[OsString]) -> bool {
+    args.iter()
+        .skip(1)
+        .any(|arg| arg.as_os_str() == OsStr::new("--json"))
+}
+
+fn machine_command_for_raw_args(args: &[OsString]) -> crate::machine_output::MachineCommand {
+    let mut skip_value = false;
+    for arg in args.iter().skip(1) {
+        if skip_value {
+            skip_value = false;
+        } else if let Some(arg) = arg.to_str() {
+            if arg == "--cd"
+                || arg == "--base"
+                || arg == "--prefix"
+                || arg == "--until"
+                || arg == "--exact"
+                || arg == "-b"
+            {
+                skip_value = true;
+            } else if arg == "restack" {
+                return crate::machine_output::MachineCommand::Restack;
+            } else if arg == "absorb" {
+                return crate::machine_output::MachineCommand::Absorb;
+            } else if arg == "move" || arg == "mv" {
+                return crate::machine_output::MachineCommand::Move;
+            } else if arg == "fix-pr" || arg == "fix" {
+                return crate::machine_output::MachineCommand::FixPr;
+            } else if arg == "resume" {
+                return crate::machine_output::MachineCommand::Resume;
+            } else if arg == "land" {
+                return crate::machine_output::MachineCommand::Land;
+            } else if !arg.starts_with('-') {
+                return crate::machine_output::MachineCommand::Cli;
+            }
         }
     }
-    Ok(())
+    crate::machine_output::MachineCommand::Cli
+}
+
+fn parse_failure_as_machine_output(
+    args: &[OsString],
+    err: &clap::Error,
+) -> Option<crate::machine_output::MachineOutput> {
+    let is_display_only = matches!(
+        err.kind(),
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+    );
+    if raw_args_request_json(args) && !is_display_only {
+        Some(crate::machine_output::MachineOutput::error(
+            machine_command_for_raw_args(args),
+            err.to_string(),
+        ))
+    } else {
+        None
+    }
+}
+
+fn main() {
+    let raw_args: Vec<OsString> = std::env::args_os().collect();
+    let cli = match crate::cli::Cli::try_parse_from(raw_args.clone()) {
+        Ok(cli) => cli,
+        Err(err) => {
+            if let Some(output) = parse_failure_as_machine_output(&raw_args, &err) {
+                println!("{}", serde_json::to_string(&output).unwrap());
+                std::process::exit(crate::machine_output::EXIT_FAILURE);
+            } else {
+                err.exit();
+            }
+        }
+    };
+    let output_mode = if cli.cmd.json_mode() {
+        OutputMode::Json
+    } else {
+        OutputMode::Human
+    };
+    init_logging(cli.verbose, output_mode);
+    let command = machine_command_for_cli(&cli.cmd);
+    match run_cli(cli, output_mode) {
+        Ok(output) => {
+            if output_mode == OutputMode::Json {
+                println!("{}", serde_json::to_string(&output).unwrap());
+                std::process::exit(output.exit_code());
+            }
+        }
+        Err(err) => {
+            if output_mode == OutputMode::Json {
+                let output =
+                    crate::machine_output::MachineOutput::error(command, format!("{err:#}"));
+                println!("{}", serde_json::to_string(&output).unwrap());
+            } else {
+                eprintln!("Error: {err:#}");
+            }
+            std::process::exit(crate::machine_output::EXIT_FAILURE);
+        }
+    }
+}
+
+fn machine_command_for_cli(cmd: &crate::cli::Cmd) -> crate::machine_output::MachineCommand {
+    match cmd {
+        crate::cli::Cmd::Restack { .. } => crate::machine_output::MachineCommand::Restack,
+        crate::cli::Cmd::Absorb { .. } => crate::machine_output::MachineCommand::Absorb,
+        crate::cli::Cmd::Resume { .. } => crate::machine_output::MachineCommand::Resume,
+        crate::cli::Cmd::Land { .. } => crate::machine_output::MachineCommand::Land,
+        crate::cli::Cmd::FixPr { .. } => crate::machine_output::MachineCommand::FixPr,
+        crate::cli::Cmd::Move { .. } => crate::machine_output::MachineCommand::Move,
+        crate::cli::Cmd::Update { .. }
+        | crate::cli::Cmd::Prep {}
+        | crate::cli::Cmd::List { .. }
+        | crate::cli::Cmd::Status {}
+        | crate::cli::Cmd::RelinkPrs {}
+        | crate::cli::Cmd::Cleanup {} => crate::machine_output::MachineCommand::Restack,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_working_directory_override, command_requires_gh, resolve_update_pr_limit};
+    use super::{
+        apply_working_directory_override, command_requires_gh, machine_command_for_raw_args,
+        parse_failure_as_machine_output, resolve_update_pr_limit,
+    };
+    use crate::machine_output::{MachineCommand, MachinePayload};
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, StableHandle};
     use crate::test_support::lock_cwd;
+    use clap::Parser;
+    use std::ffi::OsString;
     use std::fs;
     use std::path::PathBuf;
     use std::process::Command;
@@ -452,6 +733,15 @@ mod tests {
     fn absorb_is_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::Absorb {
             allow_replayed_duplicates: false,
+            json: false,
+        }));
+    }
+
+    #[test]
+    fn resume_is_local_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::Resume {
+            path: std::path::PathBuf::from(".git/spr/resume/example.json"),
+            json: false,
         }));
     }
 
@@ -483,5 +773,64 @@ mod tests {
         let actual_root = PathBuf::from(crate::git::repo_root().unwrap().unwrap());
 
         assert_eq!(fs::canonicalize(actual_root).unwrap(), expected_root);
+    }
+
+    #[test]
+    fn machine_command_for_raw_args_skips_global_option_values() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("--cd"),
+            OsString::from("/tmp/repo"),
+            OsString::from("resume"),
+            OsString::from("--json"),
+            OsString::from("state.json"),
+        ];
+
+        assert_eq!(machine_command_for_raw_args(&args), MachineCommand::Resume);
+    }
+
+    #[test]
+    fn parse_failure_with_json_returns_machine_error() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("restack"),
+            OsString::from("--json"),
+        ];
+        let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
+        let output = parse_failure_as_machine_output(&args, &err)
+            .expect("json parse failure should serialize");
+
+        match output.payload {
+            MachinePayload::Error {
+                command,
+                ref message,
+            } => {
+                assert_eq!(command, MachineCommand::Restack);
+                assert!(message.contains("--after"));
+            }
+            other => panic!("unexpected parse-failure payload: {:?}", other),
+        }
+        assert_eq!(output.exit_code(), crate::machine_output::EXIT_FAILURE);
+    }
+
+    #[test]
+    fn parse_failure_without_json_stays_human() {
+        let args = vec![OsString::from("spr"), OsString::from("restack")];
+        let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
+
+        assert!(parse_failure_as_machine_output(&args, &err).is_none());
+    }
+
+    #[test]
+    fn help_request_with_json_stays_human() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("restack"),
+            OsString::from("--json"),
+            OsString::from("--help"),
+        ];
+        let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected help output");
+
+        assert!(parse_failure_as_machine_output(&args, &err).is_none());
     }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,5 +1,7 @@
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Mutex, MutexGuard};
 
 static PROCESS_CWD_LOCK: Mutex<()> = Mutex::new(());
@@ -26,4 +28,43 @@ impl Drop for DirGuard {
     fn drop(&mut self) {
         env::set_current_dir(&self.original).expect("restore original current dir");
     }
+}
+
+pub(crate) fn git(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+pub(crate) fn write_file(repo: &Path, file: &str, contents: &str) {
+    fs::write(repo.join(file), contents).expect("write file");
+}
+
+pub(crate) fn commit_file(repo: &Path, file: &str, contents: &str, message: &str) -> String {
+    write_file(repo, file, contents);
+    git(repo, ["add", file].as_slice());
+    git(repo, ["commit", "-m", message].as_slice());
+    git(repo, ["rev-parse", "HEAD"].as_slice())
+        .trim()
+        .to_string()
+}
+
+pub(crate) fn log_subjects(repo: &Path, count: usize) -> Vec<String> {
+    git(
+        repo,
+        ["log", "--format=%s", &format!("-{}", count)].as_slice(),
+    )
+    .lines()
+    .map(|line| line.to_string())
+    .collect()
 }


### PR DESCRIPTION
Before this change, a conflict during `spr absorb`, `spr restack`, `spr move`, or `spr fix-pr` could strand the operator in a temp worktree with a raw Git cherry-pick state and no first-class way back into `spr`. The rewrite commands now persist resumable state, print the original branch alongside the temp worktree and resume path, and resume the replay through `spr resume` after the conflict is resolved and staged.

Each rewrite command now drives the same shared replay engine. When a replayed commit conflicts, `spr` records the paused step under the repository common Git dir, leaves the temp worktree intact, and returns control to the operator. After the operator resolves and stages the current conflict in that temp worktree, `spr resume <path>` continues the remaining replay steps.

Human mode and JSON mode are separate UI surfaces over the same rewrite engine. In JSON mode, `spr restack`, `spr absorb`, `spr move`, `spr fix-pr`, `spr land`, and `spr resume` emit one structured stdout object, keep stderr quiet by default, and use exit code `2` to mean "the rewrite suspended and needs resume".

`restack_conflict` now defaults to `halt` so the resume flow can preserve the conflicted state instead of discarding it immediately. That is a deliberate behavior change from automatic rollback, but explicit `rollback` mode remains available for users who want the old cleanup behavior.

This change set deliberately grows the rewrite engine in order to preserve operator recovery guarantees across both human and machine callers.

- Introduce a shared rewrite-resume engine with typed replay steps and durable resume files, and move the local rewrite commands onto that engine.
- Harden resume validation so it rejects unrelated manual history surgery while still tolerating Git's own range-sequencer auto-advance and other already-advanced replay states.
- Add a dedicated machine-output module and extend the CLI surface with `--json` for each conflict-capable rewrite command plus `spr resume`.
- Keep `resume_argv` self-contained by carrying both `--cd` and `--json`, and keep `--json` parse failures inside the same machine-readable error envelope.
- Preserve the tuple-style suspended output contract across the absorb integration follow-up so callers do not need per-command JSON shape exceptions.

Suspension output now tells the operator which original branch is paused, which temp worktree and temp branch hold the conflict, and which `spr resume` command continues the rewrite. In JSON mode, the suspended payload reports the original branch, temp branch, temp worktree, resume file, resume argv, paused source commit, conflicted paths, and optional post-success hints in one structured response.

Validation:
- cargo clippy --tests
- cargo fmt
- cargo test
- temp-repo conflict and resume coverage for `restack`, `absorb`, `move`, and `fix-pr`
- machine-mode suspension/resume proofs including verbatim `resume_argv` replay from outside the repo

<!-- spr-stack:start -->
**Stack**:
-   #120
-   #119
- ➡ #118

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->