### PR TITLE
resume: relaunch untouched range suffixes after paused conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,8 +195,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -198,12 +217,21 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -213,6 +241,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -255,6 +284,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -348,6 +383,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +415,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
@@ -429,10 +480,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -509,6 +572,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -535,7 +599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -557,6 +621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -654,6 +719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +735,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -681,6 +763,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +779,7 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -735,6 +827,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -927,3 +1053,85 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 indicatif = "0.17"
-time = { version = "0.3", features = ["parsing"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
+uuid = { version = "1.18", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ spr update
 spr list pr
 spr list commit
 
+# Discover which stack branch owns a canonical PR branch
+spr resolve-stack dank-spr/alpha
+
 # After appending commits directly to canonical local per-PR branches,
 # fold those tails back into the checked-out stack branch.
 spr absorb
@@ -253,6 +256,39 @@ Override example for intentionally keeping both an earlier copied follow-up comm
 
 ```bash
 spr absorb --allow-replayed-duplicates
+```
+
+### spr resolve-stack
+
+Resolve a canonical PR branch back to its owning stack branch using repo-local
+metadata stored under the repository common Git directory:
+
+- Metadata path: `<git-common-dir>/spr/stack_metadata_v1.json`
+- Metadata is refreshed after successful `spr update`, `spr restack`,
+  `spr absorb`, `spr move`, `spr fix-pr`, `spr resume`, and `spr land` when it
+  also finishes the local follow-on restack
+- Supported targets:
+  - no argument: current branch
+  - local branch name such as `dank-spr/alpha`
+  - remote-qualified branch name such as `origin/dank-spr/alpha`
+  - GitHub PR URL
+- JSON mode returns typed states such as `found`, `already_stack_branch`,
+  `missing_metadata`, `stale_metadata`, `tombstoned`, `ambiguous`, and
+  `invalid_target`
+- This command is strict and local-only after target normalization: it does not
+  scan unrelated branches or repair stale metadata
+
+Examples:
+
+```bash
+# PR branch -> owning stack branch
+spr resolve-stack dank-spr/alpha
+
+# Current branch
+spr resolve-stack
+
+# Automation-friendly JSON
+spr resolve-stack --json https://github.com/org/repo/pull/123
 ```
 
 ### spr resume

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,6 +136,18 @@ pub enum Cmd {
         // no options; uses global flags
     },
 
+    /// Find the owning stack branch for a PR branch or report that the target is already a stack branch
+    #[command(
+        long_about = "Find the owning stack branch for a PR branch using repo-local stack metadata.\n\nTargets may be omitted (use the current branch), a local branch name, a remote-qualified branch name such as `origin/dank-spr/alpha`, or a GitHub PR URL. This command is strict and metadata-backed: it does not scan unrelated branches or guess a likely owner."
+    )]
+    ResolveStack {
+        /// Optional target: current branch, local branch, remote-qualified branch, or PR URL
+        target: Option<String>,
+        /// Emit machine-readable JSON result states such as `found`, `stale_metadata`, or `tombstoned`
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Land PRs (merge variants) and halt early on case-colliding synthetic branch names
     Land {
         // Target PR index is provided via global --until. For `flatten`, 0 means the top PR. For `per-pr`, 0 means all
@@ -201,6 +213,7 @@ impl Cmd {
         match self {
             Self::Restack { json, .. }
             | Self::Absorb { json, .. }
+            | Self::ResolveStack { json, .. }
             | Self::Resume { json, .. }
             | Self::Land { json, .. }
             | Self::FixPr { json, .. }

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -69,7 +69,7 @@ pub fn absorb_branch_tails(
             Ok(RewriteCommandOutcome::Completed)
         }
         AbsorbPlanValidation::ReadyToRewrite => {
-            execute_absorb_plan(&plan, dry, dirty_worktree_policy)
+            execute_absorb_plan(base, prefix, ignore_tag, &plan, dry, dirty_worktree_policy)
         }
     }
 }
@@ -937,6 +937,9 @@ fn build_replay_ops_for_commits(
 /// Executes a validated absorb rewrite plan by rebuilding the current stack in
 /// a temporary worktree and resetting the checked-out branch to the new tip.
 fn execute_absorb_plan(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
     plan: &RewritePlan,
     dry: bool,
     dirty_worktree_policy: DirtyWorktreePolicy,
@@ -982,6 +985,13 @@ fn execute_absorb_plan(
                     post_success_hint: Some(
                         "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
                             .to_string(),
+                    ),
+                    metadata_refresh_context: Some(
+                        crate::stack_metadata::RefreshMetadataContext {
+                            base: base.to_string(),
+                            prefix: prefix.to_string(),
+                            ignore_tag: ignore_tag.to_string(),
+                        },
                     ),
                 },
             )

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -588,7 +588,7 @@ pub enum CherryPickEmptyPolicy {
     KeepRedundantCommits,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CherryPickOp {
     /// Cherry-pick exactly one commit.
     Commit {

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -451,10 +451,16 @@ mod tests {
             let resume_state: RewriteResumeState =
                 serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
                     .expect("parse resume state");
-            let paused_step = &resume_state.steps[resume_state.suspended_step_index];
             let paused_subject = git(
                 &repo,
-                ["log", "-n", "1", "--format=%s", &paused_step.source_sha].as_slice(),
+                [
+                    "log",
+                    "-n",
+                    "1",
+                    "--format=%s",
+                    &resume_state.paused_step.source_sha,
+                ]
+                .as_slice(),
             );
             let resolved_contents = if paused_subject.trim() == "fix review comment" {
                 "review-fix\n"
@@ -558,10 +564,16 @@ mod tests {
             let resume_state: RewriteResumeState =
                 serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
                     .expect("parse resume state");
-            let paused_step = &resume_state.steps[resume_state.suspended_step_index];
             let paused_subject = git(
                 &repo,
-                ["log", "-n", "1", "--format=%s", &paused_step.source_sha].as_slice(),
+                [
+                    "log",
+                    "-n",
+                    "1",
+                    "--format=%s",
+                    &resume_state.paused_step.source_sha,
+                ]
+                .as_slice(),
             );
             let resolved_contents = if paused_subject.trim() == "fix review comment" {
                 "review-fix\n"

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -47,8 +47,7 @@ fn build_fix_pr_operations(
 /// `pr:<tag>` markers, when the tail intersects ignored commits, or when Git
 /// operations (worktree creation, cherry-picks, reset) fail.
 pub fn fix_pr_tail(
-    base: &str,
-    ignore_tag: &str,
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     target: &GroupSelector,
     tail_count: usize,
     safe: bool,
@@ -59,7 +58,8 @@ pub fn fix_pr_tail(
         return Ok(RewriteCommandOutcome::Completed);
     }
 
-    let (merge_base, leading_ignored, groups) = derive_local_groups_with_ignored(base, ignore_tag)?;
+    let (merge_base, leading_ignored, groups) =
+        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
     let total_groups = groups.len();
     if total_groups == 0 {
         info!("No local PR groups found; nothing to fix.");
@@ -191,6 +191,7 @@ pub fn fix_pr_tail(
                     "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
                         .to_string(),
                 ),
+                metadata_refresh_context: Some(metadata_context.clone()),
             },
         )
         },
@@ -210,6 +211,14 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
     use tempfile::TempDir;
+
+    fn metadata_context() -> crate::stack_metadata::RefreshMetadataContext {
+        crate::stack_metadata::RefreshMetadataContext {
+            base: "main".to_string(),
+            prefix: "dank-spr/".to_string(),
+            ignore_tag: "ignore".to_string(),
+        }
+    }
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
@@ -339,8 +348,7 @@ mod tests {
         dirty_worktree(&repo);
 
         fix_pr_tail(
-            "main",
-            "ignore",
+            &metadata_context(),
             &GroupSelector::LocalPr(1),
             1,
             false,
@@ -379,8 +387,7 @@ mod tests {
         dirty_worktree(&repo);
 
         fix_pr_tail(
-            "main",
-            "ignore",
+            &metadata_context(),
             &GroupSelector::LocalPr(1),
             1,
             false,
@@ -422,8 +429,7 @@ mod tests {
         dirty_worktree(&repo);
 
         let mut current = fix_pr_tail(
-            "main",
-            "ignore",
+            &metadata_context(),
             &GroupSelector::LocalPr(1),
             1,
             false,
@@ -507,8 +513,7 @@ mod tests {
         dirty_worktree(&repo);
 
         let err = fix_pr_tail(
-            "main",
-            "ignore",
+            &metadata_context(),
             &GroupSelector::LocalPr(1),
             1,
             false,
@@ -548,8 +553,7 @@ mod tests {
         let _guard = DirGuard::change_to(&repo);
 
         let outcome = fix_pr_tail(
-            "main",
-            "ignore",
+            &metadata_context(),
             &GroupSelector::LocalPr(1),
             1,
             false,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod list;
 pub mod r#move;
 pub mod prep;
 pub mod relink_prs;
+pub mod resolve_stack;
 pub mod restack;
 pub mod rewrite_resume;
 pub mod update;
@@ -20,6 +21,7 @@ pub use list::list_prs_display;
 pub use prep::prep_squash;
 pub use r#move::{move_groups_after, MoveExecutionOptions};
 pub use relink_prs::relink_prs;
+pub use resolve_stack::{looks_like_pr_url, resolve_stack, ResolveStackOutput};
 pub use restack::{restack_after, restack_after_count};
 pub use rewrite_resume::{
     resume_rewrite, RewriteCommandKind, RewriteCommandOutcome, RewriteSuspendedState,

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -431,10 +431,16 @@ mod tests {
             let resume_state: RewriteResumeState =
                 serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
                     .expect("parse resume state");
-            let paused_step = &resume_state.steps[resume_state.suspended_step_index];
             let paused_subject = git(
                 &repo,
-                ["log", "-n", "1", "--format=%s", &paused_step.source_sha].as_slice(),
+                [
+                    "log",
+                    "-n",
+                    "1",
+                    "--format=%s",
+                    &resume_state.paused_step.source_sha,
+                ]
+                .as_slice(),
             );
             let resolved_contents = if paused_subject.trim() == "feat: gamma pr:gamma" {
                 "gamma-1\n"

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -255,6 +255,13 @@ pub fn move_groups_after(
                         "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
                             .to_string(),
                     ),
+                    metadata_refresh_context: Some(
+                        crate::stack_metadata::RefreshMetadataContext {
+                            base: base.to_string(),
+                            prefix: prefix.to_string(),
+                            ignore_tag: ignore_tag.to_string(),
+                        },
+                    ),
                 },
             )
         },

--- a/src/commands/resolve_stack.rs
+++ b/src/commands/resolve_stack.rs
@@ -1,0 +1,852 @@
+//! Read-only stack discovery backed by repo-local stack metadata.
+
+use anyhow::{anyhow, bail, Result};
+use serde::Serialize;
+
+use crate::git::{git_ref_exists_at, git_ro_in, repo_root};
+use crate::github::resolve_pr_url_head_ref;
+use crate::stack_metadata::{
+    current_branch_or_none, load_metadata_for_repo_path, stack_ids_for_branch,
+    verify_stack_branch_for_pr_record, verify_stack_branch_for_stack_id, PrBranchName,
+    PrBranchRecord, StackBranchName, StackMetadataFile, TombstoneReason,
+};
+
+const RESOLVE_STACK_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolveStackTargetKind {
+    PrBranch,
+    StackBranch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResolveStackDiagnostic {
+    DetachedHead,
+    MissingRemoteTrackingRef {
+        remote_ref: String,
+    },
+    MultipleMatchingStacks {
+        branch: String,
+        stack_ids: Vec<String>,
+    },
+    PreferredBranchDidNotVerify {
+        branch: String,
+    },
+    ResolvedPrUrl {
+        url: String,
+        head_ref_name: String,
+    },
+    UnrecordedCurrentBranch {
+        branch: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolveStackOutput {
+    pub schema_version: u32,
+    #[serde(flatten)]
+    pub payload: ResolveStackPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ResolveStackPayload {
+    Found {
+        target_kind: ResolveStackTargetKind,
+        normalized_target: String,
+        stack_id: String,
+        stack_branch: String,
+        preferred_branch: String,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+    AlreadyStackBranch {
+        target_kind: ResolveStackTargetKind,
+        normalized_target: String,
+        stack_id: String,
+        stack_branch: String,
+        preferred_branch: String,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+    MissingMetadata {
+        target_kind: ResolveStackTargetKind,
+        normalized_target: String,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+    StaleMetadata {
+        target_kind: ResolveStackTargetKind,
+        normalized_target: String,
+        stack_id: Option<String>,
+        preferred_branch: Option<String>,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+    Tombstoned {
+        target_kind: ResolveStackTargetKind,
+        normalized_target: String,
+        stack_id: String,
+        preferred_branch: Option<String>,
+        tombstone_reason: TombstoneReason,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+    Ambiguous {
+        target_kind: ResolveStackTargetKind,
+        normalized_target: String,
+        stack_id: Option<String>,
+        preferred_branch: Option<String>,
+        candidate_branches: Vec<String>,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+    InvalidTarget {
+        target_kind: Option<ResolveStackTargetKind>,
+        normalized_target: Option<String>,
+        diagnostics: Vec<ResolveStackDiagnostic>,
+    },
+}
+
+impl ResolveStackOutput {
+    fn new(payload: ResolveStackPayload) -> Self {
+        Self {
+            schema_version: RESOLVE_STACK_SCHEMA_VERSION,
+            payload,
+        }
+    }
+
+    pub fn render_human(&self) -> String {
+        match &self.payload {
+            ResolveStackPayload::Found { stack_branch, .. }
+            | ResolveStackPayload::AlreadyStackBranch { stack_branch, .. } => stack_branch.clone(),
+            ResolveStackPayload::MissingMetadata {
+                normalized_target, ..
+            } => format!("No stack metadata recorded for {}.", normalized_target),
+            ResolveStackPayload::StaleMetadata {
+                normalized_target, ..
+            } => format!("Stack metadata for {} is stale.", normalized_target),
+            ResolveStackPayload::Tombstoned {
+                normalized_target, ..
+            } => format!("{} is tombstoned in stack metadata.", normalized_target),
+            ResolveStackPayload::Ambiguous {
+                normalized_target,
+                candidate_branches,
+                ..
+            } => format!(
+                "Stack metadata for {} is ambiguous: {}",
+                normalized_target,
+                candidate_branches.join(", ")
+            ),
+            ResolveStackPayload::InvalidTarget {
+                normalized_target, ..
+            } => {
+                if let Some(normalized_target) = normalized_target {
+                    format!(
+                        "{} is not a supported stack-discovery target.",
+                        normalized_target
+                    )
+                } else {
+                    "The current checkout is not a supported stack-discovery target.".to_string()
+                }
+            }
+        }
+    }
+}
+
+fn configured_remote_names(repo_path: &str) -> Result<Vec<String>> {
+    Ok(git_ro_in(repo_path, ["remote"].as_slice())?
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+pub fn looks_like_pr_url(target: &str) -> bool {
+    (target.starts_with("https://github.com/") || target.starts_with("http://github.com/"))
+        && target.contains("/pull/")
+}
+
+fn resolve_stack_branch_target(
+    repo_path: &str,
+    metadata: &StackMetadataFile,
+    branch_name: &str,
+    ignore_tag: &str,
+) -> Result<ResolveStackOutput> {
+    let stack_ids = stack_ids_for_branch(metadata, branch_name);
+    if stack_ids.len() > 1 {
+        return Ok(ResolveStackOutput::new(ResolveStackPayload::Ambiguous {
+            target_kind: ResolveStackTargetKind::StackBranch,
+            normalized_target: branch_name.to_string(),
+            stack_id: None,
+            preferred_branch: None,
+            candidate_branches: vec![branch_name.to_string()],
+            diagnostics: vec![ResolveStackDiagnostic::MultipleMatchingStacks {
+                branch: branch_name.to_string(),
+                stack_ids: stack_ids.into_iter().map(|stack_id| stack_id.0).collect(),
+            }],
+        }));
+    }
+
+    let Some(stack_id) = stack_ids.into_iter().next() else {
+        bail!("resolve_stack_branch_target called without a matching recorded stack");
+    };
+    let stack_record = metadata
+        .stacks
+        .get(&stack_id)
+        .ok_or_else(|| anyhow!("recorded stack_id {} is missing stack metadata", stack_id.0))?;
+    if verify_stack_branch_for_stack_id(
+        repo_path,
+        metadata,
+        &StackBranchName(branch_name.to_string()),
+        &stack_id,
+        ignore_tag,
+    )? {
+        Ok(ResolveStackOutput::new(
+            ResolveStackPayload::AlreadyStackBranch {
+                target_kind: ResolveStackTargetKind::StackBranch,
+                normalized_target: branch_name.to_string(),
+                stack_id: stack_id.0.clone(),
+                stack_branch: branch_name.to_string(),
+                preferred_branch: stack_record.preferred_branch.0.clone(),
+                diagnostics: Vec::new(),
+            },
+        ))
+    } else {
+        Ok(ResolveStackOutput::new(
+            ResolveStackPayload::StaleMetadata {
+                target_kind: ResolveStackTargetKind::StackBranch,
+                normalized_target: branch_name.to_string(),
+                stack_id: Some(stack_id.0.clone()),
+                preferred_branch: Some(stack_record.preferred_branch.0.clone()),
+                diagnostics: Vec::new(),
+            },
+        ))
+    }
+}
+
+fn resolve_pr_branch_target(
+    repo_path: &str,
+    metadata: Option<&StackMetadataFile>,
+    pr_branch_name: &str,
+    ignore_tag: &str,
+    mut diagnostics: Vec<ResolveStackDiagnostic>,
+) -> Result<ResolveStackOutput> {
+    let Some(metadata) = metadata else {
+        return Ok(ResolveStackOutput::new(
+            ResolveStackPayload::MissingMetadata {
+                target_kind: ResolveStackTargetKind::PrBranch,
+                normalized_target: pr_branch_name.to_string(),
+                diagnostics,
+            },
+        ));
+    };
+    let branch_name = PrBranchName(pr_branch_name.to_string());
+    let Some(record) = metadata.pr_branches.get(&branch_name) else {
+        return Ok(ResolveStackOutput::new(
+            ResolveStackPayload::MissingMetadata {
+                target_kind: ResolveStackTargetKind::PrBranch,
+                normalized_target: pr_branch_name.to_string(),
+                diagnostics,
+            },
+        ));
+    };
+
+    match record {
+        PrBranchRecord::Tombstoned {
+            stack_id,
+            tombstone_reason,
+            ..
+        } => {
+            let preferred_branch = metadata
+                .stacks
+                .get(stack_id)
+                .map(|stack_record| stack_record.preferred_branch.0.clone());
+            Ok(ResolveStackOutput::new(ResolveStackPayload::Tombstoned {
+                target_kind: ResolveStackTargetKind::PrBranch,
+                normalized_target: pr_branch_name.to_string(),
+                stack_id: stack_id.0.clone(),
+                preferred_branch,
+                tombstone_reason: tombstone_reason.clone(),
+                diagnostics,
+            }))
+        }
+        PrBranchRecord::Live { stack_id, .. } => {
+            let stack_record = metadata.stacks.get(stack_id).ok_or_else(|| {
+                anyhow!(
+                    "recorded stack_id {} is missing stack metadata for {}",
+                    stack_id.0,
+                    pr_branch_name
+                )
+            })?;
+            let live_record = record.as_live().ok_or_else(|| {
+                anyhow!(
+                    "live PR branch record unexpectedly downgraded for {}",
+                    pr_branch_name
+                )
+            })?;
+            if verify_stack_branch_for_pr_record(
+                repo_path,
+                &stack_record.preferred_branch,
+                stack_record,
+                &branch_name,
+                live_record.clone(),
+                ignore_tag,
+            )? {
+                return Ok(ResolveStackOutput::new(ResolveStackPayload::Found {
+                    target_kind: ResolveStackTargetKind::PrBranch,
+                    normalized_target: pr_branch_name.to_string(),
+                    stack_id: stack_id.0.clone(),
+                    stack_branch: stack_record.preferred_branch.0.clone(),
+                    preferred_branch: stack_record.preferred_branch.0.clone(),
+                    diagnostics,
+                }));
+            }
+
+            diagnostics.push(ResolveStackDiagnostic::PreferredBranchDidNotVerify {
+                branch: stack_record.preferred_branch.0.clone(),
+            });
+            let verified_aliases = stack_record
+                .known_branches
+                .iter()
+                .filter(|candidate| **candidate != stack_record.preferred_branch)
+                .map(|candidate| -> Result<Option<String>> {
+                    if verify_stack_branch_for_pr_record(
+                        repo_path,
+                        candidate,
+                        stack_record,
+                        &branch_name,
+                        live_record.clone(),
+                        ignore_tag,
+                    )? {
+                        Ok(Some(candidate.0.clone()))
+                    } else {
+                        Ok(None)
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            if verified_aliases.len() == 1 {
+                Ok(ResolveStackOutput::new(ResolveStackPayload::Found {
+                    target_kind: ResolveStackTargetKind::PrBranch,
+                    normalized_target: pr_branch_name.to_string(),
+                    stack_id: stack_id.0.clone(),
+                    stack_branch: verified_aliases[0].clone(),
+                    preferred_branch: stack_record.preferred_branch.0.clone(),
+                    diagnostics,
+                }))
+            } else if verified_aliases.len() > 1 {
+                Ok(ResolveStackOutput::new(ResolveStackPayload::Ambiguous {
+                    target_kind: ResolveStackTargetKind::PrBranch,
+                    normalized_target: pr_branch_name.to_string(),
+                    stack_id: Some(stack_id.0.clone()),
+                    preferred_branch: Some(stack_record.preferred_branch.0.clone()),
+                    candidate_branches: verified_aliases,
+                    diagnostics,
+                }))
+            } else {
+                Ok(ResolveStackOutput::new(
+                    ResolveStackPayload::StaleMetadata {
+                        target_kind: ResolveStackTargetKind::PrBranch,
+                        normalized_target: pr_branch_name.to_string(),
+                        stack_id: Some(stack_id.0.clone()),
+                        preferred_branch: Some(stack_record.preferred_branch.0.clone()),
+                        diagnostics,
+                    },
+                ))
+            }
+        }
+    }
+}
+
+fn resolve_branch_target(
+    repo_path: &str,
+    metadata: Option<&StackMetadataFile>,
+    branch_name: &str,
+    ignore_tag: &str,
+) -> Result<ResolveStackOutput> {
+    if let Some(metadata) = metadata {
+        if !stack_ids_for_branch(metadata, branch_name).is_empty() {
+            return resolve_stack_branch_target(repo_path, metadata, branch_name, ignore_tag);
+        }
+    }
+    resolve_pr_branch_target(repo_path, metadata, branch_name, ignore_tag, Vec::new())
+}
+
+fn resolve_explicit_target(
+    repo_path: &str,
+    metadata: Option<&StackMetadataFile>,
+    target: &str,
+    ignore_tag: &str,
+) -> Result<ResolveStackOutput> {
+    if looks_like_pr_url(target) {
+        let head_ref_name = resolve_pr_url_head_ref(target)?;
+        let diagnostics = vec![ResolveStackDiagnostic::ResolvedPrUrl {
+            url: target.to_string(),
+            head_ref_name: head_ref_name.clone(),
+        }];
+        return resolve_pr_branch_target(
+            repo_path,
+            metadata,
+            &head_ref_name,
+            ignore_tag,
+            diagnostics,
+        );
+    }
+
+    let remote_names = configured_remote_names(repo_path)?;
+    if let Some((remote_name, branch_name)) = target.split_once('/') {
+        if remote_names
+            .iter()
+            .any(|candidate| candidate == remote_name)
+        {
+            let remote_reference = format!("refs/remotes/{target}");
+            if !git_ref_exists_at(repo_path, &remote_reference)? {
+                return Ok(ResolveStackOutput::new(
+                    ResolveStackPayload::InvalidTarget {
+                        target_kind: Some(ResolveStackTargetKind::PrBranch),
+                        normalized_target: Some(target.to_string()),
+                        diagnostics: vec![ResolveStackDiagnostic::MissingRemoteTrackingRef {
+                            remote_ref: target.to_string(),
+                        }],
+                    },
+                ));
+            }
+            return resolve_branch_target(repo_path, metadata, branch_name, ignore_tag);
+        }
+    }
+
+    resolve_branch_target(repo_path, metadata, target, ignore_tag)
+}
+
+fn resolve_current_branch_target(
+    repo_path: &str,
+    metadata: Option<&StackMetadataFile>,
+    ignore_tag: &str,
+) -> Result<ResolveStackOutput> {
+    let Some(current_branch) = current_branch_or_none(repo_path)? else {
+        return Ok(ResolveStackOutput::new(
+            ResolveStackPayload::InvalidTarget {
+                target_kind: None,
+                normalized_target: None,
+                diagnostics: vec![ResolveStackDiagnostic::DetachedHead],
+            },
+        ));
+    };
+
+    if let Some(metadata) = metadata {
+        if !stack_ids_for_branch(metadata, &current_branch).is_empty() {
+            return resolve_stack_branch_target(repo_path, metadata, &current_branch, ignore_tag);
+        }
+        if metadata
+            .pr_branches
+            .contains_key(&PrBranchName(current_branch.clone()))
+        {
+            return resolve_pr_branch_target(
+                repo_path,
+                Some(metadata),
+                &current_branch,
+                ignore_tag,
+                Vec::new(),
+            );
+        }
+    }
+
+    Ok(ResolveStackOutput::new(
+        ResolveStackPayload::InvalidTarget {
+            target_kind: Some(ResolveStackTargetKind::PrBranch),
+            normalized_target: Some(current_branch.clone()),
+            diagnostics: vec![ResolveStackDiagnostic::UnrecordedCurrentBranch {
+                branch: current_branch,
+            }],
+        },
+    ))
+}
+
+pub fn resolve_stack(target: Option<String>, ignore_tag: &str) -> Result<ResolveStackOutput> {
+    let repo_path = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
+    let metadata = load_metadata_for_repo_path(&repo_path)?;
+    if let Some(target) = target {
+        resolve_explicit_target(&repo_path, metadata.as_ref(), &target, ignore_tag)
+    } else {
+        resolve_current_branch_target(&repo_path, metadata.as_ref(), ignore_tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        looks_like_pr_url, resolve_stack, ResolveStackDiagnostic, ResolveStackOutput,
+        ResolveStackPayload,
+    };
+    use crate::stack_metadata::{
+        load_metadata_for_repo_path, metadata_path, refresh_metadata_for_branch,
+        RefreshMetadataContext, StackBranchName,
+    };
+    use crate::test_support::{commit_file, git, lock_cwd, DirGuard};
+    use std::env;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    const STACK_BRANCH: &str = "dank/stack";
+    const PREFIX: &str = "dank-spr/";
+    const IGNORE_TAG: &str = "ignore";
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            let original = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.original {
+                env::set_var(self.key, value);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    struct TestRepo {
+        _dir: TempDir,
+        repo: PathBuf,
+        alpha_tip: String,
+    }
+
+    impl TestRepo {
+        fn init() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let repo = dir.path().join("repo");
+            fs::create_dir_all(&repo).unwrap();
+            git(&repo, ["init", "-b", "main"].as_slice());
+            git(
+                &repo,
+                ["config", "user.email", "spr@example.com"].as_slice(),
+            );
+            git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+            commit_file(&repo, "story.txt", "base\n", "init");
+            git(&repo, ["checkout", "-b", STACK_BRANCH].as_slice());
+            commit_file(&repo, "story.txt", "alpha-1\n", "feat: alpha\n\npr:alpha");
+            let alpha_tip = commit_file(&repo, "story.txt", "alpha-2\n", "feat: alpha follow-up");
+            commit_file(&repo, "story.txt", "beta-1\n", "feat: beta\n\npr:beta");
+            Self {
+                _dir: dir,
+                repo,
+                alpha_tip,
+            }
+        }
+
+        fn repo_path(&self) -> &Path {
+            &self.repo
+        }
+
+        fn refresh_metadata(&self, branch: &str) {
+            refresh_metadata_for_branch(
+                self.repo.to_str().unwrap(),
+                branch,
+                &RefreshMetadataContext {
+                    base: "main".to_string(),
+                    prefix: PREFIX.to_string(),
+                    ignore_tag: IGNORE_TAG.to_string(),
+                },
+                None,
+            )
+            .unwrap();
+        }
+
+        fn metadata_path(&self) -> PathBuf {
+            let git_common_dir =
+                crate::git::git_common_dir_at(self.repo.to_str().unwrap()).unwrap();
+            metadata_path(&git_common_dir)
+        }
+
+        fn rewrite_stack_branch(&self, commits: &[(&str, &str)]) {
+            git(
+                &self.repo,
+                ["checkout", "-B", STACK_BRANCH, "main"].as_slice(),
+            );
+            for (contents, message) in commits {
+                commit_file(&self.repo, "story.txt", contents, message);
+            }
+        }
+
+        fn with_cwd<T>(&self, f: impl FnOnce() -> T) -> T {
+            let _lock = lock_cwd();
+            let _guard = DirGuard::change_to(&self.repo);
+            f()
+        }
+    }
+
+    fn install_gh_wrapper(script_body: &str) -> (TempDir, EnvVarGuard) {
+        let wrapper_dir = tempfile::tempdir().unwrap();
+        let script_path = wrapper_dir.path().join("gh");
+        fs::write(&script_path, script_body).unwrap();
+        let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).unwrap();
+
+        let original_path = env::var("PATH").unwrap_or_default();
+        let path_guard = EnvVarGuard::set(
+            "PATH",
+            format!("{}:{}", wrapper_dir.path().display(), original_path),
+        );
+
+        (wrapper_dir, path_guard)
+    }
+
+    fn read_metadata(repo: &TestRepo) -> crate::stack_metadata::StackMetadataFile {
+        load_metadata_for_repo_path(repo.repo.to_str().unwrap())
+            .unwrap()
+            .unwrap()
+    }
+
+    fn write_metadata(repo: &TestRepo, metadata: &crate::stack_metadata::StackMetadataFile) {
+        fs::write(
+            repo.metadata_path(),
+            serde_json::to_string_pretty(metadata).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn assert_status(output: ResolveStackOutput) -> ResolveStackPayload {
+        output.payload
+    }
+
+    #[test]
+    fn resolve_stack_returns_found_for_pr_branch() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(resolve_stack(Some("dank-spr/alpha".to_string()), IGNORE_TAG).unwrap())
+        });
+
+        match payload {
+            ResolveStackPayload::Found {
+                stack_branch,
+                preferred_branch,
+                ..
+            } => {
+                assert_eq!(stack_branch, STACK_BRANCH);
+                assert_eq!(preferred_branch, STACK_BRANCH);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_returns_already_stack_branch_without_target() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+
+        let payload = repo.with_cwd(|| assert_status(resolve_stack(None, IGNORE_TAG).unwrap()));
+
+        match payload {
+            ResolveStackPayload::AlreadyStackBranch { stack_branch, .. } => {
+                assert_eq!(stack_branch, STACK_BRANCH);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_returns_invalid_target_for_detached_head() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+        git(
+            repo.repo_path(),
+            ["checkout", "--detach", "HEAD"].as_slice(),
+        );
+
+        let payload = repo.with_cwd(|| assert_status(resolve_stack(None, IGNORE_TAG).unwrap()));
+
+        match payload {
+            ResolveStackPayload::InvalidTarget {
+                diagnostics,
+                normalized_target,
+                ..
+            } => {
+                assert!(normalized_target.is_none());
+                assert_eq!(diagnostics, vec![ResolveStackDiagnostic::DetachedHead]);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_returns_missing_metadata_for_unknown_pr_branch() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(resolve_stack(Some("dank-spr/gamma".to_string()), IGNORE_TAG).unwrap())
+        });
+
+        match payload {
+            ResolveStackPayload::MissingMetadata {
+                normalized_target, ..
+            } => assert_eq!(normalized_target, "dank-spr/gamma"),
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_returns_tombstoned_for_retired_pr_branch() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+        git(
+            repo.repo_path(),
+            ["reset", "--hard", &repo.alpha_tip].as_slice(),
+        );
+        repo.refresh_metadata(STACK_BRANCH);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(resolve_stack(Some("dank-spr/beta".to_string()), IGNORE_TAG).unwrap())
+        });
+
+        match payload {
+            ResolveStackPayload::Tombstoned {
+                normalized_target, ..
+            } => assert_eq!(normalized_target, "dank-spr/beta"),
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_returns_stale_metadata_when_recorded_owner_no_longer_verifies() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+        repo.rewrite_stack_branch(&[
+            ("alpha-new-1\n", "feat: alpha rewritten\n\npr:alpha"),
+            ("beta-new-1\n", "feat: beta rewritten\n\npr:beta"),
+        ]);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(resolve_stack(Some("dank-spr/alpha".to_string()), IGNORE_TAG).unwrap())
+        });
+
+        match payload {
+            ResolveStackPayload::StaleMetadata {
+                normalized_target, ..
+            } => assert_eq!(normalized_target, "dank-spr/alpha"),
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_returns_ambiguous_when_multiple_recorded_aliases_verify() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+        git(
+            repo.repo_path(),
+            ["branch", "dank/alias-one", "HEAD"].as_slice(),
+        );
+        git(
+            repo.repo_path(),
+            ["branch", "dank/alias-two", "HEAD"].as_slice(),
+        );
+
+        let mut metadata = read_metadata(&repo);
+        let stack_id = metadata.stacks.keys().next().unwrap().clone();
+        let stack = metadata.stacks.get_mut(&stack_id).unwrap();
+        stack.preferred_branch = StackBranchName("dank/stale".to_string());
+        stack.known_branches = vec![
+            StackBranchName("dank/stale".to_string()),
+            StackBranchName("dank/alias-one".to_string()),
+            StackBranchName("dank/alias-two".to_string()),
+        ];
+        write_metadata(&repo, &metadata);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(resolve_stack(Some("dank-spr/alpha".to_string()), IGNORE_TAG).unwrap())
+        });
+
+        match payload {
+            ResolveStackPayload::Ambiguous {
+                candidate_branches, ..
+            } => assert_eq!(
+                candidate_branches,
+                vec!["dank/alias-one".to_string(), "dank/alias-two".to_string()]
+            ),
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_does_not_scan_unrecorded_alias_branches() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+        git(
+            repo.repo_path(),
+            ["branch", "dank/unrelated", "HEAD"].as_slice(),
+        );
+
+        let mut metadata = read_metadata(&repo);
+        let stack_id = metadata.stacks.keys().next().unwrap().clone();
+        let stack = metadata.stacks.get_mut(&stack_id).unwrap();
+        stack.preferred_branch = StackBranchName("dank/stale".to_string());
+        stack.known_branches = vec![StackBranchName("dank/stale".to_string())];
+        write_metadata(&repo, &metadata);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(resolve_stack(Some("dank-spr/alpha".to_string()), IGNORE_TAG).unwrap())
+        });
+
+        match payload {
+            ResolveStackPayload::StaleMetadata { .. } => {}
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_stack_resolves_pr_url_only_to_head_ref_name() {
+        let repo = TestRepo::init();
+        repo.refresh_metadata(STACK_BRANCH);
+        let log_path = repo.repo.join("gh.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n  echo '{{\"headRefName\":\"dank-spr/alpha\"}}'\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+
+        let payload = repo.with_cwd(|| {
+            assert_status(
+                resolve_stack(
+                    Some("https://github.com/o/r/pull/17".to_string()),
+                    IGNORE_TAG,
+                )
+                .unwrap(),
+            )
+        });
+
+        match payload {
+            ResolveStackPayload::Found { diagnostics, .. } => assert_eq!(
+                diagnostics,
+                vec![ResolveStackDiagnostic::ResolvedPrUrl {
+                    url: "https://github.com/o/r/pull/17".to_string(),
+                    head_ref_name: "dank-spr/alpha".to_string(),
+                }]
+            ),
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("pr view https://github.com/o/r/pull/17 --json headRefName"));
+    }
+
+    #[test]
+    fn looks_like_pr_url_requires_github_pull_path() {
+        assert!(looks_like_pr_url("https://github.com/o/r/pull/17"));
+        assert!(!looks_like_pr_url("https://github.com/o/r/issues/17"));
+        assert!(!looks_like_pr_url("dank-spr/alpha"));
+    }
+}

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -87,7 +87,7 @@ fn resolve_restack_after_count(groups: &[Group], after: &AfterSelector) -> Resul
 }
 
 fn restack_after_resolved(
-    base: &str,
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     leading_ignored: Vec<String>,
     groups: Vec<Group>,
     after: usize,
@@ -105,6 +105,7 @@ fn restack_after_resolved(
             let (cur_branch, short) = common::get_current_branch_and_short()?;
             let original_head = git_rev_parse("HEAD")?;
             let original_worktree_root = rewrite_resume::current_repo_root()?;
+            let metadata_refresh_context = metadata_context.clone();
             if remaining.is_empty() && kept_ignored_segments.is_empty() {
                 if options.safe {
                     let _ = common::create_backup_tag(options.dry, "restack", &cur_branch, &short)?;
@@ -113,9 +114,17 @@ fn restack_after_resolved(
                     "Skipping all {} PR(s); syncing current branch {} to {}",
                     groups.len(),
                     cur_branch,
-                    base
+                    metadata_context.base
                 );
-                common::reset_current_branch_to(options.dry, base)?;
+                common::reset_current_branch_to(options.dry, &metadata_context.base)?;
+                if !options.dry {
+                    crate::stack_metadata::refresh_metadata_for_branch(
+                        &original_worktree_root,
+                        &cur_branch,
+                        &metadata_refresh_context,
+                        None,
+                    )?;
+                }
                 Ok(RewriteCommandOutcome::Completed)
             } else {
                 let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
@@ -135,8 +144,12 @@ fn restack_after_resolved(
                     None
                 };
 
-                let (tmp_path, tmp_branch) =
-                    common::create_temp_worktree(options.dry, "restack", base, &short)?;
+                let (tmp_path, tmp_branch) = common::create_temp_worktree(
+                    options.dry,
+                    "restack",
+                    &metadata_context.base,
+                    &short,
+                )?;
                 let ops = build_cherry_pick_plan(&kept_ignored_segments, &remaining);
                 let outcome = rewrite_resume::run_rewrite_session(
                     options.dry,
@@ -159,12 +172,13 @@ fn restack_after_resolved(
                         operations: ops,
                         deferred_dirty_worktree_restore,
                         post_success_hint: None,
+                        metadata_refresh_context: Some(metadata_refresh_context),
                     },
                 )?;
                 if outcome == RewriteCommandOutcome::Completed {
                     info!(
                         "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
-                        after, cur_branch, base
+                        after, cur_branch, metadata_context.base
                     );
                 }
                 Ok(outcome)
@@ -191,8 +205,7 @@ fn restack_after_resolved(
 ///
 /// Returns errors from git operations (fetch, worktree creation, cherry-picks, reset).
 pub fn restack_after(
-    base: &str,
-    ignore_tag: &str,
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     after: &AfterSelector,
     safe: bool,
     dry: bool,
@@ -202,14 +215,14 @@ pub fn restack_after(
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
     let (_merge_base, leading_ignored, groups) =
-        derive_local_groups_with_ignored(base, ignore_tag)?;
+        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
     if groups.is_empty() {
         info!("No local PR groups found; nothing to restack.");
         Ok(RewriteCommandOutcome::Completed)
     } else {
         let after = resolve_restack_after_count(&groups, after)?;
         restack_after_resolved(
-            base,
+            metadata_context,
             leading_ignored,
             groups,
             after,
@@ -225,8 +238,7 @@ pub fn restack_after(
 
 /// Restack the local stack by keeping the first `after` groups in place.
 pub fn restack_after_count(
-    base: &str,
-    ignore_tag: &str,
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     after: usize,
     safe: bool,
     dry: bool,
@@ -236,12 +248,12 @@ pub fn restack_after_count(
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
     let (_merge_base, leading_ignored, groups) =
-        derive_local_groups_with_ignored(base, ignore_tag)?;
+        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
     if groups.is_empty() {
         Ok(RewriteCommandOutcome::Completed)
     } else {
         restack_after_resolved(
-            base,
+            metadata_context,
             leading_ignored,
             groups,
             after,
@@ -268,6 +280,14 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use tempfile::TempDir;
+
+    fn metadata_context() -> crate::stack_metadata::RefreshMetadataContext {
+        crate::stack_metadata::RefreshMetadataContext {
+            base: "main".to_string(),
+            prefix: "dank-spr/".to_string(),
+            ignore_tag: "ignore".to_string(),
+        }
+    }
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
@@ -399,8 +419,7 @@ mod tests {
         let _guard = DirGuard::change_to(&repo);
 
         let outcome = super::restack_after(
-            "main",
-            "ignore",
+            &metadata_context(),
             &AfterSelector::Group(GroupSelector::LocalPr(1)),
             false,
             false,

--- a/src/commands/rewrite_resume.rs
+++ b/src/commands/rewrite_resume.rs
@@ -83,16 +83,6 @@ pub struct RewriteReplayStep {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RewritePausedStepProof {
-    pub source_sha: String,
-    pub expected_parent: String,
-    pub expected_message: String,
-    pub expected_author_name: String,
-    pub expected_author_email: String,
-    pub expected_author_date: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RewriteResumeState {
     pub schema_version: u32,
     pub command_kind: RewriteCommandKind,
@@ -104,10 +94,8 @@ pub struct RewriteResumeState {
     pub temp_worktree_path: String,
     pub backup_tag: Option<String>,
     pub paused_head: String,
-    #[serde(default)]
-    pub paused_step_proof: Option<RewritePausedStepProof>,
-    pub suspended_step_index: usize,
-    pub steps: Vec<RewriteReplayStep>,
+    pub paused_step: RewriteReplayStep,
+    pub remaining_operations: Vec<CherryPickOp>,
     #[serde(default)]
     pub deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore,
     pub post_success_hint: Option<String>,
@@ -133,30 +121,6 @@ impl DirtyWorktreeOutcome for RewriteCommandOutcome {
     fn keeps_dirty_worktree_restore_deferred(&self) -> bool {
         matches!(self, Self::Suspended { .. })
     }
-}
-
-pub fn build_replay_steps(ops: &[CherryPickOp]) -> Result<Vec<RewriteReplayStep>> {
-    let mut steps = Vec::new();
-    for op in ops {
-        match op {
-            CherryPickOp::Commit { sha, empty_policy } => steps.push(RewriteReplayStep {
-                source_sha: sha.clone(),
-                empty_policy: *empty_policy,
-            }),
-            CherryPickOp::Range {
-                first,
-                last,
-                empty_policy,
-            } => {
-                let commits = git_rev_list_range(&format!("{first}^"), last)?;
-                steps.extend(commits.into_iter().map(|source_sha| RewriteReplayStep {
-                    source_sha,
-                    empty_policy: *empty_policy,
-                }));
-            }
-        }
-    }
-    Ok(steps)
 }
 
 pub fn current_repo_root() -> Result<String> {
@@ -221,14 +185,16 @@ pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<Rewrite
         git_common_dir: git_common_dir.display().to_string(),
         original_worktree_root: session.original_worktree_root,
         original_branch: session.original_branch,
-        original_head: session.original_head,
+        original_head: session.original_head.clone(),
         temp_branch: session.temp_branch,
         temp_worktree_path: session.temp_worktree_path.clone(),
         backup_tag: session.backup_tag,
         paused_head: head_at(&session.temp_worktree_path)?,
-        paused_step_proof: None,
-        suspended_step_index: 0,
-        steps: Vec::new(),
+        paused_step: RewriteReplayStep {
+            source_sha: session.original_head,
+            empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+        },
+        remaining_operations: Vec::new(),
         deferred_dirty_worktree_restore: session.deferred_dirty_worktree_restore,
         post_success_hint: session.post_success_hint,
     };
@@ -248,18 +214,9 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
     }
 
     let resume_path = absolute_path(path)?;
-    let mut state = read_resume_state(&resume_path)?;
+    let state = read_resume_state(&resume_path)?;
     validate_resume_state_against_current_repo(&resume_path, &state)?;
     validate_temp_worktree_exists(&state)?;
-
-    if state.suspended_step_index >= state.steps.len() {
-        bail!(
-            "resume file {} refers to step {} but only records {} replay steps",
-            resume_path.display(),
-            state.suspended_step_index,
-            state.steps.len()
-        );
-    }
 
     if cherry_pick_head_exists(&state.temp_worktree_path) {
         if head_at(&state.temp_worktree_path)? != state.paused_head {
@@ -287,7 +244,6 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
                 state.temp_worktree_path
             )
         });
-        let mut skipped_current_step = false;
         if let Err(err) = continue_result {
             if cherry_pick_head_exists(&state.temp_worktree_path)
                 && worktree_status_lines(&state.temp_worktree_path)?.is_empty()
@@ -313,56 +269,15 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
                         state.temp_worktree_path
                     )
                 });
-                if let Err(skip_err) = skip_result {
-                    if cherry_pick_head_exists(&state.temp_worktree_path) {
-                        let consumed_steps = validated_advanced_step_count(&state)? + 1;
-                        state.suspended_step_index += consumed_steps;
-                        state.paused_head = head_at(&state.temp_worktree_path)?;
-                        state.paused_step_proof = state
-                            .steps
-                            .get(state.suspended_step_index)
-                            .map(|step| build_paused_step_proof(&state.paused_head, step))
-                            .transpose()?;
-                        write_resume_state(&resume_path, &state)?;
-                        emit_suspend_instructions(&resume_path, &state);
-                        return Ok(RewriteCommandOutcome::Suspended(Box::new(
-                            suspended_state_from_resume_state(&resume_path, &state)?,
-                        )));
-                    }
-                    return Err(skip_err);
-                }
-                skipped_current_step = true;
-            } else if cherry_pick_head_exists(&state.temp_worktree_path) {
-                let consumed_steps = validated_advanced_step_count(&state)?;
-                if consumed_steps == 0 {
-                    return Err(err);
-                }
-                state.suspended_step_index += consumed_steps;
-                state.paused_head = head_at(&state.temp_worktree_path)?;
-                state.paused_step_proof = state
-                    .steps
-                    .get(state.suspended_step_index)
-                    .map(|step| build_paused_step_proof(&state.paused_head, step))
-                    .transpose()?;
-                write_resume_state(&resume_path, &state)?;
-                emit_suspend_instructions(&resume_path, &state);
-                return Ok(RewriteCommandOutcome::Suspended(Box::new(
-                    suspended_state_from_resume_state(&resume_path, &state)?,
-                )));
+                skip_result?;
             } else {
                 return Err(err);
             }
         }
-        let mut consumed_steps = validated_advanced_step_count(&state)?;
-        if skipped_current_step {
-            consumed_steps += 1;
-        }
-        state.suspended_step_index += consumed_steps;
-        state.paused_step_proof = None;
-        persist_resume_progress(&resume_path, &state)?;
     } else {
-        let consumed_steps = validated_advanced_step_count(&state)?;
-        if consumed_steps == 0 {
+        let advanced_commits =
+            advanced_commits_since_paused_head(&state.temp_worktree_path, &state.paused_head)?;
+        if advanced_commits.is_empty() {
             bail!(
                 "resume file {} expects an in-progress cherry-pick in {}, but `CHERRY_PICK_HEAD` is missing and HEAD did not advance from {}",
                 resume_path.display(),
@@ -372,21 +287,19 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
         } else {
             validate_manual_continue_commit(&state)?;
             info!(
-                "Detected manual cherry-pick progress of {} step(s) in {}; resuming remaining replay steps.",
-                consumed_steps,
+                "Detected one manual `git cherry-pick --continue` in {}; resuming the remaining replay operations.",
                 state.temp_worktree_path
             );
-            state.suspended_step_index += consumed_steps;
-            state.paused_step_proof = None;
-            persist_resume_progress(&resume_path, &state)?;
         }
     }
 
-    continue_rewrite_steps(
+    let remaining_operations = state.remaining_operations.clone();
+    continue_rewrite_operations(
         false,
         state,
         RewriteConflictPolicy::Suspend,
         &resume_path,
+        &remaining_operations,
         true,
     )
 }
@@ -404,21 +317,13 @@ fn continue_rewrite_operations(
             let conflict = cherry_pick_head_exists(&state.temp_worktree_path);
             if conflict && conflict_policy == RewriteConflictPolicy::Suspend {
                 state.paused_head = head_at(&state.temp_worktree_path)?;
-                state.steps = remaining_steps_after_conflicted_operation(
+                let (paused_step, remaining_operations) = split_conflicted_operation(
                     &state.temp_worktree_path,
                     op,
                     &operations[op_index + 1..],
                 )?;
-                state.suspended_step_index = 0;
-                state.paused_step_proof = Some(build_paused_step_proof(
-                    &state.paused_head,
-                    state.steps.first().ok_or_else(|| {
-                        anyhow!(
-                            "{} suspended without recording a paused replay step",
-                            state.command_kind.command_name()
-                        )
-                    })?,
-                )?);
+                state.paused_step = paused_step;
+                state.remaining_operations = remaining_operations;
                 write_resume_state(resume_path, &state)?;
                 emit_suspend_instructions(resume_path, &state);
                 return Ok(RewriteCommandOutcome::Suspended(Box::new(
@@ -437,54 +342,6 @@ fn continue_rewrite_operations(
                 )
             });
         }
-    }
-
-    finish_rewrite(dry, state, resume_path, restore_dirty_worktree_on_success)
-}
-
-fn continue_rewrite_steps(
-    dry: bool,
-    mut state: RewriteResumeState,
-    conflict_policy: RewriteConflictPolicy,
-    resume_path: &Path,
-    restore_dirty_worktree_on_success: bool,
-) -> Result<RewriteCommandOutcome> {
-    let mut next_index = state.suspended_step_index;
-    while next_index < state.steps.len() {
-        let step = &state.steps[next_index];
-        if let Err(err) = common::cherry_pick_commit(
-            dry,
-            &state.temp_worktree_path,
-            &step.source_sha,
-            step.empty_policy,
-        ) {
-            let conflict = cherry_pick_head_exists(&state.temp_worktree_path);
-            if conflict && conflict_policy == RewriteConflictPolicy::Suspend {
-                state.paused_head = head_at(&state.temp_worktree_path)?;
-                state.suspended_step_index = next_index;
-                state.paused_step_proof = Some(build_paused_step_proof(&state.paused_head, step)?);
-                write_resume_state(resume_path, &state)?;
-                emit_suspend_instructions(resume_path, &state);
-                return Ok(RewriteCommandOutcome::Suspended(Box::new(
-                    suspended_state_from_resume_state(resume_path, &state)?,
-                )));
-            }
-
-            if conflict {
-                abort_cherry_pick_best_effort(dry, &state.temp_worktree_path);
-            }
-            cleanup_temp_state_best_effort(dry, &state.temp_worktree_path, &state.temp_branch);
-            return Err(err).with_context(|| {
-                format!(
-                    "{} failed; temp rewrite state was cleaned up",
-                    state.command_kind.command_name()
-                )
-            });
-        }
-        next_index += 1;
-        state.suspended_step_index = next_index;
-        state.paused_step_proof = None;
-        persist_resume_progress(resume_path, &state)?;
     }
 
     finish_rewrite(dry, state, resume_path, restore_dirty_worktree_on_success)
@@ -546,17 +403,6 @@ fn suspended_state_from_resume_state(
 ) -> Result<RewriteSuspendedState> {
     let conflicted_paths =
         conflicted_paths_from_status_lines(&worktree_status_lines(&state.temp_worktree_path)?);
-    let paused_source_sha = state
-        .steps
-        .get(state.suspended_step_index)
-        .map(|step| step.source_sha.clone())
-        .ok_or_else(|| {
-            anyhow!(
-                "resume state refers to missing step {} out of {} replay steps",
-                state.suspended_step_index,
-                state.steps.len()
-            )
-        })?;
     Ok(RewriteSuspendedState {
         command_kind: state.command_kind,
         original_worktree_root: state.original_worktree_root.clone(),
@@ -564,7 +410,7 @@ fn suspended_state_from_resume_state(
         temp_branch: state.temp_branch.clone(),
         temp_worktree_path: state.temp_worktree_path.clone(),
         resume_path: resume_path.to_path_buf(),
-        paused_source_sha,
+        paused_source_sha: state.paused_step.source_sha.clone(),
         conflicted_paths,
         post_success_hint: state.post_success_hint.clone(),
     })
@@ -629,16 +475,19 @@ fn run_cherry_pick_op(dry: bool, tmp_path: &str, op: &CherryPickOp) -> Result<()
     }
 }
 
-fn remaining_steps_after_conflicted_operation(
+fn split_conflicted_operation(
     tmp_path: &str,
     op: &CherryPickOp,
     later_operations: &[CherryPickOp],
-) -> Result<Vec<RewriteReplayStep>> {
-    let mut steps = match op {
-        CherryPickOp::Commit { sha, empty_policy } => vec![RewriteReplayStep {
-            source_sha: sha.clone(),
-            empty_policy: *empty_policy,
-        }],
+) -> Result<(RewriteReplayStep, Vec<CherryPickOp>)> {
+    match op {
+        CherryPickOp::Commit { sha, empty_policy } => Ok((
+            RewriteReplayStep {
+                source_sha: sha.clone(),
+                empty_policy: *empty_policy,
+            },
+            later_operations.to_vec(),
+        )),
         CherryPickOp::Range {
             first,
             last,
@@ -657,52 +506,48 @@ fn remaining_steps_after_conflicted_operation(
                         last
                     )
                 })?;
-            commits[paused_index..]
-                .iter()
-                .map(|source_sha| RewriteReplayStep {
-                    source_sha: source_sha.clone(),
-                    empty_policy: *empty_policy,
-                })
-                .collect()
+            trim_sequencer_todo_to_current_step(tmp_path)?;
+            let paused_step = RewriteReplayStep {
+                source_sha: paused_source_sha,
+                empty_policy: *empty_policy,
+            };
+            let mut remaining_operations = Vec::new();
+            if let Some(remaining_range) = CherryPickOp::from_commits_with_empty_policy(
+                &commits[paused_index + 1..],
+                *empty_policy,
+            ) {
+                remaining_operations.push(remaining_range);
+            }
+            remaining_operations.extend_from_slice(later_operations);
+            Ok((paused_step, remaining_operations))
         }
-    };
-    steps.extend(build_replay_steps(later_operations)?);
-    Ok(steps)
-}
-
-fn build_paused_step_proof(
-    paused_head: &str,
-    step: &RewriteReplayStep,
-) -> Result<RewritePausedStepProof> {
-    let identity = commit_identity(&step.source_sha)?;
-    Ok(RewritePausedStepProof {
-        source_sha: step.source_sha.clone(),
-        expected_parent: paused_head.to_string(),
-        expected_message: identity.message,
-        expected_author_name: identity.author_name,
-        expected_author_email: identity.author_email,
-        expected_author_date: identity.author_date,
-    })
+    }
 }
 
 fn validate_manual_continue_commit(state: &RewriteResumeState) -> Result<()> {
-    let consumed_steps = validated_advanced_step_count(state)?;
-    if consumed_steps == 0 {
+    let advanced_commits =
+        advanced_commits_since_paused_head(&state.temp_worktree_path, &state.paused_head)?;
+    if advanced_commits.len() > 1 {
+        bail!(
+            "temp worktree {} advanced by {} commits beyond paused HEAD {}; only one accidental manual continue is supported",
+            state.temp_worktree_path,
+            advanced_commits.len(),
+            state.paused_head
+        );
+    } else if let Some(actual_sha) = advanced_commits.first() {
+        validate_replayed_commit_matches_step(
+            &state.temp_worktree_path,
+            actual_sha,
+            &state.paused_step,
+            &state.paused_head,
+        )
+    } else {
         bail!(
             "temp worktree {} did not advance any validated replay steps beyond paused HEAD {}",
             state.temp_worktree_path,
             state.paused_head
-        );
-    } else {
-        Ok(())
+        )
     }
-}
-
-fn persist_resume_progress(resume_path: &Path, state: &RewriteResumeState) -> Result<()> {
-    if resume_path.exists() {
-        write_resume_state(resume_path, state)?;
-    }
-    Ok(())
 }
 
 fn commit_identity(sha: &str) -> Result<CommitIdentity> {
@@ -760,33 +605,6 @@ fn commit_identity_from_args(args: &[&str]) -> Result<CommitIdentity> {
     })
 }
 
-fn validated_advanced_step_count(state: &RewriteResumeState) -> Result<usize> {
-    let advanced_commits =
-        advanced_commits_since_paused_head(&state.temp_worktree_path, &state.paused_head)?;
-    let remaining_steps = &state.steps[state.suspended_step_index..];
-    if advanced_commits.len() > remaining_steps.len() {
-        bail!(
-            "temp worktree {} advanced by {} commits beyond paused HEAD {}, but only {} replay step(s) remain",
-            state.temp_worktree_path,
-            advanced_commits.len(),
-            state.paused_head,
-            remaining_steps.len()
-        );
-    }
-
-    let mut expected_parent = state.paused_head.clone();
-    for (advanced_commit, step) in advanced_commits.iter().zip(remaining_steps.iter()) {
-        validate_replayed_commit_matches_step(
-            &state.temp_worktree_path,
-            advanced_commit,
-            step,
-            &expected_parent,
-        )?;
-        expected_parent = advanced_commit.clone();
-    }
-    Ok(advanced_commits.len())
-}
-
 fn validate_replayed_commit_matches_step(
     tmp_path: &str,
     actual_sha: &str,
@@ -831,6 +649,49 @@ fn validate_replayed_commit_matches_step(
         );
     } else {
         Ok(())
+    }
+}
+
+fn trim_sequencer_todo_to_current_step(tmp_path: &str) -> Result<()> {
+    let todo_path = git_dir_at(tmp_path)?.join("sequencer").join("todo");
+    let todo = fs::read_to_string(&todo_path)
+        .with_context(|| format!("failed to read sequencer todo {}", todo_path.display()))?;
+    let trimmed = trim_todo_to_first_action(&todo)?;
+    fs::write(&todo_path, trimmed)
+        .with_context(|| format!("failed to rewrite sequencer todo {}", todo_path.display()))
+}
+
+fn trim_todo_to_first_action(todo: &str) -> Result<String> {
+    let mut kept_lines = Vec::new();
+    let mut kept_action = false;
+    for line in todo.lines() {
+        if kept_action {
+            continue;
+        }
+        kept_lines.push(line.to_string());
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            kept_action = true;
+        }
+    }
+    if !kept_action {
+        bail!("sequencer todo did not contain a cherry-pick action to keep");
+    } else {
+        let mut trimmed = kept_lines.join("\n");
+        if todo.ends_with('\n') {
+            trimmed.push('\n');
+        }
+        Ok(trimmed)
+    }
+}
+
+fn git_dir_at(tmp_path: &str) -> Result<PathBuf> {
+    let raw = git_ro(["-C", tmp_path, "rev-parse", "--git-dir"].as_slice())?;
+    let path = PathBuf::from(raw.trim());
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(Path::new(tmp_path).join(path))
     }
 }
 
@@ -1163,11 +1024,11 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        build_replay_steps, conflicted_paths_from_status_lines, default_resume_path,
+        conflicted_paths_from_status_lines, default_resume_path,
         prepare_resume_path_for_new_session, resume_rewrite, run_rewrite_session,
         sanitize_branch_for_filename, suspend_instruction_lines, RewriteCommandKind,
-        RewriteCommandOutcome, RewriteConflictPolicy, RewriteResumeState, RewriteSession,
-        REWRITE_RESUME_SCHEMA_VERSION,
+        RewriteCommandOutcome, RewriteConflictPolicy, RewriteReplayStep, RewriteResumeState,
+        RewriteSession, REWRITE_RESUME_SCHEMA_VERSION,
     };
     use crate::commands::common::{
         CherryPickEmptyPolicy, CherryPickOp, DeferredDirtyWorktreeRestore,
@@ -1219,6 +1080,20 @@ mod tests {
         } else {
             fs::canonicalize(repo.join(path)).expect("canonicalize git common dir")
         }
+    }
+
+    fn git_dir(repo: &Path) -> PathBuf {
+        let raw = git(repo, ["rev-parse", "--git-dir"].as_slice());
+        let path = PathBuf::from(raw.trim());
+        if path.is_absolute() {
+            path
+        } else {
+            repo.join(path)
+        }
+    }
+
+    fn sequencer_todo(repo: &Path) -> String {
+        fs::read_to_string(git_dir(repo).join("sequencer").join("todo")).expect("read todo")
     }
 
     fn resolve_keep_both(repo: &Path, contents: &str) {
@@ -1278,40 +1153,7 @@ mod tests {
         (dir, repo, resume_path)
     }
 
-    #[test]
-    fn build_replay_steps_expands_ranges_to_single_commits() {
-        let _lock = lock_cwd();
-        let dir = init_conflict_repo();
-        let repo = dir.path().to_path_buf();
-        let _guard = DirGuard::change_to(&repo);
-
-        let first = commit_file(&repo, "alpha.txt", "alpha-1\n", "feat: alpha");
-        let second = commit_file(&repo, "alpha.txt", "alpha-1\nalpha-2\n", "feat: alpha 2");
-        let steps = build_replay_steps(&[
-            CherryPickOp::Commit {
-                sha: first.clone(),
-                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
-            },
-            CherryPickOp::Range {
-                first,
-                last: second.clone(),
-                empty_policy: CherryPickEmptyPolicy::KeepRedundantCommits,
-            },
-        ])
-        .expect("flatten replay steps");
-
-        assert_eq!(steps.len(), 3);
-        assert_eq!(steps[1].source_sha, steps[0].source_sha);
-        assert_eq!(steps[2].source_sha, second);
-        assert_eq!(
-            steps[2].empty_policy,
-            CherryPickEmptyPolicy::KeepRedundantCommits
-        );
-    }
-
-    #[test]
-    fn run_rewrite_session_uses_range_replay_before_first_conflict() {
-        let _lock = lock_cwd();
+    fn suspended_range_session_repo() -> (TempDir, PathBuf, PathBuf, String, String, String) {
         let dir = init_conflict_repo();
         let repo = dir.path().to_path_buf();
         let _guard = DirGuard::change_to(&repo);
@@ -1319,12 +1161,12 @@ mod tests {
         git(&repo, ["checkout", "-b", "stack"].as_slice());
         let first = commit_file(&repo, "story.txt", "stack-1\n", "feat: first");
         let second = commit_file(&repo, "extra.txt", "stack-2\n", "feat: second");
-        let original_head = second.clone();
+        let third = commit_file(&repo, "more.txt", "stack-3\n", "feat: third");
+        let original_head = third.clone();
 
         git(&repo, ["checkout", "main"].as_slice());
         let base_head = commit_file(&repo, "story.txt", "base-updated\n", "feat: base update");
         git(&repo, ["checkout", "stack"].as_slice());
-
         let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
             .trim()
             .to_string();
@@ -1349,35 +1191,136 @@ mod tests {
                 original_head,
                 resume_path: resume_path.clone(),
                 temp_branch: tmp_branch,
-                temp_worktree_path: tmp_path.clone(),
+                temp_worktree_path: tmp_path,
                 backup_tag: None,
                 operations: vec![CherryPickOp::Range {
                     first: first.clone(),
-                    last: second.clone(),
+                    last: third.clone(),
                     empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
                 }],
                 deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
                 post_success_hint: None,
             },
         )
-        .expect("run rewrite session");
+        .expect("run range rewrite session");
+
+        let resume_path = match outcome {
+            RewriteCommandOutcome::Completed => panic!("expected suspended rewrite"),
+            RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
+        };
+
+        (dir, repo, resume_path, first, second, third)
+    }
+
+    fn suspended_repeated_range_conflict_repo() -> (
+        TempDir,
+        PathBuf,
+        PathBuf,
+        String,
+        String,
+        String,
+        String,
+        String,
+    ) {
+        let dir = init_conflict_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        let first = commit_file(&repo, "story.txt", "stack-1\n", "feat: first");
+        let second = commit_file(&repo, "extra.txt", "stack-2\n", "feat: second");
+        let third = commit_file(&repo, "notes.txt", "stack-notes\n", "feat: third");
+        let fourth = commit_file(&repo, "tail-a.txt", "tail-a\n", "feat: fourth");
+        let fifth = commit_file(&repo, "tail-b.txt", "tail-b\n", "feat: fifth");
+        let original_head = fifth.clone();
+
+        git(&repo, ["checkout", "main"].as_slice());
+        fs::write(repo.join("story.txt"), "base-updated\n").expect("write base story");
+        fs::write(repo.join("notes.txt"), "base-notes\n").expect("write base notes");
+        git(&repo, ["add", "story.txt", "notes.txt"].as_slice());
+        git(&repo, ["commit", "-m", "feat: base update"].as_slice());
+        let base_head = git(&repo, ["rev-parse", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        git(&repo, ["checkout", "stack"].as_slice());
+        let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        let (tmp_path, tmp_branch) =
+            crate::commands::common::create_temp_worktree(false, "restack", &base_head, &short)
+                .expect("create temp worktree");
+        let resume_path = prepare_resume_path_for_new_session(
+            false,
+            RewriteCommandKind::Restack,
+            "stack",
+            &original_head,
+        )
+        .expect("prepare resume path");
+
+        let outcome = run_rewrite_session(
+            false,
+            RewriteSession {
+                command_kind: RewriteCommandKind::Restack,
+                conflict_policy: RewriteConflictPolicy::Suspend,
+                original_worktree_root: repo.display().to_string(),
+                original_branch: "stack".to_string(),
+                original_head,
+                resume_path: resume_path.clone(),
+                temp_branch: tmp_branch,
+                temp_worktree_path: tmp_path,
+                backup_tag: None,
+                operations: vec![CherryPickOp::Range {
+                    first: first.clone(),
+                    last: fifth.clone(),
+                    empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+                }],
+                deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
+                post_success_hint: None,
+            },
+        )
+        .expect("run repeated range rewrite session");
+
+        let resume_path = match outcome {
+            RewriteCommandOutcome::Completed => panic!("expected suspended rewrite"),
+            RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
+        };
+
+        (dir, repo, resume_path, first, second, third, fourth, fifth)
+    }
+
+    #[test]
+    fn suspend_trims_range_todo_and_persists_range_suffix() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path, first, second, third) = suspended_range_session_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        let temp_repo = Path::new(&resume_state.temp_worktree_path);
+        let todo = sequencer_todo(temp_repo);
 
         assert!(
-            matches!(outcome, RewriteCommandOutcome::Suspended(_)),
-            "expected range replay to suspend"
+            todo.contains("feat: first")
+                && !todo.contains("feat: second")
+                && !todo.contains("feat: third"),
+            "expected the suspended sequencer todo to keep only the current pick: {todo}"
         );
-        let git_dir_raw = git(Path::new(&tmp_path), ["rev-parse", "--git-dir"].as_slice());
-        let git_dir = PathBuf::from(git_dir_raw.trim());
-        let git_dir = if git_dir.is_absolute() {
-            git_dir
-        } else {
-            Path::new(&tmp_path).join(git_dir)
-        };
-        let sequencer_todo =
-            fs::read_to_string(git_dir.join("sequencer").join("todo")).expect("read todo");
-        assert!(
-            sequencer_todo.contains("feat: second") && sequencer_todo.contains(&second[..7]),
-            "expected the range sequencer todo to mention the later commit: {sequencer_todo}"
+        assert_eq!(
+            resume_state.paused_step,
+            RewriteReplayStep {
+                source_sha: first,
+                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+            }
+        );
+        assert_eq!(
+            resume_state.remaining_operations,
+            vec![CherryPickOp::Range {
+                first: second,
+                last: third,
+                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+            }]
         );
     }
 
@@ -1416,7 +1359,7 @@ mod tests {
     #[test]
     fn resume_rewrite_tolerates_one_manual_continue() {
         let _lock = lock_cwd();
-        let (dir, repo, resume_path) = suspended_session_repo();
+        let (dir, repo, resume_path, _first, _second, _third) = suspended_range_session_repo();
         let _keep_dir_alive = dir.path();
         let _guard = DirGuard::change_to(&repo);
 
@@ -1424,14 +1367,30 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
                 .expect("parse resume state");
         let temp_repo = Path::new(&resume_state.temp_worktree_path);
-        resolve_keep_both(temp_repo, "base-updated\nstack-change\n");
+        resolve_keep_both(temp_repo, "base-updated\nstack-1\n");
         git(temp_repo, ["cherry-pick", "--continue"].as_slice());
+        assert!(
+            !temp_repo.join("extra.txt").exists() && !temp_repo.join("more.txt").exists(),
+            "manual continue should finish only the paused commit before spr resume relaunches the suffix"
+        );
 
         let outcome = resume_rewrite(false, &resume_path).expect("resume after manual continue");
         assert_eq!(outcome, RewriteCommandOutcome::Completed);
         assert!(
             !resume_path.exists(),
             "resume file should be removed after the resumed replay finishes"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("story.txt")).expect("read final story"),
+            "base-updated\nstack-1\n"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("extra.txt")).expect("read final extra"),
+            "stack-2\n"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("more.txt")).expect("read final more"),
+            "stack-3\n"
         );
     }
 
@@ -1523,7 +1482,7 @@ mod tests {
     #[test]
     fn resume_rewrite_rejects_multiple_manual_commits() {
         let _lock = lock_cwd();
-        let (dir, repo, resume_path) = suspended_session_repo();
+        let (dir, repo, resume_path, _first, _second, _third) = suspended_range_session_repo();
         let _keep_dir_alive = dir.path();
         let _guard = DirGuard::change_to(&repo);
 
@@ -1531,7 +1490,7 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
                 .expect("parse resume state");
         let temp_repo = Path::new(&resume_state.temp_worktree_path);
-        resolve_keep_both(temp_repo, "base-updated\nstack-change\n");
+        resolve_keep_both(temp_repo, "base-updated\nstack-1\n");
         git(temp_repo, ["cherry-pick", "--continue"].as_slice());
         commit_file(
             temp_repo,
@@ -1543,9 +1502,52 @@ mod tests {
         let err = resume_rewrite(false, &resume_path).expect_err("extra manual commit should fail");
         let err_text = format!("{err:#}");
         assert!(
-            err_text.contains("only 1 replay step(s) remain")
-                || err_text.contains("only one accidental manual continue is supported"),
+            err_text.contains("only one accidental manual continue is supported"),
             "unexpected error: {err_text}"
+        );
+    }
+
+    #[test]
+    fn second_conflict_resuspends_with_new_suffix_range() {
+        let _lock = lock_cwd();
+        let (dir, repo, resume_path, _first, _second, third, fourth, fifth) =
+            suspended_repeated_range_conflict_repo();
+        let _keep_dir_alive = dir.path();
+        let _guard = DirGuard::change_to(&repo);
+
+        let first_resume_state: RewriteResumeState =
+            serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
+                .expect("parse resume state");
+        resolve_keep_both(
+            Path::new(&first_resume_state.temp_worktree_path),
+            "base-updated\nstack-1\n",
+        );
+
+        let resumed = resume_rewrite(false, &resume_path).expect("resume into second conflict");
+        let second_resume_path = match resumed {
+            RewriteCommandOutcome::Completed => panic!("expected second suspension"),
+            RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
+        };
+        let second_resume_state: RewriteResumeState = serde_json::from_str(
+            &fs::read_to_string(&second_resume_path).expect("read second resume state"),
+        )
+        .expect("parse second resume state");
+        let todo = sequencer_todo(Path::new(&second_resume_state.temp_worktree_path));
+
+        assert!(
+            todo.contains("feat: third")
+                && !todo.contains("feat: fourth")
+                && !todo.contains("feat: fifth"),
+            "expected the second suspended todo to keep only the current conflicted pick: {todo}"
+        );
+        assert_eq!(second_resume_state.paused_step.source_sha, third);
+        assert_eq!(
+            second_resume_state.remaining_operations,
+            vec![CherryPickOp::Range {
+                first: fourth,
+                last: fifth,
+                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+            }]
         );
     }
 
@@ -1608,9 +1610,11 @@ mod tests {
             temp_worktree_path: "/tmp/spr-restack-abcdef0".to_string(),
             backup_tag: None,
             paused_head: "abcdef0123456789".to_string(),
-            paused_step_proof: None,
-            suspended_step_index: 0,
-            steps: vec![],
+            paused_step: RewriteReplayStep {
+                source_sha: "abcdef0123456789".to_string(),
+                empty_policy: CherryPickEmptyPolicy::StopOnEmpty,
+            },
+            remaining_operations: vec![],
             deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
             post_success_hint: None,
         };

--- a/src/commands/rewrite_resume.rs
+++ b/src/commands/rewrite_resume.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 use crate::commands::common::{
     self, CherryPickEmptyPolicy, CherryPickOp, DeferredDirtyWorktreeRestore, DirtyWorktreeOutcome,
 };
-use crate::git::{git_rev_list_range, git_ro, git_rw, repo_root};
+use crate::git::{git_common_dir, git_rev_list_range, git_ro, git_rw, repo_root};
 
 const REWRITE_RESUME_SCHEMA_VERSION: u32 = 1;
 
@@ -99,6 +99,8 @@ pub struct RewriteResumeState {
     #[serde(default)]
     pub deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore,
     pub post_success_hint: Option<String>,
+    #[serde(default)]
+    pub metadata_refresh_context: Option<crate::stack_metadata::RefreshMetadataContext>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -115,6 +117,7 @@ pub struct RewriteSession {
     pub operations: Vec<CherryPickOp>,
     pub deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore,
     pub post_success_hint: Option<String>,
+    pub metadata_refresh_context: Option<crate::stack_metadata::RefreshMetadataContext>,
 }
 
 impl DirtyWorktreeOutcome for RewriteCommandOutcome {
@@ -133,7 +136,7 @@ pub fn prepare_resume_path_for_new_session(
     original_branch: &str,
     original_head: &str,
 ) -> Result<PathBuf> {
-    let git_common_dir = current_common_git_dir()?;
+    let git_common_dir = git_common_dir()?;
     let resume_path = default_resume_path(
         &git_common_dir,
         command_kind,
@@ -178,7 +181,7 @@ pub fn prepare_resume_path_for_new_session(
 }
 
 pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<RewriteCommandOutcome> {
-    let git_common_dir = current_common_git_dir()?;
+    let git_common_dir = git_common_dir()?;
     let state = RewriteResumeState {
         schema_version: REWRITE_RESUME_SCHEMA_VERSION,
         command_kind: session.command_kind,
@@ -197,6 +200,7 @@ pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<Rewrite
         remaining_operations: Vec::new(),
         deferred_dirty_worktree_restore: session.deferred_dirty_worktree_restore,
         post_success_hint: session.post_success_hint,
+        metadata_refresh_context: session.metadata_refresh_context,
     };
     continue_rewrite_operations(
         dry,
@@ -370,6 +374,18 @@ fn finish_rewrite(
         ]
         .as_slice(),
     )?;
+    let metadata_refresh_result = if dry {
+        Ok(())
+    } else if let Some(metadata_refresh_context) = &state.metadata_refresh_context {
+        crate::stack_metadata::refresh_metadata_for_branch(
+            &state.original_worktree_root,
+            &state.original_branch,
+            metadata_refresh_context,
+            Some(Path::new(&state.git_common_dir)),
+        )
+    } else {
+        Ok(())
+    };
     let restore_result = if restore_dirty_worktree_on_success {
         state
             .deferred_dirty_worktree_restore
@@ -388,6 +404,7 @@ fn finish_rewrite(
         info!("{post_success_hint}");
     }
     restore_result?;
+    metadata_refresh_result?;
     Ok(RewriteCommandOutcome::Completed)
 }
 
@@ -744,7 +761,7 @@ fn validate_resume_state_against_current_repo(
     path: &Path,
     state: &RewriteResumeState,
 ) -> Result<()> {
-    let current_common_dir = current_common_git_dir()?;
+    let current_common_dir = git_common_dir()?;
     let expected_common_dir = canonicalize_existing_path(Path::new(&state.git_common_dir))
         .with_context(|| {
             format!(
@@ -822,12 +839,6 @@ fn validate_original_worktree_target(state: &RewriteResumeState) -> Result<()> {
 
     Ok(())
 }
-
-fn current_common_git_dir() -> Result<PathBuf> {
-    let raw = git_ro(["rev-parse", "--git-common-dir"].as_slice())?;
-    canonicalize_existing_path(&absolute_path(Path::new(raw.trim()))?)
-}
-
 fn default_resume_path(
     git_common_dir: &Path,
     command_kind: RewriteCommandKind,
@@ -1142,6 +1153,7 @@ mod tests {
             }],
             deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
             post_success_hint: None,
+            metadata_refresh_context: None,
         };
 
         let outcome = run_rewrite_session(false, session).expect("run rewrite session");
@@ -1200,6 +1212,7 @@ mod tests {
                 }],
                 deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
                 post_success_hint: None,
+                metadata_refresh_context: None,
             },
         )
         .expect("run range rewrite session");
@@ -1276,6 +1289,7 @@ mod tests {
                 }],
                 deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
                 post_success_hint: None,
+                metadata_refresh_context: None,
             },
         )
         .expect("run repeated range rewrite session");
@@ -1617,6 +1631,7 @@ mod tests {
             remaining_operations: vec![],
             deferred_dirty_worktree_restore: DeferredDirtyWorktreeRestore::Noop,
             post_success_hint: None,
+            metadata_refresh_context: None,
         };
 
         let lines =

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,6 +8,7 @@
 use anyhow::{bail, Context, Result};
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tracing::{error, info};
 
@@ -32,6 +33,14 @@ pub fn git_ro(args: &[&str]) -> Result<String> {
     }
     verbose_log_cmd("git", args);
     run("git", args)
+}
+
+pub fn git_ro_in(path: &str, args: &[&str]) -> Result<String> {
+    let mut argv = Vec::with_capacity(args.len() + 2);
+    argv.push("-C");
+    argv.push(path);
+    argv.extend_from_slice(args);
+    git_ro(argv.as_slice())
 }
 
 pub fn git_rw(dry: bool, args: &[&str]) -> Result<String> {
@@ -181,6 +190,59 @@ pub fn repo_root() -> Result<Option<String>> {
     }
 }
 
+fn canonicalize_existing_path(path: &Path) -> Result<PathBuf> {
+    std::fs::canonicalize(path)
+        .with_context(|| format!("failed to canonicalize path {}", path.display()))
+}
+
+fn resolve_reported_git_path(reported: &str, base_path: Option<&str>) -> Result<PathBuf> {
+    let path = PathBuf::from(reported.trim());
+    let absolute = if path.is_absolute() {
+        path
+    } else if let Some(base_path) = base_path {
+        Path::new(base_path).join(path)
+    } else {
+        std::env::current_dir()
+            .with_context(|| "current directory is unavailable")?
+            .join(path)
+    };
+    canonicalize_existing_path(&absolute)
+}
+
+pub fn git_common_dir() -> Result<PathBuf> {
+    let raw = git_ro(["rev-parse", "--git-common-dir"].as_slice())?;
+    resolve_reported_git_path(raw.trim(), None)
+}
+
+pub fn git_common_dir_at(path: &str) -> Result<PathBuf> {
+    let raw = git_ro_in(path, ["rev-parse", "--git-common-dir"].as_slice())?;
+    resolve_reported_git_path(raw.trim(), Some(path))
+}
+
+pub fn git_current_branch() -> Result<String> {
+    Ok(git_ro(["rev-parse", "--abbrev-ref", "HEAD"].as_slice())?
+        .trim()
+        .to_string())
+}
+
+pub fn git_current_branch_at(path: &str) -> Result<String> {
+    Ok(
+        git_ro_in(path, ["rev-parse", "--abbrev-ref", "HEAD"].as_slice())?
+            .trim()
+            .to_string(),
+    )
+}
+
+pub fn git_ref_exists_at(path: &str, reference: &str) -> Result<bool> {
+    let status = Command::new("git")
+        .args(["-C", path, "rev-parse", "--verify", "--quiet", reference])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .with_context(|| format!("failed to inspect git reference {}", reference))?;
+    Ok(status.success())
+}
+
 /// Discover the repository's default branch via `origin/HEAD`.
 ///
 /// This runs `git symbolic-ref --short refs/remotes/origin/HEAD` and expects
@@ -252,6 +314,12 @@ pub fn git_is_ancestor(ancestor: &str, descendant: &str) -> Result<bool> {
 /// Resolves a revision to its full object id.
 pub fn git_rev_parse(revision: &str) -> Result<String> {
     Ok(git_ro(["rev-parse", revision].as_slice())?
+        .trim()
+        .to_string())
+}
+
+pub fn git_rev_parse_at(path: &str, revision: &str) -> Result<String> {
+    Ok(git_ro_in(path, ["rev-parse", revision].as_slice())?
         .trim()
         .to_string())
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -720,6 +720,15 @@ pub fn get_repo_owner_name() -> Result<(String, String)> {
     anyhow::bail!("Unable to parse remote.origin.url: {}", url)
 }
 
+pub fn resolve_pr_url_head_ref(pr_url: &str) -> Result<String> {
+    let json = gh_ro(["pr", "view", pr_url, "--json", "headRefName"].as_slice())?;
+    let value: serde_json::Value = serde_json::from_str(&json)?;
+    value["headRefName"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("GitHub PR view result missing headRefName for {}", pr_url))
+}
+
 pub fn graphql_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 16);
     for c in s.chars() {
@@ -1053,7 +1062,7 @@ mod tests {
         filter_case_variant_head_search_matches, filter_head_search_matches,
         list_conflicting_prs_for_heads_search_exhaustive, list_exact_prs_for_heads,
         list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
-        list_recent_terminal_prs_for_heads, parse_open_pr_automerge_node,
+        list_recent_terminal_prs_for_heads, parse_open_pr_automerge_node, resolve_pr_url_head_ref,
         select_latest_merged_pr_match, select_single_open_pr_match, HeadSearchPr, PrState,
         TerminalPrState, EXACT_HEAD_QUERY_LIMIT,
     };
@@ -1181,6 +1190,25 @@ mod tests {
             path_guard,
             log_path.display().to_string(),
         )
+    }
+
+    #[test]
+    fn resolve_pr_url_head_ref_reads_only_head_ref_name() {
+        let _lock = lock_cwd();
+        let data_dir = tempfile::tempdir().unwrap();
+        let log_path = data_dir.path().join("gh.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n  echo '{{\"headRefName\":\"dank-spr/example\"}}'\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+
+        let head_ref_name =
+            resolve_pr_url_head_ref("https://github.com/o/r/pull/17").expect("resolve PR URL");
+
+        assert_eq!(head_ref_name, "dank-spr/example");
+        let log = fs::read_to_string(log_path).expect("read gh log");
+        assert!(log.contains("pr view https://github.com/o/r/pull/17 --json headRefName"));
     }
 
     #[test]

--- a/src/machine_output.rs
+++ b/src/machine_output.rs
@@ -22,6 +22,7 @@ pub enum MachineCommand {
     Absorb,
     Move,
     FixPr,
+    ResolveStack,
     Resume,
     Land,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod machine_output;
 mod parsing;
 mod pr_labels;
 mod selectors;
+mod stack_metadata;
 #[cfg(test)]
 mod test_support;
 
@@ -60,6 +61,10 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
         | crate::cli::Cmd::Absorb { .. }
         | crate::cli::Cmd::Resume { .. }
         | crate::cli::Cmd::FixPr { .. } => false,
+        crate::cli::Cmd::ResolveStack { target, .. } => target
+            .as_deref()
+            .map(crate::commands::looks_like_pr_url)
+            .unwrap_or(false),
         crate::cli::Cmd::Update { .. }
         | crate::cli::Cmd::Prep {}
         | crate::cli::Cmd::List { .. }
@@ -75,6 +80,12 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
 enum OutputMode {
     Human,
     Json,
+}
+
+enum CommandOutput {
+    None,
+    Machine(crate::machine_output::MachineOutput),
+    ResolveStack(crate::commands::ResolveStackOutput),
 }
 
 fn init_tools(needs_gh: bool) -> Result<()> {
@@ -191,22 +202,24 @@ fn ensure_resume_completed(
     }
 }
 
-fn run_cli(
-    cli: crate::cli::Cli,
-    output_mode: OutputMode,
-) -> Result<crate::machine_output::MachineOutput> {
+fn run_cli(cli: crate::cli::Cli, output_mode: OutputMode) -> Result<CommandOutput> {
     apply_working_directory_override(cli.cd.as_deref())?;
     init_tools(command_requires_gh(&cli.cmd))?;
     if let crate::cli::Cmd::Resume { path, .. } = &cli.cmd {
-        return ensure_resume_completed(
+        return Ok(CommandOutput::Machine(ensure_resume_completed(
             output_mode,
             crate::commands::resume_rewrite(cli.dry_run, path)?,
-        );
+        )?));
     }
 
     let cfg = crate::config::load_config()?;
     let (base, prefix, ignore_tag) =
         resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone())?;
+    let metadata_refresh_context = crate::stack_metadata::RefreshMetadataContext {
+        base: base.clone(),
+        prefix: prefix.clone(),
+        ignore_tag: ignore_tag.clone(),
+    };
     let pr_description_mode = cfg.pr_description_mode;
     let restack_conflict_policy = cfg.restack_conflict;
     let dirty_worktree_policy = cfg.dirty_worktree;
@@ -266,9 +279,14 @@ fn run_cli(
                     allow_branch_reuse,
                     branch_reuse_guard_days,
                 )?;
-                Ok(crate::machine_output::MachineOutput::completed(
-                    crate::machine_output::MachineCommand::Restack,
-                ))
+                if !cli.dry_run {
+                    crate::stack_metadata::refresh_metadata_for_current_checkout(
+                        &metadata_refresh_context.base,
+                        &metadata_refresh_context.prefix,
+                        &metadata_refresh_context.ignore_tag,
+                    )?;
+                }
+                Ok(CommandOutput::None)
             }
         }
         crate::cli::Cmd::Restack {
@@ -277,20 +295,19 @@ fn run_cli(
             json: _,
         } => {
             set_dry_run_env(cli.dry_run, false);
-            ensure_rewrite_completed(
+            Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_mode,
                 "spr restack",
                 crate::machine_output::MachineCommand::Restack,
                 crate::commands::restack_after(
-                    &base,
-                    &ignore_tag,
+                    &metadata_refresh_context,
                     &after,
                     safe,
                     cli.dry_run,
                     restack_conflict_policy,
                     dirty_worktree_policy,
                 )?,
-            )
+            )?))
         }
         crate::cli::Cmd::Absorb {
             allow_replayed_duplicates,
@@ -304,7 +321,7 @@ fn run_cli(
                     crate::commands::CopiedLaterStackCommitPolicy::Block
                 },
             };
-            ensure_rewrite_completed(
+            Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_mode,
                 "spr absorb",
                 crate::machine_output::MachineCommand::Absorb,
@@ -316,7 +333,7 @@ fn run_cli(
                     dirty_worktree_policy,
                     options,
                 )?,
-            )
+            )?))
         }
         crate::cli::Cmd::Prep {} => {
             set_dry_run_env(cli.dry_run, false);
@@ -343,9 +360,7 @@ fn run_cli(
                 selection,
                 cli.dry_run,
             )?;
-            Ok(crate::machine_output::MachineOutput::completed(
-                crate::machine_output::MachineCommand::Restack,
-            ))
+            Ok(CommandOutput::None)
         }
         crate::cli::Cmd::List { what } => {
             match what {
@@ -356,17 +371,17 @@ fn run_cli(
                     crate::commands::list_commits_display(&base, &prefix, &ignore_tag, list_order)?;
                 }
             }
-            Ok(crate::machine_output::MachineOutput::completed(
-                crate::machine_output::MachineCommand::Restack,
-            ))
+            Ok(CommandOutput::None)
         }
         crate::cli::Cmd::Status {} => {
             // alias for `spr list pr`
             crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
-            Ok(crate::machine_output::MachineOutput::completed(
-                crate::machine_output::MachineCommand::Restack,
-            ))
+            Ok(CommandOutput::None)
         }
+        crate::cli::Cmd::ResolveStack { target, json: _ } => Ok(CommandOutput::ResolveStack(
+            crate::commands::resolve_stack(target, &ignore_tag)?,
+        )),
+        crate::cli::Cmd::Resume { .. } => unreachable!("handled before config loading"),
         crate::cli::Cmd::Land {
             which,
             r#unsafe,
@@ -402,8 +417,7 @@ fn run_cli(
             if !no_restack {
                 // After landing the first N PRs, restack the remaining commits onto the latest base
                 let outcome = crate::commands::restack_after_count(
-                    &base,
-                    &ignore_tag,
+                    &metadata_refresh_context,
                     landed_count,
                     false,
                     cli.dry_run,
@@ -416,10 +430,12 @@ fn run_cli(
                             .to_string(),
                     );
                     if output_mode == OutputMode::Json {
-                        return Ok(crate::machine_output::MachineOutput::suspended(
-                            crate::machine_output::MachineCommand::Land,
-                            *state,
-                            post_success_hint,
+                        return Ok(CommandOutput::Machine(
+                            crate::machine_output::MachineOutput::suspended(
+                                crate::machine_output::MachineCommand::Land,
+                                *state,
+                                post_success_hint,
+                            ),
                         ));
                     } else {
                         return Err(anyhow::anyhow!(
@@ -429,23 +445,21 @@ fn run_cli(
                     }
                 }
             }
-            Ok(crate::machine_output::MachineOutput::completed(
-                crate::machine_output::MachineCommand::Land,
+            Ok(CommandOutput::Machine(
+                crate::machine_output::MachineOutput::completed(
+                    crate::machine_output::MachineCommand::Land,
+                ),
             ))
         }
         crate::cli::Cmd::RelinkPrs {} => {
             set_dry_run_env(cli.dry_run, false);
             crate::commands::relink_prs(&base, &prefix, &ignore_tag, cli.dry_run)?;
-            Ok(crate::machine_output::MachineOutput::completed(
-                crate::machine_output::MachineCommand::Restack,
-            ))
+            Ok(CommandOutput::None)
         }
         crate::cli::Cmd::Cleanup {} => {
             set_dry_run_env(cli.dry_run, false);
             crate::commands::cleanup_remote_branches(&prefix, cli.dry_run)?;
-            Ok(crate::machine_output::MachineOutput::completed(
-                crate::machine_output::MachineCommand::Restack,
-            ))
+            Ok(CommandOutput::None)
         }
         crate::cli::Cmd::FixPr {
             target,
@@ -454,20 +468,19 @@ fn run_cli(
             json: _,
         } => {
             set_dry_run_env(cli.dry_run, false);
-            ensure_rewrite_completed(
+            Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_mode,
                 "spr fix-pr",
                 crate::machine_output::MachineCommand::FixPr,
                 crate::commands::fix_pr_tail(
-                    &base,
-                    &ignore_tag,
+                    &metadata_refresh_context,
                     &target,
                     tail,
                     safe,
                     cli.dry_run,
                     dirty_worktree_policy,
                 )?,
-            )
+            )?))
         }
         crate::cli::Cmd::Move {
             range,
@@ -476,7 +489,7 @@ fn run_cli(
             json: _,
         } => {
             set_dry_run_env(cli.dry_run, false);
-            ensure_rewrite_completed(
+            Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_mode,
                 "spr move",
                 crate::machine_output::MachineCommand::Move,
@@ -492,9 +505,8 @@ fn run_cli(
                         dirty_worktree_policy,
                     },
                 )?,
-            )
+            )?))
         }
-        crate::cli::Cmd::Resume { .. } => unreachable!("handled before config loading"),
     }
 }
 
@@ -551,6 +563,8 @@ fn machine_command_for_raw_args(args: &[OsString]) -> crate::machine_output::Mac
                 return crate::machine_output::MachineCommand::Move;
             } else if arg == "fix-pr" || arg == "fix" {
                 return crate::machine_output::MachineCommand::FixPr;
+            } else if arg == "resolve-stack" {
+                return crate::machine_output::MachineCommand::ResolveStack;
             } else if arg == "resume" {
                 return crate::machine_output::MachineCommand::Resume;
             } else if arg == "land" {
@@ -602,12 +616,22 @@ fn main() {
     init_logging(cli.verbose, output_mode);
     let command = machine_command_for_cli(&cli.cmd);
     match run_cli(cli, output_mode) {
-        Ok(output) => {
-            if output_mode == OutputMode::Json {
-                println!("{}", serde_json::to_string(&output).unwrap());
-                std::process::exit(output.exit_code());
+        Ok(output) => match output {
+            CommandOutput::None => {}
+            CommandOutput::Machine(output) => {
+                if output_mode == OutputMode::Json {
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                    std::process::exit(output.exit_code());
+                }
             }
-        }
+            CommandOutput::ResolveStack(output) => {
+                if output_mode == OutputMode::Json {
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                } else {
+                    println!("{}", output.render_human());
+                }
+            }
+        },
         Err(err) => {
             if output_mode == OutputMode::Json {
                 let output =
@@ -625,6 +649,7 @@ fn machine_command_for_cli(cmd: &crate::cli::Cmd) -> crate::machine_output::Mach
     match cmd {
         crate::cli::Cmd::Restack { .. } => crate::machine_output::MachineCommand::Restack,
         crate::cli::Cmd::Absorb { .. } => crate::machine_output::MachineCommand::Absorb,
+        crate::cli::Cmd::ResolveStack { .. } => crate::machine_output::MachineCommand::ResolveStack,
         crate::cli::Cmd::Resume { .. } => crate::machine_output::MachineCommand::Resume,
         crate::cli::Cmd::Land { .. } => crate::machine_output::MachineCommand::Land,
         crate::cli::Cmd::FixPr { .. } => crate::machine_output::MachineCommand::FixPr,
@@ -749,6 +774,22 @@ mod tests {
         assert!(command_requires_gh(&crate::cli::Cmd::Status {}));
     }
 
+    #[test]
+    fn resolve_stack_without_pr_url_stays_local_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::ResolveStack {
+            target: Some("dank-spr/alpha".to_string()),
+            json: false,
+        }));
+    }
+
+    #[test]
+    fn resolve_stack_pr_url_requires_github_cli() {
+        assert!(command_requires_gh(&crate::cli::Cmd::ResolveStack {
+            target: Some("https://github.com/o/r/pull/17".to_string()),
+            json: true,
+        }));
+    }
+
     fn init_repo() -> TempDir {
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path();
@@ -786,6 +827,21 @@ mod tests {
         ];
 
         assert_eq!(machine_command_for_raw_args(&args), MachineCommand::Resume);
+    }
+
+    #[test]
+    fn machine_command_for_raw_args_detects_resolve_stack() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("resolve-stack"),
+            OsString::from("--json"),
+            OsString::from("dank-spr/alpha"),
+        ];
+
+        assert_eq!(
+            machine_command_for_raw_args(&args),
+            MachineCommand::ResolveStack
+        );
     }
 
     #[test]

--- a/src/stack_metadata.rs
+++ b/src/stack_metadata.rs
@@ -1,0 +1,921 @@
+//! Repo-local stack ownership metadata shared across worktrees.
+//!
+//! The metadata file lives under the repository common Git directory so every
+//! linked worktree sees the same stack ownership state. Refreshing metadata is
+//! intentionally strict: branch names are locators, `stack_id` is identity, and
+//! branch ownership is derived only from the current local stack plus existing
+//! metadata. The module keeps the persisted JSON schema, file locking, atomic
+//! writes, and snapshot refresh logic in one place.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use uuid::Uuid;
+
+use crate::branch_names::group_branch_identities;
+use crate::git::{
+    git_common_dir, git_common_dir_at, git_current_branch, git_current_branch_at,
+    git_ref_exists_at, git_rev_parse_at, git_ro_in, repo_root,
+};
+use crate::parsing::{parse_groups_with_ignored, split_groups_for_update};
+
+pub const STACK_METADATA_SCHEMA_VERSION: u32 = 1;
+const LOCK_RETRY_ATTEMPTS: usize = 100;
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const STACK_METADATA_FILE_NAME: &str = "stack_metadata_v1.json";
+const STACK_METADATA_LOCK_NAME: &str = "stack_metadata_v1.lock";
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StackId(pub String);
+
+impl StackId {
+    pub fn fresh() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StackBranchName(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PrBranchName(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PrTag(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TombstoneReason {
+    RemovedFromLiveStack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StackRecord {
+    pub preferred_branch: StackBranchName,
+    pub known_branches: Vec<StackBranchName>,
+    pub base: String,
+    pub prefix: String,
+    pub last_seen_head: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum PrBranchRecord {
+    Live {
+        stack_id: StackId,
+        tag: PrTag,
+        last_group_seed: String,
+        last_group_tip: String,
+        last_stack_head: String,
+        updated_at: String,
+    },
+    Tombstoned {
+        stack_id: StackId,
+        tag: PrTag,
+        last_group_seed: String,
+        last_group_tip: String,
+        last_stack_head: String,
+        updated_at: String,
+        tombstone_reason: TombstoneReason,
+    },
+}
+
+impl PrBranchRecord {
+    pub fn stack_id(&self) -> &StackId {
+        match self {
+            Self::Live { stack_id, .. } | Self::Tombstoned { stack_id, .. } => stack_id,
+        }
+    }
+
+    pub fn tag(&self) -> &PrTag {
+        match self {
+            Self::Live { tag, .. } | Self::Tombstoned { tag, .. } => tag,
+        }
+    }
+
+    pub fn last_group_seed(&self) -> &str {
+        match self {
+            Self::Live {
+                last_group_seed, ..
+            }
+            | Self::Tombstoned {
+                last_group_seed, ..
+            } => last_group_seed,
+        }
+    }
+
+    pub fn last_group_tip(&self) -> &str {
+        match self {
+            Self::Live { last_group_tip, .. } | Self::Tombstoned { last_group_tip, .. } => {
+                last_group_tip
+            }
+        }
+    }
+
+    pub fn last_stack_head(&self) -> &str {
+        match self {
+            Self::Live {
+                last_stack_head, ..
+            }
+            | Self::Tombstoned {
+                last_stack_head, ..
+            } => last_stack_head,
+        }
+    }
+
+    pub fn as_live(&self) -> Option<LivePrBranchRecord<'_>> {
+        match self {
+            Self::Live {
+                stack_id,
+                tag,
+                last_group_seed,
+                last_group_tip,
+                last_stack_head,
+                updated_at,
+            } => Some(LivePrBranchRecord {
+                stack_id,
+                tag,
+                last_group_seed,
+                last_group_tip,
+                last_stack_head,
+                updated_at,
+            }),
+            Self::Tombstoned { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LivePrBranchRecord<'a> {
+    pub stack_id: &'a StackId,
+    pub tag: &'a PrTag,
+    pub last_group_seed: &'a str,
+    pub last_group_tip: &'a str,
+    pub last_stack_head: &'a str,
+    pub updated_at: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StackMetadataFile {
+    pub schema_version: u32,
+    pub stacks: BTreeMap<StackId, StackRecord>,
+    pub pr_branches: BTreeMap<PrBranchName, PrBranchRecord>,
+}
+
+impl Default for StackMetadataFile {
+    fn default() -> Self {
+        Self {
+            schema_version: STACK_METADATA_SCHEMA_VERSION,
+            stacks: BTreeMap::new(),
+            pr_branches: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackSnapshot {
+    pub stack_branch: StackBranchName,
+    pub stack_head: String,
+    pub base: String,
+    pub prefix: String,
+    pub groups: Vec<StackSnapshotGroup>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackSnapshotGroup {
+    pub pr_branch: PrBranchName,
+    pub tag: PrTag,
+    pub last_group_seed: String,
+    pub last_group_tip: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefreshMetadataContext {
+    pub base: String,
+    pub prefix: String,
+    pub ignore_tag: String,
+}
+
+fn metadata_dir(git_common_dir: &Path) -> PathBuf {
+    git_common_dir.join("spr")
+}
+
+pub fn metadata_path(git_common_dir: &Path) -> PathBuf {
+    metadata_dir(git_common_dir).join(STACK_METADATA_FILE_NAME)
+}
+
+fn metadata_lock_path(git_common_dir: &Path) -> PathBuf {
+    metadata_dir(git_common_dir).join(STACK_METADATA_LOCK_NAME)
+}
+
+fn now_rfc3339() -> Result<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format RFC3339 timestamp")
+}
+
+fn load_metadata_from_path(path: &Path) -> Result<Option<StackMetadataFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read stack metadata {}", path.display()))?;
+    let metadata: StackMetadataFile = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse stack metadata {}", path.display()))?;
+    if metadata.schema_version != STACK_METADATA_SCHEMA_VERSION {
+        bail!(
+            "stack metadata {} uses schema version {}, but this spr expects {}",
+            path.display(),
+            metadata.schema_version,
+            STACK_METADATA_SCHEMA_VERSION
+        );
+    }
+    Ok(Some(metadata))
+}
+
+pub fn load_metadata_for_repo_path(repo_path: &str) -> Result<Option<StackMetadataFile>> {
+    let git_common_dir = git_common_dir_at(repo_path)?;
+    load_metadata_from_path(&metadata_path(&git_common_dir))
+}
+
+fn ordered_known_branches(
+    preferred_branch: &StackBranchName,
+    known_branches: impl IntoIterator<Item = StackBranchName>,
+) -> Vec<StackBranchName> {
+    let mut ordered = vec![preferred_branch.clone()];
+    let remainder = known_branches
+        .into_iter()
+        .filter(|branch| branch != preferred_branch)
+        .collect::<BTreeSet<_>>();
+    ordered.extend(remainder);
+    ordered
+}
+
+fn resolve_stack_id_for_empty_snapshot(
+    metadata: &StackMetadataFile,
+    stack_branch: &StackBranchName,
+) -> Result<StackId> {
+    let matches = metadata
+        .stacks
+        .iter()
+        .filter(|(_, record)| {
+            record.preferred_branch == *stack_branch || record.known_branches.contains(stack_branch)
+        })
+        .map(|(stack_id, _)| stack_id.clone())
+        .collect::<BTreeSet<_>>();
+    if matches.len() > 1 {
+        bail!(
+            "empty stack snapshot for branch {} matches multiple recorded stack_ids",
+            stack_branch.0
+        );
+    } else if let Some(existing_stack_id) = matches.into_iter().next() {
+        Ok(existing_stack_id)
+    } else {
+        Ok(StackId::fresh())
+    }
+}
+
+fn resolve_stack_id_for_snapshot(
+    metadata: &StackMetadataFile,
+    snapshot: &StackSnapshot,
+) -> Result<StackId> {
+    if snapshot.groups.is_empty() {
+        return resolve_stack_id_for_empty_snapshot(metadata, &snapshot.stack_branch);
+    }
+
+    let matching_stack_ids = snapshot
+        .groups
+        .iter()
+        .filter_map(|group| metadata.pr_branches.get(&group.pr_branch))
+        .filter_map(PrBranchRecord::as_live)
+        .map(|record| record.stack_id.clone())
+        .collect::<BTreeSet<_>>();
+    if matching_stack_ids.len() > 1 {
+        bail!(
+            "live PR branch records for stack {} disagree on stack ownership",
+            snapshot.stack_branch.0
+        );
+    } else if let Some(existing_stack_id) = matching_stack_ids.into_iter().next() {
+        Ok(existing_stack_id)
+    } else {
+        Ok(StackId::fresh())
+    }
+}
+
+fn tombstone_record(record: &PrBranchRecord, updated_at: &str) -> PrBranchRecord {
+    PrBranchRecord::Tombstoned {
+        stack_id: record.stack_id().clone(),
+        tag: record.tag().clone(),
+        last_group_seed: record.last_group_seed().to_string(),
+        last_group_tip: record.last_group_tip().to_string(),
+        last_stack_head: record.last_stack_head().to_string(),
+        updated_at: updated_at.to_string(),
+        tombstone_reason: TombstoneReason::RemovedFromLiveStack,
+    }
+}
+
+fn apply_snapshot(
+    mut metadata: StackMetadataFile,
+    snapshot: &StackSnapshot,
+    updated_at: &str,
+) -> Result<StackMetadataFile> {
+    let stack_id = resolve_stack_id_for_snapshot(&metadata, snapshot)?;
+    let existing_stack = metadata.stacks.get(&stack_id).cloned();
+    let mut known_branches = existing_stack
+        .as_ref()
+        .map(|stack| {
+            stack
+                .known_branches
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    if let Some(existing_stack) = &existing_stack {
+        known_branches.insert(existing_stack.preferred_branch.clone());
+    }
+    known_branches.insert(snapshot.stack_branch.clone());
+
+    metadata.stacks.insert(
+        stack_id.clone(),
+        StackRecord {
+            preferred_branch: snapshot.stack_branch.clone(),
+            known_branches: ordered_known_branches(&snapshot.stack_branch, known_branches),
+            base: snapshot.base.clone(),
+            prefix: snapshot.prefix.clone(),
+            last_seen_head: snapshot.stack_head.clone(),
+            updated_at: updated_at.to_string(),
+        },
+    );
+
+    let live_pr_branches = snapshot
+        .groups
+        .iter()
+        .map(|group| group.pr_branch.clone())
+        .collect::<BTreeSet<_>>();
+
+    let tombstoned_names = metadata
+        .pr_branches
+        .iter()
+        .filter_map(|(branch_name, record)| match record {
+            PrBranchRecord::Live {
+                stack_id: owner, ..
+            } if *owner == stack_id && !live_pr_branches.contains(branch_name) => {
+                Some(branch_name.clone())
+            }
+            PrBranchRecord::Live { .. } | PrBranchRecord::Tombstoned { .. } => None,
+        })
+        .collect::<Vec<_>>();
+    for branch_name in tombstoned_names {
+        if let Some(record) = metadata.pr_branches.get(&branch_name).cloned() {
+            metadata
+                .pr_branches
+                .insert(branch_name, tombstone_record(&record, updated_at));
+        }
+    }
+
+    for group in &snapshot.groups {
+        metadata.pr_branches.insert(
+            group.pr_branch.clone(),
+            PrBranchRecord::Live {
+                stack_id: stack_id.clone(),
+                tag: group.tag.clone(),
+                last_group_seed: group.last_group_seed.clone(),
+                last_group_tip: group.last_group_tip.clone(),
+                last_stack_head: snapshot.stack_head.clone(),
+                updated_at: updated_at.to_string(),
+            },
+        );
+    }
+
+    Ok(metadata)
+}
+
+struct MetadataLock {
+    _file: File,
+    path: PathBuf,
+}
+
+impl Drop for MetadataLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn acquire_lock(lock_path: &Path) -> Result<MetadataLock> {
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create metadata directory {}", parent.display()))?;
+    }
+
+    for attempt in 0..LOCK_RETRY_ATTEMPTS {
+        match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(lock_path)
+        {
+            Ok(mut file) => {
+                writeln!(file, "pid={}", std::process::id()).with_context(|| {
+                    format!("failed to write lock file {}", lock_path.display())
+                })?;
+                return Ok(MetadataLock {
+                    _file: file,
+                    path: lock_path.to_path_buf(),
+                });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                if attempt + 1 == LOCK_RETRY_ATTEMPTS {
+                    break;
+                }
+                thread::sleep(LOCK_RETRY_INTERVAL);
+            }
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("failed to acquire metadata lock {}", lock_path.display())
+                });
+            }
+        }
+    }
+
+    bail!(
+        "timed out acquiring stack metadata lock {}",
+        lock_path.display()
+    );
+}
+
+fn write_metadata_atomically(path: &Path, metadata: &StackMetadataFile) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "stack metadata path {} has no parent directory",
+            path.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create metadata directory {}", parent.display()))?;
+
+    let json = serde_json::to_string_pretty(metadata).context("failed to encode stack metadata")?;
+    let temp_path = parent.join(format!(
+        ".{}.{}.tmp",
+        STACK_METADATA_FILE_NAME,
+        std::process::id()
+    ));
+    let write_result = (|| -> Result<()> {
+        let mut file = File::create(&temp_path).with_context(|| {
+            format!(
+                "failed to create temp metadata file {}",
+                temp_path.display()
+            )
+        })?;
+        file.write_all(json.as_bytes()).with_context(|| {
+            format!("failed to write temp metadata file {}", temp_path.display())
+        })?;
+        file.sync_all().with_context(|| {
+            format!("failed to sync temp metadata file {}", temp_path.display())
+        })?;
+        fs::rename(&temp_path, path).with_context(|| {
+            format!(
+                "failed to rename temp metadata file {} to {}",
+                temp_path.display(),
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if write_result.is_err() && temp_path.exists() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    write_result
+}
+
+pub fn build_snapshot_for_branch(
+    repo_path: &str,
+    stack_branch: &str,
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<StackSnapshot> {
+    let branch_reference = format!("refs/heads/{stack_branch}");
+    let stack_head = git_rev_parse_at(repo_path, &branch_reference)?;
+    let merge_base = git_ro_in(
+        repo_path,
+        ["merge-base", base, &branch_reference].as_slice(),
+    )?
+    .trim()
+    .to_string();
+    let range = format!("{merge_base}..{branch_reference}");
+    let lines = git_ro_in(
+        repo_path,
+        [
+            "log",
+            "--first-parent",
+            "--format=%H%x00%B%x1e",
+            "--reverse",
+            &range,
+        ]
+        .as_slice(),
+    )?;
+    let (leading_ignored, parsed_groups) = parse_groups_with_ignored(&lines, ignore_tag)?;
+    let (groups, _skipped_handles) = split_groups_for_update(&leading_ignored, parsed_groups);
+    let branch_identities = group_branch_identities(&groups, prefix)?;
+    let groups = groups
+        .iter()
+        .zip(branch_identities.iter())
+        .map(|(group, identity)| {
+            let last_group_seed = group
+                .commits
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow!("group pr:{} has no seed commit", group.tag))?;
+            let last_group_tip = group
+                .commits
+                .last()
+                .cloned()
+                .ok_or_else(|| anyhow!("group pr:{} has no tip commit", group.tag))?;
+            Ok(StackSnapshotGroup {
+                pr_branch: PrBranchName(identity.exact.clone()),
+                tag: PrTag(group.tag.clone()),
+                last_group_seed,
+                last_group_tip,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(StackSnapshot {
+        stack_branch: StackBranchName(stack_branch.to_string()),
+        stack_head,
+        base: base.to_string(),
+        prefix: prefix.to_string(),
+        groups,
+    })
+}
+
+pub fn build_snapshot_for_current_checkout(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<StackSnapshot> {
+    let repo_path = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
+    let stack_branch = git_current_branch()?;
+    if stack_branch == "HEAD" {
+        bail!("cannot refresh stack metadata from a detached HEAD checkout");
+    }
+    build_snapshot_for_branch(&repo_path, &stack_branch, base, prefix, ignore_tag)
+}
+
+pub fn refresh_metadata_for_current_checkout(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<()> {
+    let snapshot = build_snapshot_for_current_checkout(base, prefix, ignore_tag)?;
+    let git_common_dir = git_common_dir()?;
+    let path = metadata_path(&git_common_dir);
+    let lock_path = metadata_lock_path(&git_common_dir);
+    let _lock = acquire_lock(&lock_path)?;
+    let existing = load_metadata_from_path(&path)?.unwrap_or_default();
+    let updated_at = now_rfc3339()?;
+    let metadata = apply_snapshot(existing, &snapshot, &updated_at)?;
+    write_metadata_atomically(&path, &metadata)
+}
+
+pub fn refresh_metadata_for_branch(
+    repo_path: &str,
+    stack_branch: &str,
+    context: &RefreshMetadataContext,
+    git_common_dir_override: Option<&Path>,
+) -> Result<()> {
+    let snapshot = build_snapshot_for_branch(
+        repo_path,
+        stack_branch,
+        &context.base,
+        &context.prefix,
+        &context.ignore_tag,
+    )?;
+    let git_common_dir = if let Some(git_common_dir_override) = git_common_dir_override {
+        git_common_dir_override.to_path_buf()
+    } else {
+        git_common_dir_at(repo_path)?
+    };
+    let path = metadata_path(&git_common_dir);
+    let lock_path = metadata_lock_path(&git_common_dir);
+    let _lock = acquire_lock(&lock_path)?;
+    let existing = load_metadata_from_path(&path)?.unwrap_or_default();
+    let updated_at = now_rfc3339()?;
+    let metadata = apply_snapshot(existing, &snapshot, &updated_at)?;
+    write_metadata_atomically(&path, &metadata)
+}
+
+pub fn stack_ids_for_branch(metadata: &StackMetadataFile, stack_branch: &str) -> Vec<StackId> {
+    metadata
+        .stacks
+        .iter()
+        .filter(|(_, record)| {
+            record.preferred_branch.0 == stack_branch
+                || record
+                    .known_branches
+                    .iter()
+                    .any(|candidate| candidate.0 == stack_branch)
+        })
+        .map(|(stack_id, _)| stack_id.clone())
+        .collect()
+}
+
+pub fn verify_stack_branch_for_pr_record(
+    repo_path: &str,
+    candidate_branch: &StackBranchName,
+    stack_record: &StackRecord,
+    pr_branch_name: &PrBranchName,
+    pr_record: LivePrBranchRecord<'_>,
+    ignore_tag: &str,
+) -> Result<bool> {
+    let branch_reference = format!("refs/heads/{}", candidate_branch.0);
+    if !git_ref_exists_at(repo_path, &branch_reference)? {
+        return Ok(false);
+    }
+
+    let snapshot = build_snapshot_for_branch(
+        repo_path,
+        &candidate_branch.0,
+        &stack_record.base,
+        &stack_record.prefix,
+        ignore_tag,
+    )?;
+    let matching_groups = snapshot
+        .groups
+        .iter()
+        .filter(|group| {
+            group.pr_branch == *pr_branch_name
+                && group.last_group_seed == pr_record.last_group_seed
+                && group.last_group_tip == pr_record.last_group_tip
+        })
+        .count();
+    Ok(matching_groups == 1)
+}
+
+pub fn verify_stack_branch_for_stack_id(
+    repo_path: &str,
+    metadata: &StackMetadataFile,
+    candidate_branch: &StackBranchName,
+    stack_id: &StackId,
+    ignore_tag: &str,
+) -> Result<bool> {
+    let Some(stack_record) = metadata.stacks.get(stack_id) else {
+        return Ok(false);
+    };
+    let branch_reference = format!("refs/heads/{}", candidate_branch.0);
+    if !git_ref_exists_at(repo_path, &branch_reference)? {
+        return Ok(false);
+    }
+
+    let snapshot = build_snapshot_for_branch(
+        repo_path,
+        &candidate_branch.0,
+        &stack_record.base,
+        &stack_record.prefix,
+        ignore_tag,
+    )?;
+    let recorded_live_groups = metadata
+        .pr_branches
+        .iter()
+        .filter_map(|(branch_name, record)| {
+            record.as_live().and_then(|live_record| {
+                if live_record.stack_id == stack_id {
+                    Some((branch_name, live_record))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect::<BTreeMap<_, _>>();
+    if snapshot.groups.len() != recorded_live_groups.len() {
+        return Ok(false);
+    }
+
+    Ok(snapshot.groups.iter().all(|group| {
+        recorded_live_groups
+            .get(&group.pr_branch)
+            .map(|record| {
+                record.last_group_seed == group.last_group_seed
+                    && record.last_group_tip == group.last_group_tip
+            })
+            .unwrap_or(false)
+    }))
+}
+
+pub fn current_branch_or_none(repo_path: &str) -> Result<Option<String>> {
+    let branch = git_current_branch_at(repo_path)?;
+    if branch == "HEAD" {
+        Ok(None)
+    } else {
+        Ok(Some(branch))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        acquire_lock, apply_snapshot, load_metadata_from_path, metadata_lock_path,
+        ordered_known_branches, write_metadata_atomically, PrBranchName, PrBranchRecord, PrTag,
+        StackBranchName, StackId, StackMetadataFile, StackRecord, StackSnapshot,
+        StackSnapshotGroup, TombstoneReason, STACK_METADATA_SCHEMA_VERSION,
+    };
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn sample_snapshot(branch: &str, groups: &[(&str, &str, &str)]) -> StackSnapshot {
+        StackSnapshot {
+            stack_branch: StackBranchName(branch.to_string()),
+            stack_head: "head123".to_string(),
+            base: "origin/main".to_string(),
+            prefix: "dank-spr/".to_string(),
+            groups: groups
+                .iter()
+                .map(|(branch_name, seed, tip)| StackSnapshotGroup {
+                    pr_branch: PrBranchName((*branch_name).to_string()),
+                    tag: PrTag(branch_name.rsplit('/').next().unwrap().to_string()),
+                    last_group_seed: (*seed).to_string(),
+                    last_group_tip: (*tip).to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn ordered_known_branches_keeps_preferred_first() {
+        let preferred = StackBranchName("dank/stack".to_string());
+        let known = ordered_known_branches(
+            &preferred,
+            [
+                StackBranchName("tmp/old".to_string()),
+                preferred.clone(),
+                StackBranchName("dank/stack-2".to_string()),
+            ],
+        );
+
+        assert_eq!(known[0], preferred);
+        assert_eq!(known.len(), 3);
+    }
+
+    #[test]
+    fn apply_snapshot_promotes_branch_rename_and_tombstones_removed_prs() {
+        let existing = StackMetadataFile {
+            schema_version: STACK_METADATA_SCHEMA_VERSION,
+            stacks: BTreeMap::from([(
+                StackId("stack-1".to_string()),
+                StackRecord {
+                    preferred_branch: StackBranchName("dank/old-stack".to_string()),
+                    known_branches: vec![StackBranchName("dank/old-stack".to_string())],
+                    base: "origin/main".to_string(),
+                    prefix: "dank-spr/".to_string(),
+                    last_seen_head: "old-head".to_string(),
+                    updated_at: "2026-03-05T00:00:00Z".to_string(),
+                },
+            )]),
+            pr_branches: BTreeMap::from([
+                (
+                    PrBranchName("dank-spr/alpha".to_string()),
+                    PrBranchRecord::Live {
+                        stack_id: StackId("stack-1".to_string()),
+                        tag: PrTag("alpha".to_string()),
+                        last_group_seed: "a1".to_string(),
+                        last_group_tip: "a2".to_string(),
+                        last_stack_head: "old-head".to_string(),
+                        updated_at: "2026-03-05T00:00:00Z".to_string(),
+                    },
+                ),
+                (
+                    PrBranchName("dank-spr/beta".to_string()),
+                    PrBranchRecord::Live {
+                        stack_id: StackId("stack-1".to_string()),
+                        tag: PrTag("beta".to_string()),
+                        last_group_seed: "b1".to_string(),
+                        last_group_tip: "b2".to_string(),
+                        last_stack_head: "old-head".to_string(),
+                        updated_at: "2026-03-05T00:00:00Z".to_string(),
+                    },
+                ),
+            ]),
+        };
+        let snapshot = sample_snapshot("dank/new-stack", &[("dank-spr/alpha", "a1", "a2")]);
+
+        let updated = apply_snapshot(existing, &snapshot, "2026-03-05T01:00:00Z").unwrap();
+        let stack = updated.stacks.get(&StackId("stack-1".to_string())).unwrap();
+        assert_eq!(stack.preferred_branch.0, "dank/new-stack");
+        assert!(stack
+            .known_branches
+            .contains(&StackBranchName("dank/old-stack".to_string())));
+
+        match updated
+            .pr_branches
+            .get(&PrBranchName("dank-spr/beta".to_string()))
+            .unwrap()
+        {
+            PrBranchRecord::Tombstoned {
+                tombstone_reason, ..
+            } => assert_eq!(*tombstone_reason, TombstoneReason::RemovedFromLiveStack),
+            other => panic!("expected tombstone, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_snapshot_reuses_empty_stack_by_known_branch() {
+        let existing = StackMetadataFile {
+            schema_version: STACK_METADATA_SCHEMA_VERSION,
+            stacks: BTreeMap::from([(
+                StackId("stack-1".to_string()),
+                StackRecord {
+                    preferred_branch: StackBranchName("dank/stack".to_string()),
+                    known_branches: vec![StackBranchName("dank/stack".to_string())],
+                    base: "origin/main".to_string(),
+                    prefix: "dank-spr/".to_string(),
+                    last_seen_head: "old-head".to_string(),
+                    updated_at: "2026-03-05T00:00:00Z".to_string(),
+                },
+            )]),
+            pr_branches: BTreeMap::from([(
+                PrBranchName("dank-spr/alpha".to_string()),
+                PrBranchRecord::Live {
+                    stack_id: StackId("stack-1".to_string()),
+                    tag: PrTag("alpha".to_string()),
+                    last_group_seed: "a1".to_string(),
+                    last_group_tip: "a2".to_string(),
+                    last_stack_head: "old-head".to_string(),
+                    updated_at: "2026-03-05T00:00:00Z".to_string(),
+                },
+            )]),
+        };
+        let snapshot = sample_snapshot("dank/stack", &[]);
+
+        let updated = apply_snapshot(existing, &snapshot, "2026-03-05T02:00:00Z").unwrap();
+        match updated
+            .pr_branches
+            .get(&PrBranchName("dank-spr/alpha".to_string()))
+            .unwrap()
+        {
+            PrBranchRecord::Tombstoned { stack_id, .. } => {
+                assert_eq!(*stack_id, StackId("stack-1".to_string()))
+            }
+            other => panic!("expected tombstone, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_metadata_rejects_future_schema_version() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("stack_metadata_v1.json");
+        fs::write(
+            &path,
+            r#"{"schema_version":2,"stacks":{},"pr_branches":{}}"#,
+        )
+        .unwrap();
+
+        let err = load_metadata_from_path(&path).unwrap_err();
+        assert!(err.to_string().contains("schema version 2"));
+    }
+
+    #[test]
+    fn write_metadata_atomically_replaces_file_and_cleans_temp_state() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("stack_metadata_v1.json");
+        fs::write(&path, "old").unwrap();
+        let metadata = StackMetadataFile::default();
+
+        write_metadata_atomically(&path, &metadata).unwrap();
+
+        let written = fs::read_to_string(&path).unwrap();
+        assert!(written.contains("\"schema_version\": 1"));
+        assert!(fs::read_dir(dir.path()).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".tmp")));
+    }
+
+    #[test]
+    fn metadata_lock_file_is_removed_on_drop() {
+        let dir = TempDir::new().unwrap();
+        let git_common_dir = dir.path().join(".git");
+        fs::create_dir_all(&git_common_dir).unwrap();
+        let lock_path = metadata_lock_path(&git_common_dir);
+
+        {
+            let _lock = acquire_lock(&lock_path).unwrap();
+            assert!(lock_path.exists());
+        }
+
+        assert!(!lock_path.exists());
+    }
+}


### PR DESCRIPTION
# Problem Solved

When a range cherry-pick suspended on its first conflicting commit, Git kept the rest of the range in `.git/sequencer/todo`. If an operator resolved that conflict and ran `git cherry-pick --continue` before returning to `spr`, Git could silently replay later clean commits too. That forced `spr resume` to either accept arbitrary multi-commit advance or permanently degrade the rest of the replay into single-commit cherry-picks.

# Mental model

A suspended range is now split into two parts:
- the paused current commit, which remains Git's in-progress cherry-pick
- the untouched suffix, which `spr` persists as later `CherryPickOp`s and relaunches after the paused commit finishes

On suspend, `spr` trims Git's sequencer todo down to the current `pick`. One accidental manual `git cherry-pick --continue` is still tolerated, but it can only finish that paused commit. `spr resume` then restarts the remaining suffix as ranges where possible.

# Non-goals

- Do not broaden support for arbitrary manual replay surgery. Extra manual commits still fail closed.
- Do not change the operator-facing resume contract: resolve, stage, and run `spr resume <path>` remains the supported flow.
- Do not give up the range-based happy path before the first conflict.

# Tradeoffs

- This design now depends on Git's internal `sequencer/todo` file shape during suspended cherry-picks. That is less porcelain-stable than the previous chain-reconciliation fallback.
- In exchange, resume state gets simpler, manual continue has a tighter contract, and later untouched commits can stay batched instead of always replaying one by one.

# Architecture

- Serialize `CherryPickOp` directly so resume state can store one paused commit plus untouched later operations.
- On range conflict, trim `.git/sequencer/todo` to the current action and persist the remaining suffix as later `Commit` or `Range` operations.
- On resume, validate at most one accidental manual continue for the paused commit, then relaunch the untouched suffix through the normal op-level replay path.
- Update the temp-repo resume tests plus the schema-coupled `fix-pr` and `move` tests to use `paused_step` instead of the old flattened step index.

# Observability

- Suspended range state is now visible as a single paused source commit plus explicit later operations in the resume file.
- A manual `git cherry-pick --continue` that advances beyond the paused commit now fails with a direct "only one accidental manual continue is supported" error instead of being treated as a valid resumed chain.

# Tests

Test scope covers the shared resume engine plus the command tests that deserialize resume state. The new temp-repo proofs cover trimming `sequencer/todo`, relaunching a range suffix after one manual `git cherry-pick --continue`, and re-suspending later conflicts with a fresh suffix range. Validation ran with `cargo fmt`, `cargo clippy --tests --all-targets -- -D warnings`, and `cargo test`.

<!-- spr-stack:start -->
**Stack**:
- ➡ #120

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->