### PR TITLE
list/status: emit typed JSON summaries for stack discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,17 @@ Behavior:
 
 Machine-readable `--json` mode:
 
-- Supported on `spr restack`, `spr absorb`, `spr move`, `spr fix-pr`, `spr land`, and `spr resume`
+- Supported on `spr list pr`, `spr list commit`, `spr status`, `spr restack`, `spr absorb`,
+  `spr move`, `spr fix-pr`, `spr land`, and `spr resume`
 - In `--json` mode, stdout is exactly one JSON object and stderr is normally empty
+- `spr list pr --json`, `spr list commit --json`, and `spr status --json` use a read-only output
+  envelope and never suspend
+- Read-only JSON includes `repo_root`, `current_branch`, `base_branch`, `prefix`, and
+  `remote_metadata_state`
+- Read-only JSON always emits groups and commits in canonical bottom-up stack order, even when
+  `list_order: recent_on_top` changes the human display order
+- Read-only JSON error payloads use typed `error_kind` values such as
+  `synthetic_branch_name_collision`, `invalid_arguments`, and `internal`
 - Exit codes are:
   - `0` for completed
   - `1` for hard error, including CLI parse failures when `--json` was requested
@@ -406,6 +415,11 @@ Before listing, `spr list pr` validates that no two live PR groups derive
 synthetic branch names that collide under case-insensitive comparison. If they
 do, it halts before loading GitHub PR state.
 
+`spr list pr --json` emits one read-only JSON object instead of human-formatted lines.
+The payload always uses canonical bottom-up group order, includes remote PR metadata plus explicit
+CI/review state when available, and reports case-colliding synthetic branch failures as a typed
+`synthetic_branch_name_collision` error payload.
+
 ### spr status
 
 Aliases:
@@ -417,6 +431,9 @@ Alias for `spr list pr`.
 `spr status` runs the same early synthetic branch-collision validation as
 `spr list pr` before printing anything.
 
+`spr status --json` emits the same read-only payload shape as `spr list pr --json`, but keeps the
+top-level command identity as `status`.
+
 ### spr list commit
 
 Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top, and each group header also shows its stable `pr:<label>` handle.
@@ -424,6 +441,10 @@ Lists commits in the current stack, grouped by local PR. Display order is contro
 Before listing, `spr list commit` validates that no two live PR groups derive
 synthetic branch names that collide under case-insensitive comparison. If they
 do, it halts before loading GitHub PR state.
+
+`spr list commit --json` emits one read-only JSON object instead of human-formatted lines.
+The payload uses the same canonical bottom-up group order as `spr list pr --json`, keeps canonical
+global commit indices, and ignores `list_order` in JSON mode.
 
 Aliases:
 

--- a/src/branch_names.rs
+++ b/src/branch_names.rs
@@ -7,7 +7,7 @@
 //! become branch names, so branch-conflict decisions must use a canonicalized
 //! comparison key instead of raw string equality.
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::collections::HashMap;
 
 use crate::parsing::Group;
@@ -33,6 +33,20 @@ pub struct SyntheticBranchIdentity {
     pub conflict_key: CanonicalBranchConflictKey,
 }
 
+/// One live PR group whose synthetic branch name participates in a collision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyntheticBranchCollisionEntry {
+    pub stable_handle: String,
+    pub head_branch: String,
+}
+
+/// Two live PR groups whose derived synthetic branch names collide under case-folding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyntheticBranchNameCollision {
+    pub first: SyntheticBranchCollisionEntry,
+    pub second: SyntheticBranchCollisionEntry,
+}
+
 impl SyntheticBranchIdentity {
     pub fn new(prefix: &str, tag: &str) -> Self {
         let exact = format!("{prefix}{tag}");
@@ -56,6 +70,48 @@ pub fn synthetic_branch_name(prefix: &str, tag: &str) -> String {
     synthetic_branch_identity(prefix, tag).exact
 }
 
+impl std::fmt::Display for SyntheticBranchNameCollision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Refusing to operate on this stack because {} and {} derive conflicting synthetic branch names (`{}` and `{}`) under case-insensitive comparison. Stable handles remain exact-case, but these branch names are not safe to treat as distinct on a case-insensitive filesystem.",
+            self.first.stable_handle,
+            self.second.stable_handle,
+            self.first.head_branch,
+            self.second.head_branch
+        )
+    }
+}
+
+impl std::error::Error for SyntheticBranchNameCollision {}
+
+/// Return the first case-folding synthetic-branch collision in `groups`, if any.
+pub fn find_synthetic_branch_name_collision(
+    groups: &[Group],
+    prefix: &str,
+) -> Option<SyntheticBranchNameCollision> {
+    let mut seen: HashMap<CanonicalBranchConflictKey, SyntheticBranchCollisionEntry> =
+        HashMap::new();
+    for group in groups {
+        let head_branch = synthetic_branch_name(prefix, &group.tag);
+        let stable_handle = format!("pr:{}", group.tag);
+        let conflict_key = canonical_branch_conflict_key(&head_branch);
+        let entry = SyntheticBranchCollisionEntry {
+            stable_handle,
+            head_branch,
+        };
+        if let Some(previous) = seen.get(&conflict_key) {
+            return Some(SyntheticBranchNameCollision {
+                first: previous.clone(),
+                second: entry,
+            });
+        } else {
+            seen.insert(conflict_key, entry);
+        }
+    }
+    None
+}
+
 /// Derive synthetic branch identities for `groups` and reject canonical collisions.
 ///
 /// The returned vector preserves the input order. On collision, the error names
@@ -65,33 +121,21 @@ pub fn group_branch_identities(
     groups: &[Group],
     prefix: &str,
 ) -> Result<Vec<SyntheticBranchIdentity>> {
-    let mut identities = Vec::with_capacity(groups.len());
-    let mut seen: HashMap<CanonicalBranchConflictKey, (String, String)> = HashMap::new();
-    for group in groups {
-        let identity = synthetic_branch_identity(prefix, &group.tag);
-        if let Some((prior_tag, prior_branch)) = seen.get(&identity.conflict_key) {
-            return Err(anyhow!(
-                "Refusing to operate on this stack because pr:{} and pr:{} derive conflicting synthetic branch names (`{}` and `{}`) under case-insensitive comparison. Stable handles remain exact-case, but these branch names are not safe to treat as distinct on a case-insensitive filesystem.",
-                prior_tag,
-                group.tag,
-                prior_branch,
-                identity.exact
-            ));
-        } else {
-            seen.insert(
-                identity.conflict_key.clone(),
-                (group.tag.clone(), identity.exact.clone()),
-            );
-            identities.push(identity);
-        }
+    if let Some(collision) = find_synthetic_branch_name_collision(groups, prefix) {
+        Err(collision.into())
+    } else {
+        Ok(groups
+            .iter()
+            .map(|group| synthetic_branch_identity(prefix, &group.tag))
+            .collect())
     }
-    Ok(identities)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        canonical_branch_conflict_key, group_branch_identities, synthetic_branch_identity,
+        canonical_branch_conflict_key, find_synthetic_branch_name_collision,
+        group_branch_identities, synthetic_branch_identity,
     };
     use crate::parsing::Group;
 
@@ -144,5 +188,17 @@ mod tests {
         assert!(err.to_string().contains("pr:alpha and pr:Alpha"));
         assert!(err.to_string().contains("dank-spr/alpha"));
         assert!(err.to_string().contains("dank-spr/Alpha"));
+    }
+
+    #[test]
+    fn find_synthetic_branch_name_collision_returns_typed_entries() {
+        let collision =
+            find_synthetic_branch_name_collision(&[group("alpha"), group("Alpha")], "dank-spr/")
+                .unwrap();
+
+        assert_eq!(collision.first.stable_handle, "pr:alpha");
+        assert_eq!(collision.first.head_branch, "dank-spr/alpha");
+        assert_eq!(collision.second.stable_handle, "pr:Alpha");
+        assert_eq!(collision.second.head_branch, "dank-spr/Alpha");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,10 +30,18 @@ pub enum PrepSelection {
 pub enum ListWhat {
     /// List PRs in the stack (halts early if live groups derive case-colliding synthetic branch names)
     #[command(alias = "p")]
-    Pr,
+    Pr {
+        /// Emit a single machine-readable JSON object to stdout
+        #[arg(long)]
+        json: bool,
+    },
     /// List commits in the stack (halts early if live groups derive case-colliding synthetic branch names)
     #[command(alias = "c")]
-    Commit,
+    Commit {
+        /// Emit a single machine-readable JSON object to stdout
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -133,7 +141,9 @@ pub enum Cmd {
     /// Status overview (alias for `list pr`) with the same early synthetic branch-collision guard
     #[command(alias = "stat")]
     Status {
-        // no options; uses global flags
+        /// Emit a single machine-readable JSON object to stdout
+        #[arg(long)]
+        json: bool,
     },
 
     /// Find the owning stack branch for a PR branch or report that the target is already a stack branch
@@ -217,13 +227,12 @@ impl Cmd {
             | Self::Resume { json, .. }
             | Self::Land { json, .. }
             | Self::FixPr { json, .. }
+            | Self::Status { json, .. }
             | Self::Move { json, .. } => *json,
-            Self::Update { .. }
-            | Self::Prep {}
-            | Self::List { .. }
-            | Self::Status {}
-            | Self::RelinkPrs {}
-            | Self::Cleanup {} => false,
+            Self::List {
+                what: ListWhat::Pr { json, .. } | ListWhat::Commit { json, .. },
+            } => *json,
+            Self::Update { .. } | Self::Prep {} | Self::RelinkPrs {} | Self::Cleanup {} => false,
         }
     }
 }
@@ -344,8 +353,34 @@ mod tests {
         let land = Cli::try_parse_from(["spr", "land", "--json"]).unwrap();
         assert!(land.cmd.json_mode());
 
-        let list = Cli::try_parse_from(["spr", "list", "pr"]).unwrap();
-        assert!(!list.cmd.json_mode());
+        let list = Cli::try_parse_from(["spr", "list", "pr", "--json"]).unwrap();
+        assert!(list.cmd.json_mode());
+    }
+
+    #[test]
+    fn list_command_parses_json_flag() {
+        let cli = Cli::try_parse_from(["spr", "list", "commit", "--json"]).unwrap();
+
+        match cli.cmd {
+            Cmd::List {
+                what: super::ListWhat::Commit { json },
+            } => {
+                assert!(json);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn status_command_parses_json_flag() {
+        let cli = Cli::try_parse_from(["spr", "status", "--json"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Status { json } => {
+                assert!(json);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
     }
 
     #[test]
@@ -353,7 +388,7 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "status", "--cd", "/tmp/example"]).unwrap();
 
         assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
-        assert!(matches!(cli.cmd, Cmd::Status {}));
+        assert!(matches!(cli.cmd, Cmd::Status { json: false }));
     }
 
     #[test]
@@ -361,6 +396,6 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "--cd", "/tmp/example", "status"]).unwrap();
 
         assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
-        assert!(matches!(cli.cmd, Cmd::Status {}));
+        assert!(matches!(cli.cmd, Cmd::Status { json: false }));
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,8 +1,8 @@
-//! Display helpers for `spr list` output.
+//! Stack discovery and human rendering for `spr list`.
 //!
 //! The local stack order is derived bottom-up from commits and is the source of truth for
 //! local PR numbers and commit indices. `ListOrder` only affects which groups or commits
-//! are shown first; it does not change the underlying numbering.
+//! are shown first in human output; it does not change the canonical JSON ordering.
 //!
 //! For `spr list pr`, the leading two-character status slot is:
 //! - `CI` + `Review` symbols for open PRs
@@ -10,63 +10,137 @@
 //! - `??` when no matching PR metadata is available
 
 use anyhow::Result;
+use serde::Serialize;
 use std::collections::HashMap;
 use tracing::info;
 
-use crate::branch_names::{canonical_branch_conflict_key, group_branch_identities};
+use crate::branch_names::{
+    canonical_branch_conflict_key, find_synthetic_branch_name_collision, group_branch_identities,
+    CanonicalBranchConflictKey, SyntheticBranchIdentity, SyntheticBranchNameCollision,
+};
 use crate::config::ListOrder;
 use crate::github::{
-    fetch_pr_ci_review_status, list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
-    PrCiReviewStatus, PrState,
+    fetch_pr_ci_review_status, list_open_or_merged_prs_for_heads, PrCiReviewStatus,
+    PrInfoWithState, PrState,
 };
-use crate::parsing::derive_local_groups;
+use crate::parsing::{derive_local_groups, Group};
+use crate::read_only_output::RemoteMetadataState;
+
+#[derive(Debug)]
+pub enum ReadOnlyQueryError {
+    SyntheticBranchNameCollision(SyntheticBranchNameCollision),
+    Internal(anyhow::Error),
+}
+
+impl std::fmt::Display for ReadOnlyQueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SyntheticBranchNameCollision(collision) => write!(f, "{collision}"),
+            Self::Internal(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for ReadOnlyQueryError {}
+
+impl From<anyhow::Error> for ReadOnlyQueryError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Internal(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RemotePrMetadata {
+    pub pr_number: u64,
+    pub url: String,
+    pub base_branch: String,
+    pub state: PrState,
+    pub ci_review_status: Option<PrCiReviewStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PrGroupData {
+    pub local_pr_number: usize,
+    pub stable_handle: String,
+    pub head_branch: String,
+    pub first_commit_sha: String,
+    pub commit_count: usize,
+    pub first_subject: String,
+    pub remote: Option<RemotePrMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PrListData {
+    pub remote_metadata_state: RemoteMetadataState,
+    pub groups: Vec<PrGroupData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommitEntryData {
+    pub global_commit_index: usize,
+    pub sha: String,
+    pub subject: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommitGroupData {
+    pub local_pr_number: usize,
+    pub stable_handle: String,
+    pub head_branch: String,
+    pub remote: Option<RemotePrMetadata>,
+    pub commits: Vec<CommitEntryData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommitListData {
+    pub remote_metadata_state: RemoteMetadataState,
+    pub groups: Vec<CommitGroupData>,
+}
 
 /// Maps remote PR state into the two-character status slot used by `spr list pr`.
 ///
 /// Open PRs show CI and review icons independently, while merged PRs intentionally use the
 /// fixed marker `⑃M` so they are visually distinct from open green PRs (`✓✓`). If callers
-/// pass an open PR number that is missing from `status_map`, this returns `??`; displaying
-/// anything else would incorrectly imply CI/review information was fetched.
-fn status_icons(
-    pr_state: Option<PrState>,
-    pr_number: Option<u64>,
-    status_map: &HashMap<u64, PrCiReviewStatus>,
-) -> (&'static str, &'static str) {
-    match pr_state {
-        Some(PrState::Merged) => ("⑃", "M"),
-        Some(PrState::Open) => {
-            if let Some(n) = pr_number {
-                if let Some(st) = status_map.get(&n) {
-                    let ci_icon = match st.ci_state.as_str() {
-                        "SUCCESS" => "✓",
-                        "FAILURE" | "ERROR" => "✗",
-                        "PENDING" | "EXPECTED" => "◐",
-                        _ => "?",
-                    };
-                    let rv_icon = match st.review_decision.as_str() {
-                        "APPROVED" => "✓",
-                        "CHANGES_REQUESTED" => "✗",
-                        "REVIEW_REQUIRED" => "◐",
-                        _ => "?",
-                    };
-                    (ci_icon, rv_icon)
-                } else {
-                    ("?", "?")
-                }
+/// pass an open PR that is missing `ci_review_status`, this returns `??`; displaying anything
+/// else would incorrectly imply CI/review information was fetched.
+fn status_icons(remote: Option<&RemotePrMetadata>) -> (&'static str, &'static str) {
+    if let Some(remote) = remote {
+        if remote.state == PrState::Merged {
+            ("⑃", "M")
+        } else if let Some(status) = &remote.ci_review_status {
+            let ci_icon = if status.ci_state == "SUCCESS" {
+                "✓"
+            } else if status.ci_state == "FAILURE" || status.ci_state == "ERROR" {
+                "✗"
+            } else if status.ci_state == "PENDING" || status.ci_state == "EXPECTED" {
+                "◐"
             } else {
-                ("?", "?")
-            }
+                "?"
+            };
+            let rv_icon = if status.review_decision == "APPROVED" {
+                "✓"
+            } else if status.review_decision == "CHANGES_REQUESTED" {
+                "✗"
+            } else if status.review_decision == "REVIEW_REQUIRED" {
+                "◐"
+            } else {
+                "?"
+            };
+            (ci_icon, rv_icon)
+        } else {
+            ("?", "?")
         }
-        None => ("?", "?"),
+    } else {
+        ("?", "?")
     }
 }
 
-/// Return the subject shown on the indented summary line for a PR group.
-///
-/// This is always the first (oldest) commit subject in the group. Display ordering only
-/// controls which groups are listed first and must not change the per-group summary subject.
-fn summary_subject(subjects: &[String], _list_order: ListOrder) -> &str {
-    subjects.first().map(|s| s.as_str()).unwrap_or("")
+fn short_sha(sha: &str) -> &str {
+    if sha.len() >= 8 {
+        &sha[..8]
+    } else {
+        sha
+    }
 }
 
 fn stable_handle_text(tag: &str) -> String {
@@ -119,92 +193,286 @@ fn format_commit_group_header(
     format!("===== Local PR #{local_pr_num} / {stable_handle}{remote_pr_num} : {head_branch} =====")
 }
 
+fn derive_groups_and_identities(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> std::result::Result<(Vec<Group>, Vec<SyntheticBranchIdentity>), ReadOnlyQueryError> {
+    let (_merge_base, groups) =
+        derive_local_groups(base, ignore_tag).map_err(ReadOnlyQueryError::Internal)?;
+    if let Some(collision) = find_synthetic_branch_name_collision(&groups, prefix) {
+        Err(ReadOnlyQueryError::SyntheticBranchNameCollision(collision))
+    } else {
+        let identities =
+            group_branch_identities(&groups, prefix).map_err(ReadOnlyQueryError::Internal)?;
+        Ok((groups, identities))
+    }
+}
+
+fn fetch_remote_pr_metadata(
+    branch_identities: &[SyntheticBranchIdentity],
+) -> Result<(
+    RemoteMetadataState,
+    HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
+)> {
+    let heads: Vec<String> = branch_identities
+        .iter()
+        .map(|identity| identity.exact.clone())
+        .collect();
+    let prs = list_open_or_merged_prs_for_heads(&heads)?;
+    let open_numbers: Vec<u64> = prs
+        .iter()
+        .filter(|pr| pr.state == PrState::Open)
+        .map(|pr| pr.number)
+        .collect();
+    let (remote_metadata_state, status_map) = if open_numbers.is_empty() {
+        (RemoteMetadataState::Complete, HashMap::new())
+    } else if let Ok(status_map) = fetch_pr_ci_review_status(&open_numbers) {
+        (RemoteMetadataState::Complete, status_map)
+    } else {
+        (
+            RemoteMetadataState::CiReviewStatusUnavailable,
+            HashMap::new(),
+        )
+    };
+
+    Ok((
+        remote_metadata_state,
+        build_remote_pr_metadata(prs, &status_map),
+    ))
+}
+
+fn build_remote_pr_metadata(
+    prs: Vec<PrInfoWithState>,
+    status_map: &HashMap<u64, PrCiReviewStatus>,
+) -> HashMap<CanonicalBranchConflictKey, RemotePrMetadata> {
+    prs.into_iter()
+        .map(|pr| {
+            let ci_review_status = if pr.state == PrState::Open {
+                status_map.get(&pr.number).cloned()
+            } else {
+                None
+            };
+            (
+                canonical_branch_conflict_key(&pr.head),
+                RemotePrMetadata {
+                    pr_number: pr.number,
+                    url: pr.url,
+                    base_branch: pr.base,
+                    state: pr.state,
+                    ci_review_status,
+                },
+            )
+        })
+        .collect()
+}
+
+fn build_pr_list_data(
+    groups: &[Group],
+    branch_identities: &[SyntheticBranchIdentity],
+    remote_metadata_state: RemoteMetadataState,
+    remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
+) -> PrListData {
+    let groups = groups
+        .iter()
+        .enumerate()
+        .map(|(group_idx, group)| {
+            let identity = &branch_identities[group_idx];
+            PrGroupData {
+                local_pr_number: group_idx + 1,
+                stable_handle: stable_handle_text(&group.tag),
+                head_branch: identity.exact.clone(),
+                first_commit_sha: group.commits.first().cloned().unwrap_or_default(),
+                commit_count: group.commits.len(),
+                first_subject: group.subjects.first().cloned().unwrap_or_default(),
+                remote: remote_by_head.get(&identity.conflict_key).cloned(),
+            }
+        })
+        .collect();
+
+    PrListData {
+        remote_metadata_state,
+        groups,
+    }
+}
+
+fn build_commit_list_data(
+    groups: &[Group],
+    branch_identities: &[SyntheticBranchIdentity],
+    remote_metadata_state: RemoteMetadataState,
+    remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
+) -> CommitListData {
+    let group_start_indices: Vec<usize> = groups
+        .iter()
+        .scan(1, |next_index, group| {
+            let start_index = *next_index;
+            *next_index += group.commits.len();
+            Some(start_index)
+        })
+        .collect();
+
+    let groups = groups
+        .iter()
+        .enumerate()
+        .map(|(group_idx, group)| {
+            let identity = &branch_identities[group_idx];
+            let commits = group
+                .commits
+                .iter()
+                .zip(group.subjects.iter())
+                .enumerate()
+                .map(|(commit_offset, (sha, subject))| CommitEntryData {
+                    global_commit_index: group_start_indices[group_idx] + commit_offset,
+                    sha: sha.clone(),
+                    subject: subject.clone(),
+                })
+                .collect();
+            CommitGroupData {
+                local_pr_number: group_idx + 1,
+                stable_handle: stable_handle_text(&group.tag),
+                head_branch: identity.exact.clone(),
+                remote: remote_by_head.get(&identity.conflict_key).cloned(),
+                commits,
+            }
+        })
+        .collect();
+
+    CommitListData {
+        remote_metadata_state,
+        groups,
+    }
+}
+
+pub fn collect_pr_list_data_for_json(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> std::result::Result<PrListData, ReadOnlyQueryError> {
+    let (groups, branch_identities) = derive_groups_and_identities(base, prefix, ignore_tag)?;
+    let (remote_metadata_state, remote_by_head) =
+        fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?;
+    Ok(build_pr_list_data(
+        &groups,
+        &branch_identities,
+        remote_metadata_state,
+        &remote_by_head,
+    ))
+}
+
+pub fn collect_pr_list_data(base: &str, prefix: &str, ignore_tag: &str) -> Result<PrListData> {
+    collect_pr_list_data_for_json(base, prefix, ignore_tag).map_err(anyhow::Error::from)
+}
+
+pub fn collect_commit_list_data_for_json(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> std::result::Result<CommitListData, ReadOnlyQueryError> {
+    let (groups, branch_identities) = derive_groups_and_identities(base, prefix, ignore_tag)?;
+    let (remote_metadata_state, remote_by_head) =
+        fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?;
+    Ok(build_commit_list_data(
+        &groups,
+        &branch_identities,
+        remote_metadata_state,
+        &remote_by_head,
+    ))
+}
+
+pub fn collect_commit_list_data(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<CommitListData> {
+    collect_commit_list_data_for_json(base, prefix, ignore_tag).map_err(anyhow::Error::from)
+}
+
+fn render_pr_list(data: &PrListData, list_order: ListOrder) -> Vec<String> {
+    if data.groups.is_empty() {
+        vec!["No groups discovered; nothing to list.".to_string()]
+    } else {
+        let mut lines = vec![
+            format!("┏━━{}CI status", crate::format::EM_SPACE),
+            format!("┃┏━{}review status", crate::format::EM_SPACE),
+        ];
+        for group_idx in list_order.display_indices(data.groups.len()) {
+            let group = &data.groups[group_idx];
+            let (ci_icon, rv_icon) = status_icons(group.remote.as_ref());
+            lines.push(format_pr_summary_line(PrSummaryLine {
+                ci_icon,
+                rv_icon,
+                local_pr_num: group.local_pr_number,
+                stable_handle: &group.stable_handle,
+                short: short_sha(&group.first_commit_sha),
+                head_branch: &group.head_branch,
+                pr_number: group.remote.as_ref().map(|remote| remote.pr_number),
+                count: group.commit_count,
+            }));
+            lines.push(format!(
+                "{s}{s}{s}{s}{s}{subject}",
+                s = crate::format::EM_SPACE,
+                subject = group.first_subject
+            ));
+        }
+        lines
+    }
+}
+
+fn render_commit_list(data: &CommitListData, list_order: ListOrder) -> Vec<String> {
+    if data.groups.is_empty() {
+        vec!["No groups discovered; nothing to list.".to_string()]
+    } else {
+        let mut lines = Vec::new();
+        for group_idx in list_order.display_indices(data.groups.len()) {
+            let group = &data.groups[group_idx];
+            let remote_pr_number = group.remote.as_ref().and_then(|remote| {
+                if remote.state == PrState::Open {
+                    Some(remote.pr_number)
+                } else {
+                    None
+                }
+            });
+            lines.push(format_commit_group_header(
+                group.local_pr_number,
+                &group.stable_handle,
+                remote_pr_number,
+                &group.head_branch,
+            ));
+            let commit_iter: Box<dyn Iterator<Item = &CommitEntryData>> =
+                if list_order == ListOrder::RecentOnTop {
+                    Box::new(group.commits.iter().rev())
+                } else {
+                    Box::new(group.commits.iter())
+                };
+            for commit in commit_iter {
+                lines.push(format!(
+                    "{:>4}  {} - {}",
+                    commit.global_commit_index,
+                    short_sha(&commit.sha),
+                    commit.subject
+                ));
+            }
+            lines.push(String::new());
+        }
+        lines
+    }
+}
+
 /// Print a per-PR summary for the current local stack.
 ///
 /// The local stack order is derived bottom-up from commits, so local PR numbers are based
 /// on that ordering even when `list_order` reverses the display. If a caller assumes the
 /// first printed line is "LPR #1" in display order, the labels will be wrong under
 /// `RecentOnTop`.
-///
-/// Errors are returned when local groups or GitHub metadata cannot be loaded.
 pub fn list_prs_display(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
     list_order: ListOrder,
 ) -> Result<()> {
-    // Derive stack from local commits (source of truth)
-    let (_merge_base, groups) = derive_local_groups(base, ignore_tag)?;
-    if groups.is_empty() {
-        info!("No groups discovered; nothing to list.");
-        return Ok(());
-    }
-    let branch_identities = group_branch_identities(&groups, prefix)?;
-
-    // Fetch PRs to annotate with numbers and statuses when available.
-    // Optimize by querying only the heads in this local stack rather than scanning many PRs.
-    let heads: Vec<String> = branch_identities
-        .iter()
-        .map(|identity| identity.exact.clone())
-        .collect();
-    let prs = list_open_or_merged_prs_for_heads(&heads)?; // may be empty; that's fine
-    let prs_by_head: HashMap<_, _> = prs
-        .iter()
-        .map(|pr| (canonical_branch_conflict_key(&pr.head), pr))
-        .collect();
-    let mut status_map: HashMap<u64, PrCiReviewStatus> = HashMap::new();
-    if !prs.is_empty() {
-        let numbers: Vec<u64> = prs
-            .iter()
-            .filter(|p| p.state == PrState::Open)
-            .map(|p| p.number)
-            .collect();
-        if let Ok(m) = fetch_pr_ci_review_status(&numbers) {
-            status_map = m;
-        }
-    }
-
-    // Header showing columns for CI and Review status
-    info!("┏━━{}CI status", crate::format::EM_SPACE);
-    info!("┃┏━{}review status", crate::format::EM_SPACE);
-
-    let display_indices = list_order.display_indices(groups.len());
-    for group_idx in display_indices {
-        let g = &groups[group_idx];
-        let identity = &branch_identities[group_idx];
-        let head_branch = &identity.exact;
-        let pr = prs_by_head.get(&identity.conflict_key).copied();
-        let num = pr.map(|p| p.number);
-        let pr_state = pr.map(|p| p.state);
-        let count = g.commits.len();
-        let first_sha = g.commits.first().map(|s| s.as_str()).unwrap_or("");
-        let short = if first_sha.len() >= 8 {
-            &first_sha[..8]
-        } else {
-            first_sha
-        };
-        let (ci_icon, rv_icon) = status_icons(pr_state, num, &status_map);
-        let local_pr_num = group_idx + 1;
-        let stable_handle = stable_handle_text(&g.tag);
-        info!(
-            "{}",
-            format_pr_summary_line(PrSummaryLine {
-                ci_icon,
-                rv_icon,
-                local_pr_num,
-                stable_handle: &stable_handle,
-                short,
-                head_branch,
-                pr_number: num,
-                count,
-            })
-        );
-        let first_subject = summary_subject(&g.subjects, list_order);
-        info!(
-            "{s}{s}{s}{s}{s}{subject}",
-            s = crate::format::EM_SPACE,
-            subject = first_subject
-        );
+    let data = collect_pr_list_data(base, prefix, ignore_tag)?;
+    for line in render_pr_list(&data, list_order) {
+        info!("{line}");
     }
     Ok(())
 }
@@ -215,70 +483,15 @@ pub fn list_prs_display(
 /// is `RecentOnTop`, commits are shown newest-first but their indices still count from the
 /// bottom. If a caller treats the visible order as the numbering order, the output will
 /// look inconsistent to users.
-///
-/// Errors are returned when local groups or PR metadata cannot be loaded.
 pub fn list_commits_display(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
     list_order: ListOrder,
 ) -> Result<()> {
-    // Derive stack from local commits (source of truth)
-    let (_merge_base, groups) = derive_local_groups(base, ignore_tag)?;
-    if groups.is_empty() {
-        info!("No groups discovered; nothing to list.");
-        return Ok(());
-    }
-    let branch_identities = group_branch_identities(&groups, prefix)?;
-
-    // Fetch PRs to annotate groups with remote numbers when available
-    let heads: Vec<String> = branch_identities
-        .iter()
-        .map(|identity| identity.exact.clone())
-        .collect();
-    let prs = list_open_prs_for_heads(&heads)?; // may be empty; that's fine
-    let prs_by_head: HashMap<_, _> = prs
-        .iter()
-        .map(|pr| (canonical_branch_conflict_key(&pr.head), pr))
-        .collect();
-
-    // Precompute global commit numbering in bottom-up stack order.
-    let mut group_start_idx: Vec<usize> = Vec::with_capacity(groups.len());
-    let mut commit_counter: usize = 1; // 1-based, bottom-up
-    for g in &groups {
-        group_start_idx.push(commit_counter);
-        commit_counter += g.commits.len();
-    }
-
-    let display_indices = list_order.display_indices(groups.len());
-    for group_idx in display_indices {
-        let g = &groups[group_idx];
-        let identity = &branch_identities[group_idx];
-        let head_branch = &identity.exact;
-        let num = prs_by_head.get(&identity.conflict_key).map(|pr| pr.number);
-        let stable_handle = stable_handle_text(&g.tag);
-
-        // Group separator with local PR number
-        info!(
-            "{}",
-            format_commit_group_header(group_idx + 1, &stable_handle, num, head_branch)
-        );
-
-        let start_idx = group_start_idx[group_idx];
-        let commit_indices: Vec<usize> = if list_order == ListOrder::RecentOnTop {
-            (0..g.commits.len()).rev().collect()
-        } else {
-            (0..g.commits.len()).collect()
-        };
-        for j in commit_indices {
-            let sha = &g.commits[j];
-            let commit_idx = start_idx + j;
-            let short = if sha.len() >= 8 { &sha[..8] } else { sha };
-            let subject = g.subjects.get(j).map(|s| s.as_str()).unwrap_or("");
-            info!("{:>4}  {} - {}", commit_idx, short, subject);
-        }
-        // Blank line between groups for readability
-        info!("");
+    let data = collect_commit_list_data(base, prefix, ignore_tag)?;
+    for line in render_commit_list(&data, list_order) {
+        info!("{line}");
     }
     Ok(())
 }
@@ -287,56 +500,57 @@ pub fn list_commits_display(
 mod tests {
     use super::*;
     use crate::config::ListOrder;
+    use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
 
     #[test]
     fn status_icons_uses_merged_marker() {
-        let status_map = HashMap::new();
         assert_eq!(
-            status_icons(Some(PrState::Merged), Some(42), &status_map),
+            status_icons(Some(&RemotePrMetadata {
+                pr_number: 42,
+                url: "https://github.com/o/r/pull/42".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Merged,
+                ci_review_status: None,
+            })),
             ("⑃", "M")
         );
     }
 
     #[test]
     fn status_icons_maps_open_ci_and_review_states() {
-        let mut status_map = HashMap::new();
-        status_map.insert(
-            7,
-            PrCiReviewStatus {
-                ci_state: "SUCCESS".to_string(),
-                review_decision: "APPROVED".to_string(),
-            },
-        );
         assert_eq!(
-            status_icons(Some(PrState::Open), Some(7), &status_map),
+            status_icons(Some(&RemotePrMetadata {
+                pr_number: 7,
+                url: "https://github.com/o/r/pull/7".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Open,
+                ci_review_status: Some(PrCiReviewStatus {
+                    ci_state: "SUCCESS".to_string(),
+                    review_decision: "APPROVED".to_string(),
+                }),
+            })),
             ("✓", "✓")
         );
     }
 
     #[test]
     fn status_icons_unknown_when_status_missing() {
-        let status_map = HashMap::new();
         assert_eq!(
-            status_icons(Some(PrState::Open), Some(99), &status_map),
+            status_icons(Some(&RemotePrMetadata {
+                pr_number: 99,
+                url: "https://github.com/o/r/pull/99".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Open,
+                ci_review_status: None,
+            })),
             ("?", "?")
         );
     }
 
     #[test]
-    fn summary_subject_uses_first_commit_subject_for_any_display_order() {
-        let subjects = vec![
-            "oldest commit subject".to_string(),
-            "newest commit subject".to_string(),
-        ];
-
-        assert_eq!(
-            summary_subject(&subjects, ListOrder::RecentOnBottom),
-            "oldest commit subject"
-        );
-        assert_eq!(
-            summary_subject(&subjects, ListOrder::RecentOnTop),
-            "oldest commit subject"
-        );
+    fn short_sha_truncates_only_long_values() {
+        assert_eq!(short_sha("abcdef123456"), "abcdef12");
+        assert_eq!(short_sha("abc123"), "abc123");
     }
 
     #[test]
@@ -368,5 +582,266 @@ mod tests {
             format_commit_group_header(2, "pr:beta", None, "dank-spr/beta"),
             "===== Local PR #2 / pr:beta : dank-spr/beta ====="
         );
+    }
+
+    fn group(tag: &str, commits: &[(&str, &str)]) -> Group {
+        Group {
+            tag: tag.to_string(),
+            subjects: commits
+                .iter()
+                .map(|(_, subject)| (*subject).to_string())
+                .collect(),
+            commits: commits.iter().map(|(sha, _)| (*sha).to_string()).collect(),
+            first_message: None,
+            ignored_after: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn build_pr_list_data_uses_canonical_group_order() {
+        let groups = vec![
+            group("alpha", &[("aaaaaaaa1", "feat: alpha")]),
+            group("beta", &[("bbbbbbbb1", "feat: beta")]),
+        ];
+        let branch_identities = vec![
+            SyntheticBranchIdentity::new("dank-spr/", "alpha"),
+            SyntheticBranchIdentity::new("dank-spr/", "beta"),
+        ];
+        let remote_by_head = HashMap::from([(
+            canonical_branch_conflict_key("dank-spr/beta"),
+            RemotePrMetadata {
+                pr_number: 17,
+                url: "https://github.com/o/r/pull/17".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Open,
+                ci_review_status: Some(PrCiReviewStatus {
+                    ci_state: "SUCCESS".to_string(),
+                    review_decision: "APPROVED".to_string(),
+                }),
+            },
+        )]);
+
+        let data = build_pr_list_data(
+            &groups,
+            &branch_identities,
+            RemoteMetadataState::Complete,
+            &remote_by_head,
+        );
+
+        assert_eq!(data.remote_metadata_state, RemoteMetadataState::Complete);
+        assert_eq!(data.groups[0].local_pr_number, 1);
+        assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+        assert_eq!(data.groups[1].local_pr_number, 2);
+        assert_eq!(data.groups[1].stable_handle, "pr:beta");
+        assert_eq!(
+            data.groups[1]
+                .remote
+                .as_ref()
+                .map(|remote| remote.url.as_str()),
+            Some("https://github.com/o/r/pull/17")
+        );
+    }
+
+    #[test]
+    fn build_remote_pr_metadata_keeps_open_prs_when_status_map_is_empty() {
+        let metadata = build_remote_pr_metadata(
+            vec![
+                PrInfoWithState {
+                    number: 17,
+                    head: "dank-spr/alpha".to_string(),
+                    base: "main".to_string(),
+                    state: PrState::Open,
+                    url: "https://github.com/o/r/pull/17".to_string(),
+                },
+                PrInfoWithState {
+                    number: 18,
+                    head: "dank-spr/beta".to_string(),
+                    base: "main".to_string(),
+                    state: PrState::Merged,
+                    url: "https://github.com/o/r/pull/18".to_string(),
+                },
+            ],
+            &HashMap::new(),
+        );
+
+        assert_eq!(
+            metadata.get(&canonical_branch_conflict_key("dank-spr/alpha")),
+            Some(&RemotePrMetadata {
+                pr_number: 17,
+                url: "https://github.com/o/r/pull/17".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Open,
+                ci_review_status: None,
+            })
+        );
+        assert_eq!(
+            metadata.get(&canonical_branch_conflict_key("dank-spr/beta")),
+            Some(&RemotePrMetadata {
+                pr_number: 18,
+                url: "https://github.com/o/r/pull/18".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Merged,
+                ci_review_status: None,
+            })
+        );
+    }
+
+    #[test]
+    fn build_commit_list_data_uses_canonical_group_and_commit_order() {
+        let groups = vec![
+            group(
+                "alpha",
+                &[
+                    ("aaaaaaaa1", "feat: alpha one"),
+                    ("aaaaaaaa2", "feat: alpha two"),
+                ],
+            ),
+            group("beta", &[("bbbbbbbb1", "feat: beta one")]),
+        ];
+        let branch_identities = vec![
+            SyntheticBranchIdentity::new("dank-spr/", "alpha"),
+            SyntheticBranchIdentity::new("dank-spr/", "beta"),
+        ];
+        let remote_by_head = HashMap::from([(
+            canonical_branch_conflict_key("dank-spr/alpha"),
+            RemotePrMetadata {
+                pr_number: 11,
+                url: "https://github.com/o/r/pull/11".to_string(),
+                base_branch: "main".to_string(),
+                state: PrState::Open,
+                ci_review_status: None,
+            },
+        )]);
+
+        let data = build_commit_list_data(
+            &groups,
+            &branch_identities,
+            RemoteMetadataState::Complete,
+            &remote_by_head,
+        );
+
+        assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+        assert_eq!(
+            data.groups[0]
+                .commits
+                .iter()
+                .map(|commit| commit.global_commit_index)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(data.groups[1].stable_handle, "pr:beta");
+        assert_eq!(data.groups[1].commits[0].global_commit_index, 3);
+    }
+
+    #[test]
+    fn render_pr_list_preserves_recent_on_top_human_order() {
+        let data = PrListData {
+            remote_metadata_state: RemoteMetadataState::Complete,
+            groups: vec![
+                PrGroupData {
+                    local_pr_number: 1,
+                    stable_handle: "pr:alpha".to_string(),
+                    head_branch: "dank-spr/alpha".to_string(),
+                    first_commit_sha: "aaaaaaaa1".to_string(),
+                    commit_count: 1,
+                    first_subject: "feat: alpha".to_string(),
+                    remote: None,
+                },
+                PrGroupData {
+                    local_pr_number: 2,
+                    stable_handle: "pr:beta".to_string(),
+                    head_branch: "dank-spr/beta".to_string(),
+                    first_commit_sha: "bbbbbbbb1".to_string(),
+                    commit_count: 1,
+                    first_subject: "feat: beta".to_string(),
+                    remote: None,
+                },
+            ],
+        };
+
+        let lines = render_pr_list(&data, ListOrder::RecentOnTop);
+
+        assert_eq!(
+            lines[2],
+            "?? LPR #2 / pr:beta - bbbbbbbb : dank-spr/beta - 1 commit"
+        );
+        assert_eq!(
+            lines[3],
+            format!("{s}{s}{s}{s}{s}feat: beta", s = crate::format::EM_SPACE)
+        );
+        assert_eq!(
+            lines[4],
+            "?? LPR #1 / pr:alpha - aaaaaaaa : dank-spr/alpha - 1 commit"
+        );
+    }
+
+    #[test]
+    fn render_commit_list_preserves_recent_on_top_human_order() {
+        let data = CommitListData {
+            remote_metadata_state: RemoteMetadataState::Complete,
+            groups: vec![
+                CommitGroupData {
+                    local_pr_number: 1,
+                    stable_handle: "pr:alpha".to_string(),
+                    head_branch: "dank-spr/alpha".to_string(),
+                    remote: None,
+                    commits: vec![
+                        CommitEntryData {
+                            global_commit_index: 1,
+                            sha: "aaaaaaaa1".to_string(),
+                            subject: "feat: alpha one".to_string(),
+                        },
+                        CommitEntryData {
+                            global_commit_index: 2,
+                            sha: "aaaaaaaa2".to_string(),
+                            subject: "feat: alpha two".to_string(),
+                        },
+                    ],
+                },
+                CommitGroupData {
+                    local_pr_number: 2,
+                    stable_handle: "pr:beta".to_string(),
+                    head_branch: "dank-spr/beta".to_string(),
+                    remote: None,
+                    commits: vec![CommitEntryData {
+                        global_commit_index: 3,
+                        sha: "bbbbbbbb1".to_string(),
+                        subject: "feat: beta one".to_string(),
+                    }],
+                },
+            ],
+        };
+
+        let lines = render_commit_list(&data, ListOrder::RecentOnTop);
+
+        assert_eq!(
+            lines[0],
+            "===== Local PR #2 / pr:beta : dank-spr/beta ====="
+        );
+        assert_eq!(lines[1], "   3  bbbbbbbb - feat: beta one");
+        assert_eq!(
+            lines[3],
+            "===== Local PR #1 / pr:alpha : dank-spr/alpha ====="
+        );
+        assert_eq!(lines[4], "   2  aaaaaaaa - feat: alpha two");
+        assert_eq!(lines[5], "   1  aaaaaaaa - feat: alpha one");
+    }
+
+    #[test]
+    fn collect_pr_list_data_for_json_returns_typed_collision_error() {
+        let _lock = lock_cwd();
+        let repo = init_case_conflicting_stack_repo();
+        let _guard = DirGuard::change_to(repo.path());
+
+        let err =
+            collect_pr_list_data_for_json("main", "dank-spr/", "ignore").expect_err("collision");
+
+        match err {
+            ReadOnlyQueryError::SyntheticBranchNameCollision(collision) => {
+                assert_eq!(collision.first.stable_handle, "pr:alpha");
+                assert_eq!(collision.second.stable_handle, "pr:Alpha");
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,8 +16,12 @@ pub use absorb::{absorb_branch_tails, AbsorbOptions, CopiedLaterStackCommitPolic
 pub use cleanup::cleanup_remote_branches;
 pub use fix_pr::fix_pr_tail;
 pub use land::{land_flatten_until, land_per_pr_until};
-pub use list::list_commits_display;
-pub use list::list_prs_display;
+#[allow(unused_imports)]
+pub use list::{
+    collect_commit_list_data, collect_commit_list_data_for_json, collect_pr_list_data,
+    collect_pr_list_data_for_json, list_commits_display, list_prs_display, CommitEntryData,
+    CommitGroupData, CommitListData, PrGroupData, PrListData, ReadOnlyQueryError, RemotePrMetadata,
+};
 pub use prep::prep_squash;
 pub use r#move::{move_groups_after, MoveExecutionOptions};
 pub use relink_prs::relink_prs;

--- a/src/github.rs
+++ b/src/github.rs
@@ -9,7 +9,7 @@
 //! recent merges or closes.
 
 use anyhow::{anyhow, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::info;
@@ -36,7 +36,8 @@ pub struct OpenPrAutomergeInfo {
     pub auto_merge_enabled: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PrState {
     /// The head ref currently has an open pull request.
     Open,
@@ -53,7 +54,9 @@ pub enum PrState {
 pub struct PrInfoWithState {
     pub number: u64,
     pub head: String,
+    pub base: String,
     pub state: PrState,
+    pub url: String,
 }
 
 /// Terminal state for a branch-name reuse guard lookup.
@@ -605,7 +608,7 @@ pub fn fetch_pr_bodies_graphql(numbers: &[u64]) -> Result<HashMap<u64, PrBodyInf
     Ok(out)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PrCiReviewStatus {
     pub ci_state: String, // SUCCESS | FAILURE | ERROR | PENDING | EXPECTED | UNKNOWN
     pub review_decision: String, // APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | UNKNOWN
@@ -908,7 +911,21 @@ pub fn list_open_or_merged_prs_for_heads(heads: &[String]) -> Result<Vec<PrInfoW
             out.push(PrInfoWithState {
                 number: pr.number,
                 head: pr.head,
+                base: pr.base.ok_or_else(|| {
+                    anyhow!(
+                        "Open PR #{} missing baseRefName for requested head {}",
+                        pr.number,
+                        head
+                    )
+                })?,
                 state: PrState::Open,
+                url: pr.url.ok_or_else(|| {
+                    anyhow!(
+                        "Open PR #{} missing url for requested head {}",
+                        pr.number,
+                        head
+                    )
+                })?,
             });
         } else {
             heads_without_open_prs.push(head.clone());
@@ -934,7 +951,21 @@ pub fn list_open_or_merged_prs_for_heads(heads: &[String]) -> Result<Vec<PrInfoW
                 out.push(PrInfoWithState {
                     number: pr.number,
                     head: pr.head,
+                    base: pr.base.ok_or_else(|| {
+                        anyhow!(
+                            "Merged PR #{} missing baseRefName for requested head {}",
+                            pr.number,
+                            head
+                        )
+                    })?,
                     state: PrState::Merged,
+                    url: pr.url.ok_or_else(|| {
+                        anyhow!(
+                            "Merged PR #{} missing url for requested head {}",
+                            pr.number,
+                            head
+                        )
+                    })?,
                 });
             }
         }
@@ -1499,39 +1530,40 @@ mod tests {
     }
 
     #[test]
-    fn list_open_or_merged_prs_for_heads_uses_exact_open_then_exact_merged() {
+    fn list_open_or_merged_prs_for_heads_keeps_urls_for_exact_open_and_merged_matches() {
         let _lock = lock_cwd();
-        let exact_merged_json = graphql_nodes_response(&[
+        let exact_open_json = graphql_nodes_response(&[
             (
                 "pr0",
                 json!([{
-                    "number": 21,
+                    "number": 17,
                     "headRefName": "skilltest/alpha",
                     "baseRefName": "main",
-                    "state": "MERGED",
-                    "mergedAt": "2026-02-01T00:00:00Z",
-                    "closedAt": "2026-02-01T00:00:00Z",
-                    "url": "https://github.com/o/r/pull/21",
+                    "state": "OPEN",
+                    "mergedAt": null,
+                    "closedAt": null,
+                    "url": "https://github.com/o/r/pull/17",
                     "autoMergeRequest": null
                 }]),
             ),
-            (
-                "pr1",
-                json!([{
-                    "number": 22,
-                    "headRefName": "skilltest/beta",
-                    "baseRefName": "main",
-                    "state": "MERGED",
-                    "mergedAt": "2026-02-02T00:00:00Z",
-                    "closedAt": "2026-02-02T00:00:00Z",
-                    "url": "https://github.com/o/r/pull/22",
-                    "autoMergeRequest": null
-                }]),
-            ),
+            ("pr1", json!([])),
         ]);
+        let exact_merged_json = graphql_nodes_response(&[(
+            "pr0",
+            json!([{
+                "number": 22,
+                "headRefName": "skilltest/beta",
+                "baseRefName": "main",
+                "state": "MERGED",
+                "mergedAt": "2026-02-02T00:00:00Z",
+                "closedAt": "2026-02-02T00:00:00Z",
+                "url": "https://github.com/o/r/pull/22",
+                "autoMergeRequest": null
+            }]),
+        )]);
         let open_search_json = graphql_search_response(&[("pr0", json!([])), ("pr1", json!([]))]);
         let (_wrapper_dir, _data_dir, _path_guard, log_path) = install_gh_graphql_and_list_wrapper(
-            "[]",
+            &exact_open_json,
             &exact_merged_json,
             &graphql_nodes_response(&[]),
             &open_search_json,
@@ -1546,14 +1578,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(prs.len(), 2);
-        assert_eq!(prs[0].number, 21);
-        assert_eq!(prs[0].state, PrState::Merged);
+        assert_eq!(prs[0].number, 17);
+        assert_eq!(prs[0].state, PrState::Open);
+        assert_eq!(prs[0].url, "https://github.com/o/r/pull/17");
         assert_eq!(prs[1].number, 22);
         assert_eq!(prs[1].state, PrState::Merged);
+        assert_eq!(prs[1].url, "https://github.com/o/r/pull/22");
 
         let log = fs::read_to_string(log_path).unwrap();
         let lines: Vec<&str> = log.lines().collect();
-        assert_eq!(lines.len(), 5);
+        assert_eq!(lines.len(), 4);
         assert!(lines[0].contains("api graphql"));
         assert!(lines[0].contains("states:[OPEN]"));
         assert!(lines[1].contains("api graphql"));
@@ -1561,8 +1595,8 @@ mod tests {
         assert!(lines[1].contains("is:pr is:open head:skilltest/beta"));
         assert!(lines[2].contains("api graphql"));
         assert!(lines[2].contains("states:[MERGED]"));
-        assert!(lines[3].contains("pr list --state merged --search head:skilltest/alpha"));
-        assert!(lines[4].contains("pr list --state merged --search head:skilltest/beta"));
+        assert!(lines[2].contains("skilltest/beta"));
+        assert!(lines[3].contains("pr list --state merged --search head:skilltest/beta"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod limit;
 mod machine_output;
 mod parsing;
 mod pr_labels;
+mod read_only_output;
 mod selectors;
 mod stack_metadata;
 #[cfg(test)]
@@ -66,9 +67,9 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
             .map(crate::commands::looks_like_pr_url)
             .unwrap_or(false),
         crate::cli::Cmd::Update { .. }
-        | crate::cli::Cmd::Prep {}
         | crate::cli::Cmd::List { .. }
-        | crate::cli::Cmd::Status {}
+        | crate::cli::Cmd::Status { .. }
+        | crate::cli::Cmd::Prep {}
         | crate::cli::Cmd::Land { .. }
         | crate::cli::Cmd::RelinkPrs {}
         | crate::cli::Cmd::Cleanup {}
@@ -82,9 +83,11 @@ enum OutputMode {
     Json,
 }
 
+#[derive(Debug)]
 enum CommandOutput {
     None,
     Machine(crate::machine_output::MachineOutput),
+    ReadOnly(crate::read_only_output::ReadOnlyOutput),
     ResolveStack(crate::commands::ResolveStackOutput),
 }
 
@@ -199,6 +202,56 @@ fn ensure_resume_completed(
         Ok(crate::machine_output::MachineOutput::completed(
             crate::machine_output::MachineCommand::Resume,
         ))
+    }
+}
+
+fn read_only_pr_list_output(
+    command: crate::read_only_output::ReadOnlyCommand,
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> crate::read_only_output::ReadOnlyOutput {
+    match crate::commands::collect_pr_list_data_for_json(base, prefix, ignore_tag) {
+        Ok(data) => crate::read_only_output::ReadOnlyOutput::pr_list(command, base, prefix, data),
+        Err(crate::commands::ReadOnlyQueryError::SyntheticBranchNameCollision(collision)) => {
+            crate::read_only_output::ReadOnlyOutput::synthetic_branch_name_collision(
+                command, base, prefix, &collision,
+            )
+        }
+        Err(crate::commands::ReadOnlyQueryError::Internal(err)) => {
+            crate::read_only_output::ReadOnlyOutput::internal(
+                command,
+                base,
+                prefix,
+                format!("{err:#}"),
+            )
+        }
+    }
+}
+
+fn read_only_commit_list_output(
+    command: crate::read_only_output::ReadOnlyCommand,
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> crate::read_only_output::ReadOnlyOutput {
+    match crate::commands::collect_commit_list_data_for_json(base, prefix, ignore_tag) {
+        Ok(data) => {
+            crate::read_only_output::ReadOnlyOutput::commit_list(command, base, prefix, data)
+        }
+        Err(crate::commands::ReadOnlyQueryError::SyntheticBranchNameCollision(collision)) => {
+            crate::read_only_output::ReadOnlyOutput::synthetic_branch_name_collision(
+                command, base, prefix, &collision,
+            )
+        }
+        Err(crate::commands::ReadOnlyQueryError::Internal(err)) => {
+            crate::read_only_output::ReadOnlyOutput::internal(
+                command,
+                base,
+                prefix,
+                format!("{err:#}"),
+            )
+        }
     }
 }
 
@@ -363,20 +416,52 @@ fn run_cli(cli: crate::cli::Cli, output_mode: OutputMode) -> Result<CommandOutpu
             Ok(CommandOutput::None)
         }
         crate::cli::Cmd::List { what } => {
-            match what {
-                crate::cli::ListWhat::Pr => {
-                    crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
+            if output_mode == OutputMode::Json {
+                match what {
+                    crate::cli::ListWhat::Pr { .. } => {
+                        Ok(CommandOutput::ReadOnly(read_only_pr_list_output(
+                            crate::read_only_output::ReadOnlyCommand::ListPr,
+                            &base,
+                            &prefix,
+                            &ignore_tag,
+                        )))
+                    }
+                    crate::cli::ListWhat::Commit { .. } => {
+                        Ok(CommandOutput::ReadOnly(read_only_commit_list_output(
+                            crate::read_only_output::ReadOnlyCommand::ListCommit,
+                            &base,
+                            &prefix,
+                            &ignore_tag,
+                        )))
+                    }
                 }
-                crate::cli::ListWhat::Commit => {
-                    crate::commands::list_commits_display(&base, &prefix, &ignore_tag, list_order)?;
+            } else {
+                match what {
+                    crate::cli::ListWhat::Pr { .. } => {
+                        crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?
+                    }
+                    crate::cli::ListWhat::Commit { .. } => crate::commands::list_commits_display(
+                        &base,
+                        &prefix,
+                        &ignore_tag,
+                        list_order,
+                    )?,
                 }
+                Ok(CommandOutput::None)
             }
-            Ok(CommandOutput::None)
         }
-        crate::cli::Cmd::Status {} => {
-            // alias for `spr list pr`
-            crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
-            Ok(CommandOutput::None)
+        crate::cli::Cmd::Status { json: _ } => {
+            if output_mode == OutputMode::Json {
+                Ok(CommandOutput::ReadOnly(read_only_pr_list_output(
+                    crate::read_only_output::ReadOnlyCommand::Status,
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                )))
+            } else {
+                crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
+                Ok(CommandOutput::None)
+            }
         }
         crate::cli::Cmd::ResolveStack { target, json: _ } => Ok(CommandOutput::ResolveStack(
             crate::commands::resolve_stack(target, &ignore_tag)?,
@@ -541,6 +626,58 @@ fn raw_args_request_json(args: &[OsString]) -> bool {
         .any(|arg| arg.as_os_str() == OsStr::new("--json"))
 }
 
+fn read_only_command_for_cli(
+    cmd: &crate::cli::Cmd,
+) -> Option<crate::read_only_output::ReadOnlyCommand> {
+    match cmd {
+        crate::cli::Cmd::List {
+            what: crate::cli::ListWhat::Pr { .. },
+        } => Some(crate::read_only_output::ReadOnlyCommand::ListPr),
+        crate::cli::Cmd::List {
+            what: crate::cli::ListWhat::Commit { .. },
+        } => Some(crate::read_only_output::ReadOnlyCommand::ListCommit),
+        crate::cli::Cmd::Status { .. } => Some(crate::read_only_output::ReadOnlyCommand::Status),
+        _ => None,
+    }
+}
+
+fn read_only_command_for_raw_args(
+    args: &[OsString],
+) -> Option<crate::read_only_output::ReadOnlyCommand> {
+    let mut skip_value = false;
+    let mut saw_list = false;
+    for arg in args.iter().skip(1) {
+        if skip_value {
+            skip_value = false;
+        } else if let Some(arg) = arg.to_str() {
+            if arg == "--cd"
+                || arg == "--base"
+                || arg == "--prefix"
+                || arg == "--until"
+                || arg == "--exact"
+                || arg == "-b"
+            {
+                skip_value = true;
+            } else if saw_list && (arg == "pr" || arg == "p") {
+                return Some(crate::read_only_output::ReadOnlyCommand::ListPr);
+            } else if saw_list && (arg == "commit" || arg == "c") {
+                return Some(crate::read_only_output::ReadOnlyCommand::ListCommit);
+            } else if arg == "list" || arg == "ls" {
+                saw_list = true;
+            } else if arg == "status" || arg == "stat" {
+                return Some(crate::read_only_output::ReadOnlyCommand::Status);
+            } else if !arg.starts_with('-') {
+                saw_list = false;
+            }
+        }
+    }
+    if saw_list {
+        Some(crate::read_only_output::ReadOnlyCommand::Cli)
+    } else {
+        None
+    }
+}
+
 fn machine_command_for_raw_args(args: &[OsString]) -> crate::machine_output::MachineCommand {
     let mut skip_value = false;
     for arg in args.iter().skip(1) {
@@ -577,19 +714,36 @@ fn machine_command_for_raw_args(args: &[OsString]) -> crate::machine_output::Mac
     crate::machine_output::MachineCommand::Cli
 }
 
-fn parse_failure_as_machine_output(
+#[derive(Debug)]
+enum JsonParseFailureOutput {
+    Machine(crate::machine_output::MachineOutput),
+    ReadOnly(crate::read_only_output::ReadOnlyOutput),
+}
+
+fn parse_failure_as_json_output(
     args: &[OsString],
     err: &clap::Error,
-) -> Option<crate::machine_output::MachineOutput> {
+) -> Option<JsonParseFailureOutput> {
     let is_display_only = matches!(
         err.kind(),
         ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
     );
     if raw_args_request_json(args) && !is_display_only {
-        Some(crate::machine_output::MachineOutput::error(
-            machine_command_for_raw_args(args),
-            err.to_string(),
-        ))
+        if let Some(command) = read_only_command_for_raw_args(args) {
+            Some(JsonParseFailureOutput::ReadOnly(
+                crate::read_only_output::ReadOnlyOutput::invalid_arguments(
+                    command,
+                    err.to_string(),
+                ),
+            ))
+        } else {
+            Some(JsonParseFailureOutput::Machine(
+                crate::machine_output::MachineOutput::error(
+                    machine_command_for_raw_args(args),
+                    err.to_string(),
+                ),
+            ))
+        }
     } else {
         None
     }
@@ -600,9 +754,17 @@ fn main() {
     let cli = match crate::cli::Cli::try_parse_from(raw_args.clone()) {
         Ok(cli) => cli,
         Err(err) => {
-            if let Some(output) = parse_failure_as_machine_output(&raw_args, &err) {
-                println!("{}", serde_json::to_string(&output).unwrap());
-                std::process::exit(crate::machine_output::EXIT_FAILURE);
+            if let Some(output) = parse_failure_as_json_output(&raw_args, &err) {
+                match output {
+                    JsonParseFailureOutput::Machine(output) => {
+                        println!("{}", serde_json::to_string(&output).unwrap());
+                        std::process::exit(crate::machine_output::EXIT_FAILURE);
+                    }
+                    JsonParseFailureOutput::ReadOnly(output) => {
+                        println!("{}", serde_json::to_string(&output).unwrap());
+                        std::process::exit(crate::machine_output::EXIT_FAILURE);
+                    }
+                }
             } else {
                 err.exit();
             }
@@ -614,7 +776,8 @@ fn main() {
         OutputMode::Human
     };
     init_logging(cli.verbose, output_mode);
-    let command = machine_command_for_cli(&cli.cmd);
+    let rewrite_command = machine_command_for_cli(&cli.cmd);
+    let read_only_command = read_only_command_for_cli(&cli.cmd);
     match run_cli(cli, output_mode) {
         Ok(output) => match output {
             CommandOutput::None => {}
@@ -622,6 +785,11 @@ fn main() {
                 if output_mode == OutputMode::Json {
                     println!("{}", serde_json::to_string(&output).unwrap());
                     std::process::exit(output.exit_code());
+                }
+            }
+            CommandOutput::ReadOnly(output) => {
+                if output_mode == OutputMode::Json {
+                    println!("{}", serde_json::to_string(&output).unwrap());
                 }
             }
             CommandOutput::ResolveStack(output) => {
@@ -634,9 +802,19 @@ fn main() {
         },
         Err(err) => {
             if output_mode == OutputMode::Json {
-                let output =
-                    crate::machine_output::MachineOutput::error(command, format!("{err:#}"));
-                println!("{}", serde_json::to_string(&output).unwrap());
+                if let Some(command) = read_only_command {
+                    let output = crate::read_only_output::ReadOnlyOutput::internal_without_context(
+                        command,
+                        format!("{err:#}"),
+                    );
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                } else {
+                    let output = crate::machine_output::MachineOutput::error(
+                        rewrite_command,
+                        format!("{err:#}"),
+                    );
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                }
             } else {
                 eprintln!("Error: {err:#}");
             }
@@ -657,7 +835,7 @@ fn machine_command_for_cli(cmd: &crate::cli::Cmd) -> crate::machine_output::Mach
         crate::cli::Cmd::Update { .. }
         | crate::cli::Cmd::Prep {}
         | crate::cli::Cmd::List { .. }
-        | crate::cli::Cmd::Status {}
+        | crate::cli::Cmd::Status { .. }
         | crate::cli::Cmd::RelinkPrs {}
         | crate::cli::Cmd::Cleanup {} => crate::machine_output::MachineCommand::Restack,
     }
@@ -667,15 +845,23 @@ fn machine_command_for_cli(cmd: &crate::cli::Cmd) -> crate::machine_output::Mach
 mod tests {
     use super::{
         apply_working_directory_override, command_requires_gh, machine_command_for_raw_args,
-        parse_failure_as_machine_output, resolve_update_pr_limit,
+        parse_failure_as_json_output, read_only_command_for_raw_args, resolve_update_pr_limit,
+        run_cli, CommandOutput, JsonParseFailureOutput, OutputMode,
     };
     use crate::machine_output::{MachineCommand, MachinePayload};
     use crate::parsing::Group;
+    use crate::read_only_output::{
+        ReadOnlyCommand, ReadOnlyError, ReadOnlyPayload, RemoteMetadataState,
+    };
     use crate::selectors::{GroupSelector, StableHandle};
-    use crate::test_support::lock_cwd;
+    use crate::test_support::{
+        commit_file, git, init_case_conflicting_stack_repo, init_repo as init_stack_repo, lock_cwd,
+    };
     use clap::Parser;
+    use std::env;
     use std::ffi::OsString;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
     use std::process::Command;
     use tempfile::TempDir;
@@ -696,6 +882,44 @@ mod tests {
         fn drop(&mut self) {
             std::env::set_current_dir(&self.original).unwrap();
         }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            let original = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(original) = &self.original {
+                env::set_var(self.key, original);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn install_gh_wrapper(script_body: &str) -> (TempDir, EnvVarGuard) {
+        let wrapper_dir = tempfile::tempdir().unwrap();
+        let script_path = wrapper_dir.path().join("gh");
+        fs::write(&script_path, script_body).unwrap();
+        let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).unwrap();
+        let original_path = env::var("PATH").unwrap_or_default();
+        let path_guard = EnvVarGuard::set(
+            "PATH",
+            format!("{}:{}", wrapper_dir.path().display(), original_path),
+        );
+        (wrapper_dir, path_guard)
     }
 
     fn group(tag: &str) -> Group {
@@ -770,8 +994,10 @@ mod tests {
     }
 
     #[test]
-    fn status_still_requires_github_cli() {
-        assert!(command_requires_gh(&crate::cli::Cmd::Status {}));
+    fn status_requires_github_cli() {
+        assert!(command_requires_gh(&crate::cli::Cmd::Status {
+            json: false
+        }));
     }
 
     #[test]
@@ -845,27 +1071,88 @@ mod tests {
     }
 
     #[test]
-    fn parse_failure_with_json_returns_machine_error() {
+    fn read_only_command_for_raw_args_detects_list_status_commands() {
+        let list_args = vec![
+            OsString::from("spr"),
+            OsString::from("list"),
+            OsString::from("pr"),
+            OsString::from("--json"),
+        ];
+        let status_args = vec![
+            OsString::from("spr"),
+            OsString::from("status"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(
+            read_only_command_for_raw_args(&list_args),
+            Some(ReadOnlyCommand::ListPr)
+        );
+        assert_eq!(
+            read_only_command_for_raw_args(&status_args),
+            Some(ReadOnlyCommand::Status)
+        );
+    }
+
+    #[test]
+    fn parse_failure_with_json_returns_machine_error_for_rewrite_command() {
         let args = vec![
             OsString::from("spr"),
             OsString::from("restack"),
             OsString::from("--json"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output = parse_failure_as_machine_output(&args, &err)
-            .expect("json parse failure should serialize");
+        let output =
+            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
 
-        match output.payload {
-            MachinePayload::Error {
-                command,
-                ref message,
-            } => {
-                assert_eq!(command, MachineCommand::Restack);
-                assert!(message.contains("--after"));
+        match output {
+            JsonParseFailureOutput::Machine(output) => {
+                match output.payload {
+                    MachinePayload::Error {
+                        command,
+                        ref message,
+                    } => {
+                        assert_eq!(command, MachineCommand::Restack);
+                        assert!(message.contains("--after"));
+                    }
+                    other => panic!("unexpected parse-failure payload: {:?}", other),
+                }
+                assert_eq!(output.exit_code(), crate::machine_output::EXIT_FAILURE);
             }
-            other => panic!("unexpected parse-failure payload: {:?}", other),
+            other => panic!("unexpected parse-failure output: {:?}", other),
         }
-        assert_eq!(output.exit_code(), crate::machine_output::EXIT_FAILURE);
+    }
+
+    #[test]
+    fn parse_failure_with_json_returns_read_only_error_for_list_command() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("list"),
+            OsString::from("pr"),
+            OsString::from("--json"),
+            OsString::from("--bogus"),
+        ];
+        let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
+        let output =
+            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+
+        match output {
+            JsonParseFailureOutput::ReadOnly(output) => {
+                assert_eq!(output.command, ReadOnlyCommand::ListPr);
+                assert_eq!(output.schema_version, 1);
+                match output.payload {
+                    ReadOnlyPayload::Error {
+                        remote_metadata_state,
+                        error: ReadOnlyError::InvalidArguments { ref message },
+                    } => {
+                        assert_eq!(remote_metadata_state, RemoteMetadataState::NotRequested);
+                        assert!(message.contains("--bogus"));
+                    }
+                    other => panic!("unexpected read-only payload: {:?}", other),
+                }
+            }
+            other => panic!("unexpected parse-failure output: {:?}", other),
+        }
     }
 
     #[test]
@@ -873,7 +1160,7 @@ mod tests {
         let args = vec![OsString::from("spr"), OsString::from("restack")];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
 
-        assert!(parse_failure_as_machine_output(&args, &err).is_none());
+        assert!(parse_failure_as_json_output(&args, &err).is_none());
     }
 
     #[test]
@@ -886,6 +1173,464 @@ mod tests {
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected help output");
 
-        assert!(parse_failure_as_machine_output(&args, &err).is_none());
+        assert!(parse_failure_as_json_output(&args, &err).is_none());
+    }
+
+    fn init_local_stack_repo() -> TempDir {
+        let dir = init_stack_repo();
+        let repo = dir.path();
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        git(
+            repo,
+            ["remote", "add", "origin", "git@github.com:o/r.git"].as_slice(),
+        );
+        commit_file(repo, "alpha.txt", "alpha-1\n", "feat: alpha start pr:alpha");
+        commit_file(
+            repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\n",
+            "feat: alpha follow-up",
+        );
+        commit_file(repo, "beta.txt", "beta-1\n", "feat: beta start pr:beta");
+        fs::write(
+            repo.join(".spr_multicommit_cfg.yml"),
+            "list_order: recent_on_top\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    fn list_json_gh_script(
+        log_path: &std::path::Path,
+        open_json_path: &std::path::Path,
+        status_json_path: &std::path::Path,
+    ) -> String {
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*)\n      cat \"{}\" ;;\n    *\"is:pr is:open head:dank-spr/alpha\"*)\n      echo '{{\"data\":{{\"pr0\":{{\"nodes\":[]}},\"pr1\":{{\"nodes\":[]}}}}}}' ;;\n    *\"pullRequest(number: 17)\"*\"pullRequest(number: 18)\"*)\n      cat \"{}\" ;;\n    *)\n      echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n  echo '[]'\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display(),
+            open_json_path.display(),
+            status_json_path.display()
+        )
+    }
+
+    #[test]
+    fn run_cli_list_pr_json_uses_canonical_group_order() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_local_stack_repo();
+        let log_path = repo.path().join("gh.log");
+        let open_json_path = repo.path().join("gh-open.json");
+        let status_json_path = repo.path().join("gh-status.json");
+        fs::write(
+            &open_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "nodes": [{
+                                "number": 17,
+                                "headRefName": "dank-spr/alpha",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/17",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        },
+                        "pr1": {
+                            "nodes": [{
+                                "number": 18,
+                                "headRefName": "dank-spr/beta",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/18",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &status_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "reviewDecision": "APPROVED",
+                            "isDraft": false,
+                            "reviewRequests": { "totalCount": 0 },
+                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": { "state": "SUCCESS" }
+                                    }
+                                }]
+                            }
+                        },
+                        "pr1": {
+                            "reviewDecision": "REVIEW_REQUIRED",
+                            "isDraft": false,
+                            "reviewRequests": { "totalCount": 0 },
+                            "reviews": { "nodes": [] },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": { "state": "PENDING" }
+                                    }
+                                }]
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "list",
+            "pr",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::ReadOnly(output) => {
+                assert_eq!(output.command, ReadOnlyCommand::ListPr);
+                match output.payload {
+                    ReadOnlyPayload::PrList { data } => {
+                        assert_eq!(data.remote_metadata_state, RemoteMetadataState::Complete);
+                        assert_eq!(data.groups.len(), 2);
+                        assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+                        assert_eq!(data.groups[0].local_pr_number, 1);
+                        assert_eq!(data.groups[1].stable_handle, "pr:beta");
+                        assert_eq!(
+                            data.groups[1]
+                                .remote
+                                .as_ref()
+                                .and_then(|remote| remote.ci_review_status.as_ref())
+                                .map(|status| status.review_decision.as_str()),
+                            Some("REVIEW_REQUIRED")
+                        );
+                        let json = serde_json::to_string(
+                            &crate::read_only_output::ReadOnlyOutput::pr_list(
+                                ReadOnlyCommand::ListPr,
+                                "main",
+                                "dank-spr/",
+                                data,
+                            ),
+                        )
+                        .unwrap();
+                        assert!(!json.contains("CI status"));
+                        assert!(!json.contains("review status"));
+                    }
+                    other => panic!("unexpected read-only payload: {:?}", other),
+                }
+            }
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_cli_status_json_matches_list_pr_payload() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_local_stack_repo();
+        let log_path = repo.path().join("gh.log");
+        let open_json_path = repo.path().join("gh-open.json");
+        let status_json_path = repo.path().join("gh-status.json");
+        fs::write(
+            &open_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "nodes": [{
+                                "number": 17,
+                                "headRefName": "dank-spr/alpha",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/17",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        },
+                        "pr1": {
+                            "nodes": [{
+                                "number": 18,
+                                "headRefName": "dank-spr/beta",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/18",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &status_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "reviewDecision": "APPROVED",
+                            "isDraft": false,
+                            "reviewRequests": { "totalCount": 0 },
+                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": { "state": "SUCCESS" }
+                                    }
+                                }]
+                            }
+                        },
+                        "pr1": {
+                            "reviewDecision": "REVIEW_REQUIRED",
+                            "isDraft": false,
+                            "reviewRequests": { "totalCount": 0 },
+                            "reviews": { "nodes": [] },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": { "state": "PENDING" }
+                                    }
+                                }]
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let list_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "list",
+            "pr",
+            "--json",
+        ])
+        .unwrap();
+        let status_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "status",
+            "--json",
+        ])
+        .unwrap();
+
+        let list_output = run_cli(list_cli, OutputMode::Json).unwrap();
+        let status_output = run_cli(status_cli, OutputMode::Json).unwrap();
+
+        match (list_output, status_output) {
+            (CommandOutput::ReadOnly(list_output), CommandOutput::ReadOnly(status_output)) => {
+                assert_eq!(list_output.command, ReadOnlyCommand::ListPr);
+                assert_eq!(status_output.command, ReadOnlyCommand::Status);
+                assert_eq!(list_output.payload, status_output.payload);
+            }
+            other => panic!("unexpected command outputs: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_cli_list_commit_json_preserves_canonical_indices() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_local_stack_repo();
+        let log_path = repo.path().join("gh.log");
+        let open_json_path = repo.path().join("gh-open.json");
+        let status_json_path = repo.path().join("gh-status.json");
+        fs::write(
+            &open_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "nodes": [{
+                                "number": 17,
+                                "headRefName": "dank-spr/alpha",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/17",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        },
+                        "pr1": {
+                            "nodes": [{
+                                "number": 18,
+                                "headRefName": "dank-spr/beta",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/18",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &status_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "reviewDecision": "APPROVED",
+                            "isDraft": false,
+                            "reviewRequests": { "totalCount": 0 },
+                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": { "state": "SUCCESS" }
+                                    }
+                                }]
+                            }
+                        },
+                        "pr1": {
+                            "reviewDecision": "REVIEW_REQUIRED",
+                            "isDraft": false,
+                            "reviewRequests": { "totalCount": 0 },
+                            "reviews": { "nodes": [] },
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": { "state": "PENDING" }
+                                    }
+                                }]
+                            }
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "list",
+            "commit",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::ReadOnly(output) => match output.payload {
+                ReadOnlyPayload::CommitList { data } => {
+                    assert_eq!(data.remote_metadata_state, RemoteMetadataState::Complete);
+                    assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+                    assert_eq!(
+                        data.groups[0]
+                            .commits
+                            .iter()
+                            .map(|commit| commit.global_commit_index)
+                            .collect::<Vec<_>>(),
+                        vec![1, 2]
+                    );
+                    assert_eq!(data.groups[1].stable_handle, "pr:beta");
+                    assert_eq!(data.groups[1].commits[0].global_commit_index, 3);
+                }
+                other => panic!("unexpected read-only payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_cli_list_pr_json_collision_error_is_typed() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_case_conflicting_stack_repo();
+        let log_path = repo.path().join("gh.log");
+        let script = format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "list",
+            "pr",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::ReadOnly(output) => match output.payload {
+                ReadOnlyPayload::Error {
+                    remote_metadata_state,
+                    error: ReadOnlyError::SyntheticBranchNameCollision { conflicting_groups },
+                } => {
+                    assert_eq!(remote_metadata_state, RemoteMetadataState::NotRequested);
+                    assert_eq!(conflicting_groups[0].stable_handle, "pr:alpha");
+                    assert_eq!(conflicting_groups[1].head_branch, "dank-spr/Alpha");
+                    let gh_log = fs::read_to_string(log_path).unwrap_or_default();
+                    assert!(gh_log.is_empty());
+                }
+                other => panic!("unexpected read-only payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
     }
 }

--- a/src/read_only_output.rs
+++ b/src/read_only_output.rs
@@ -1,0 +1,351 @@
+//! Machine-readable output for read-only discovery commands.
+//!
+//! Rewrite-style commands use [`crate::machine_output`] because they need suspension-aware
+//! lifecycle states. Read-only discovery commands need schema-versioned snapshots in canonical
+//! stack order plus typed error results instead.
+
+use serde::Serialize;
+
+pub const READ_ONLY_OUTPUT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReadOnlyCommand {
+    Cli,
+    ListPr,
+    ListCommit,
+    Status,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteMetadataState {
+    Complete,
+    CiReviewStatusUnavailable,
+    NotRequested,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ReadOnlyContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prefix: Option<String>,
+}
+
+impl ReadOnlyContext {
+    fn capture(base: Option<&str>, prefix: Option<&str>) -> Self {
+        let repo_root = crate::git::repo_root().ok().flatten();
+        let current_branch = if let Some(repo_root) = repo_root.as_deref() {
+            crate::stack_metadata::current_branch_or_none(repo_root)
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+        Self {
+            repo_root,
+            current_branch,
+            base_branch: base.map(str::to_string),
+            prefix: prefix.map(str::to_string),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReadOnlyOutput {
+    pub schema_version: u32,
+    pub command: ReadOnlyCommand,
+    #[serde(flatten)]
+    context: ReadOnlyContext,
+    #[serde(flatten)]
+    pub payload: ReadOnlyPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ReadOnlyPayload {
+    Error {
+        remote_metadata_state: RemoteMetadataState,
+        #[serde(flatten)]
+        error: ReadOnlyError,
+    },
+    PrList {
+        #[serde(flatten)]
+        data: crate::commands::PrListData,
+    },
+    CommitList {
+        #[serde(flatten)]
+        data: crate::commands::CommitListData,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CollisionGroup {
+    pub stable_handle: String,
+    pub head_branch: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "error_kind", rename_all = "snake_case")]
+pub enum ReadOnlyError {
+    SyntheticBranchNameCollision {
+        conflicting_groups: Vec<CollisionGroup>,
+    },
+    InvalidArguments {
+        message: String,
+    },
+    Internal {
+        message: String,
+    },
+}
+
+impl ReadOnlyOutput {
+    fn new(command: ReadOnlyCommand, context: ReadOnlyContext, payload: ReadOnlyPayload) -> Self {
+        Self {
+            schema_version: READ_ONLY_OUTPUT_SCHEMA_VERSION,
+            command,
+            context,
+            payload,
+        }
+    }
+
+    pub fn pr_list(
+        command: ReadOnlyCommand,
+        base: &str,
+        prefix: &str,
+        data: crate::commands::PrListData,
+    ) -> Self {
+        Self::new(
+            command,
+            ReadOnlyContext::capture(Some(base), Some(prefix)),
+            ReadOnlyPayload::PrList { data },
+        )
+    }
+
+    pub fn commit_list(
+        command: ReadOnlyCommand,
+        base: &str,
+        prefix: &str,
+        data: crate::commands::CommitListData,
+    ) -> Self {
+        Self::new(
+            command,
+            ReadOnlyContext::capture(Some(base), Some(prefix)),
+            ReadOnlyPayload::CommitList { data },
+        )
+    }
+
+    pub fn invalid_arguments(command: ReadOnlyCommand, message: String) -> Self {
+        Self::new(
+            command,
+            ReadOnlyContext::capture(None, None),
+            ReadOnlyPayload::Error {
+                remote_metadata_state: RemoteMetadataState::NotRequested,
+                error: ReadOnlyError::InvalidArguments { message },
+            },
+        )
+    }
+
+    pub fn synthetic_branch_name_collision(
+        command: ReadOnlyCommand,
+        base: &str,
+        prefix: &str,
+        collision: &crate::branch_names::SyntheticBranchNameCollision,
+    ) -> Self {
+        Self::new(
+            command,
+            ReadOnlyContext::capture(Some(base), Some(prefix)),
+            ReadOnlyPayload::Error {
+                remote_metadata_state: RemoteMetadataState::NotRequested,
+                error: ReadOnlyError::SyntheticBranchNameCollision {
+                    conflicting_groups: vec![
+                        CollisionGroup {
+                            stable_handle: collision.first.stable_handle.clone(),
+                            head_branch: collision.first.head_branch.clone(),
+                        },
+                        CollisionGroup {
+                            stable_handle: collision.second.stable_handle.clone(),
+                            head_branch: collision.second.head_branch.clone(),
+                        },
+                    ],
+                },
+            },
+        )
+    }
+
+    pub fn internal(command: ReadOnlyCommand, base: &str, prefix: &str, message: String) -> Self {
+        Self::new(
+            command,
+            ReadOnlyContext::capture(Some(base), Some(prefix)),
+            ReadOnlyPayload::Error {
+                remote_metadata_state: RemoteMetadataState::NotRequested,
+                error: ReadOnlyError::Internal { message },
+            },
+        )
+    }
+
+    pub fn internal_without_context(command: ReadOnlyCommand, message: String) -> Self {
+        Self::new(
+            command,
+            ReadOnlyContext::capture(None, None),
+            ReadOnlyPayload::Error {
+                remote_metadata_state: RemoteMetadataState::NotRequested,
+                error: ReadOnlyError::Internal { message },
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CollisionGroup, ReadOnlyCommand, ReadOnlyError, ReadOnlyOutput, ReadOnlyPayload,
+        READ_ONLY_OUTPUT_SCHEMA_VERSION,
+    };
+    use crate::commands::{
+        CommitEntryData, CommitGroupData, CommitListData, PrGroupData, PrListData, RemotePrMetadata,
+    };
+    use crate::github::PrState;
+    use crate::read_only_output::RemoteMetadataState;
+
+    #[test]
+    fn schema_version_is_stable() {
+        assert_eq!(READ_ONLY_OUTPUT_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn command_serializes_in_kebab_case() {
+        let json = serde_json::to_string(&ReadOnlyCommand::ListPr).unwrap();
+
+        assert_eq!(json, "\"list-pr\"");
+    }
+
+    #[test]
+    fn invalid_arguments_output_uses_typed_error_payload() {
+        let output = ReadOnlyOutput::invalid_arguments(
+            ReadOnlyCommand::Status,
+            "unexpected flag".to_string(),
+        );
+
+        assert_eq!(output.schema_version, READ_ONLY_OUTPUT_SCHEMA_VERSION);
+        assert_eq!(output.command, ReadOnlyCommand::Status);
+        assert_eq!(
+            output.payload,
+            ReadOnlyPayload::Error {
+                remote_metadata_state: RemoteMetadataState::NotRequested,
+                error: ReadOnlyError::InvalidArguments {
+                    message: "unexpected flag".to_string(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn pr_list_output_flattens_canonical_data() {
+        let output = ReadOnlyOutput::pr_list(
+            ReadOnlyCommand::ListPr,
+            "main",
+            "dank-spr/",
+            PrListData {
+                remote_metadata_state: RemoteMetadataState::Complete,
+                groups: vec![PrGroupData {
+                    local_pr_number: 1,
+                    stable_handle: "pr:alpha".to_string(),
+                    head_branch: "dank-spr/alpha".to_string(),
+                    first_commit_sha: "aaaaaaaa1".to_string(),
+                    commit_count: 1,
+                    first_subject: "feat: alpha".to_string(),
+                    remote: Some(RemotePrMetadata {
+                        pr_number: 11,
+                        url: "https://github.com/o/r/pull/11".to_string(),
+                        base_branch: "main".to_string(),
+                        state: PrState::Open,
+                        ci_review_status: None,
+                    }),
+                }],
+            },
+        );
+
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["command"], "list-pr");
+        assert_eq!(json["base_branch"], "main");
+        assert_eq!(json["prefix"], "dank-spr/");
+        assert_eq!(json["result"], "pr_list");
+        assert_eq!(json["remote_metadata_state"], "complete");
+        assert_eq!(json["groups"][0]["local_pr_number"], 1);
+    }
+
+    #[test]
+    fn commit_list_output_flattens_canonical_data() {
+        let output = ReadOnlyOutput::commit_list(
+            ReadOnlyCommand::ListCommit,
+            "main",
+            "dank-spr/",
+            CommitListData {
+                remote_metadata_state: RemoteMetadataState::CiReviewStatusUnavailable,
+                groups: vec![CommitGroupData {
+                    local_pr_number: 1,
+                    stable_handle: "pr:alpha".to_string(),
+                    head_branch: "dank-spr/alpha".to_string(),
+                    remote: None,
+                    commits: vec![CommitEntryData {
+                        global_commit_index: 1,
+                        sha: "aaaaaaaa1".to_string(),
+                        subject: "feat: alpha".to_string(),
+                    }],
+                }],
+            },
+        );
+
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["command"], "list-commit");
+        assert_eq!(json["result"], "commit_list");
+        assert_eq!(
+            json["remote_metadata_state"],
+            "ci_review_status_unavailable"
+        );
+        assert_eq!(json["groups"][0]["commits"][0]["global_commit_index"], 1);
+    }
+
+    #[test]
+    fn synthetic_branch_name_collision_payload_is_typed() {
+        let output = ReadOnlyOutput {
+            schema_version: READ_ONLY_OUTPUT_SCHEMA_VERSION,
+            command: ReadOnlyCommand::ListPr,
+            context: super::ReadOnlyContext::capture(Some("main"), Some("dank-spr/")),
+            payload: ReadOnlyPayload::Error {
+                remote_metadata_state: RemoteMetadataState::NotRequested,
+                error: ReadOnlyError::SyntheticBranchNameCollision {
+                    conflicting_groups: vec![
+                        CollisionGroup {
+                            stable_handle: "pr:alpha".to_string(),
+                            head_branch: "dank-spr/alpha".to_string(),
+                        },
+                        CollisionGroup {
+                            stable_handle: "pr:Alpha".to_string(),
+                            head_branch: "dank-spr/Alpha".to_string(),
+                        },
+                    ],
+                },
+            },
+        };
+
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["result"], "error");
+        assert_eq!(json["error_kind"], "synthetic_branch_name_collision");
+        assert_eq!(json["conflicting_groups"][0]["stable_handle"], "pr:alpha");
+        assert_eq!(
+            json["conflicting_groups"][1]["head_branch"],
+            "dank-spr/Alpha"
+        );
+    }
+}


### PR DESCRIPTION
# Problem Solved
Automation had to scrape human `spr list` and `spr status` output. That made callers sensitive to display order, summary-line wording, and unstructured collision errors.

# Mental model
`list` and `status` are discovery queries. Human output remains presentation-oriented; JSON output is a canonical bottom-up description of the local SPR groups, optional remote PR metadata, and expected query failures.

# Non-goals
- Do not change ordinary human `spr list` or `spr status` rendering.
- Do not add JSON support for publish or rewrite commands in this PR.
- Do not make GitHub CI/review lookup a hard dependency of local stack discovery.

# Tradeoffs
The JSON path introduces typed intermediate list data instead of serializing the existing tracing strings. That is more plumbing, but it gives callers stable local PR numbers, stable handles, branch names, commit entries, and typed errors independent of `list_order`.

# Architecture
Refactor list/status around data collectors plus human renderers. Add read-only output types, CLI/main dispatch for JSON mode, typed synthetic-branch collision reporting, and JSON status output that reuses the PR-list payload while preserving `command = status`.

# Observability
JSON callers get one stdout object for list/status. The payload reports local repository context, canonical group order, derived PR branch names, remote PR metadata when available, and structured collision details instead of a free-form fatal message.

# Tests
Covered by CLI parse tests, canonical-order and human-order list tests, typed collision tests, status/list JSON fixture runs, and validation from the original implementation branch: `cargo fmt`, `cargo clippy --tests`, and `cargo test`.

<!-- spr-stack:start -->
**Stack**:
-   #129
-   #128
-   #127
-   #126
-   #125
-   #124
-   #123
-   #122
- ➡ #121

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->