### PR TITLE
update: emit typed JSON publish summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Stack-friendly CLI to manage, update, and land stacked GitHub pull requests.
 Installation
 ------------
 
-- Requires `git` in `PATH`. GitHub CLI `gh` (authenticated) is required for GitHub-backed commands such as `spr update`, `spr list`, and `spr land`, and also for `spr move` because it checks the bottom PR's auto-merge state before rewriting the stack.
+- Requires `git` in `PATH`. GitHub CLI `gh` (authenticated) is required for GitHub-backed commands such as `spr update` without `--no-pr`, `spr list`, and `spr land`, and also for `spr move` because it checks the bottom PR's auto-merge state before rewriting the stack.
 - Build from source:
 
 ```bash
@@ -166,9 +166,10 @@ Aliases:
 Key options:
 
 - `--from <REF>`: commit range upper bound when parsing tags (default `HEAD`) (untested)
-- `--no-pr`: only (re)create branches; skip PR creation/updates (untested)
+- `--no-pr`: only (re)create branches; skip PR creation/updates; this path stays Git-only in `--json` mode
 - `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
 - `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
+- `--json`: write exactly one update summary object to stdout
 - Extent (optional subcommand):
   - `pr --to <N|label|pr:<label>>`: canonical selector for limiting updates to the first N PRs from the bottom
   - `pr --n <N>`: legacy numeric-only form
@@ -308,7 +309,8 @@ Behavior:
 Machine-readable `--json` mode:
 
 - Supported on `spr list pr`, `spr list commit`, `spr status`, `spr restack`, `spr absorb`,
-  `spr move`, `spr fix-pr`, `spr land`, and `spr resume`
+- Supported on `spr move`, `spr fix-pr`, `spr land`, `spr resume`, and `spr update`
+- `spr update --json` writes one summary object with repo context, resolved extent metadata, warnings, and per-group branch or PR actions
 - In `--json` mode, stdout is exactly one JSON object and stderr is normally empty
 - `spr list pr --json`, `spr list commit --json`, and `spr status --json` use a read-only output
   envelope and never suspend

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,10 @@ pub enum Cmd {
         #[arg(long)]
         allow_branch_reuse: bool,
 
+        /// Emit machine-readable JSON to stdout and keep stderr quiet unless the underlying tools leak output unexpectedly
+        #[arg(long)]
+        json: bool,
+
         /// Limit how much to update (optional sub-mode)
         #[command(subcommand)]
         extent: Option<Extent>,
@@ -232,7 +236,8 @@ impl Cmd {
             Self::List {
                 what: ListWhat::Pr { json, .. } | ListWhat::Commit { json, .. },
             } => *json,
-            Self::Update { .. } | Self::Prep {} | Self::RelinkPrs {} | Self::Cleanup {} => false,
+            Self::Update { json, .. } => *json,
+            Self::Prep {} | Self::RelinkPrs {} | Self::Cleanup {} => false,
         }
     }
 }
@@ -358,6 +363,41 @@ mod tests {
     }
 
     #[test]
+    fn update_json_flag_enables_json_mode() {
+        let cli = Cli::try_parse_from(["spr", "update", "--json"]).unwrap();
+
+        assert!(cli.cmd.json_mode());
+    }
+
+    #[test]
+    fn update_json_flag_parses_with_extent_subcommand() {
+        let cli = Cli::try_parse_from(["spr", "update", "--json", "pr", "1"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Update {
+                json: true,
+                extent: Some(super::Extent::Pr { legacy_n, .. }),
+                ..
+            } => assert_eq!(legacy_n, Some(1)),
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn list_pr_json_flag_parses_after_leaf_subcommand() {
+        let cli = Cli::try_parse_from(["spr", "list", "pr", "--json"]).unwrap();
+
+        match cli.cmd {
+            Cmd::List {
+                what: super::ListWhat::Pr { json },
+            } => {
+                assert!(json);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
     fn list_command_parses_json_flag() {
         let cli = Cli::try_parse_from(["spr", "list", "commit", "--json"]).unwrap();
 
@@ -381,6 +421,16 @@ mod tests {
             }
             other => panic!("unexpected command: {:?}", other),
         }
+    }
+
+    #[test]
+    fn update_help_includes_json_flag() {
+        let mut cli = Cli::command();
+        let update = cli.find_subcommand_mut("update").unwrap();
+
+        assert!(update
+            .get_arguments()
+            .any(|argument| argument.get_long() == Some("json")));
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,4 +30,4 @@ pub use restack::{restack_after, restack_after_count};
 pub use rewrite_resume::{
     resume_rewrite, RewriteCommandKind, RewriteCommandOutcome, RewriteSuspendedState,
 };
-pub use update::{build_from_groups, build_from_tags};
+pub use update::{build_from_groups, build_from_groups_with_summary, build_from_tags};

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tracing::{info, warn};
@@ -17,6 +17,10 @@ use crate::github::{
 };
 use crate::limit::{apply_limit_groups, Limit};
 use crate::parsing::{derive_groups_between_with_ignored, split_groups_for_update, Group};
+use crate::update_output::{
+    SkippedUpdateGroupData, UpdateEditAction, UpdateExecutionData, UpdateGroupData, UpdatePrAction,
+    UpdatePushAction, UpdateSkippedReason,
+};
 
 /// Replace the existing spr stack block with `new_block`, or append it if missing.
 ///
@@ -180,6 +184,35 @@ const MAX_BASE_MUTATION_CHARS: usize = 20_000;
 const MAX_BODY_UPDATES_PER_MUTATION: usize = 1;
 const MAX_BODY_MUTATION_CHARS: usize = 100_000;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PushKind {
+    Skip,
+    FastForward,
+    Force,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedPush {
+    branch: String,
+    target_sha: String,
+    remote_exists: bool,
+    kind: PushKind,
+}
+
+impl UpdatePushAction {
+    fn from_planned_push(planned_push: &PlannedPush) -> Self {
+        if planned_push.kind == PushKind::Skip {
+            Self::Unchanged
+        } else if !planned_push.remote_exists {
+            Self::CreateBranch
+        } else if planned_push.kind == PushKind::FastForward {
+            Self::FastForwardBranch
+        } else {
+            Self::ForcePushBranch
+        }
+    }
+}
+
 fn mutation_len_for_inputs(update_inputs: &[String]) -> usize {
     let mut current_len = "mutation {".len() + 1;
     for (i, input) in update_inputs.iter().enumerate() {
@@ -255,14 +288,16 @@ fn run_update_chunk(dry: bool, update_inputs: &[String]) -> Result<()> {
 fn run_update_chunk_with_retry(
     dry: bool,
     update_inputs: &[String],
-    pb: &ProgressBar,
+    progress_bar: Option<&ProgressBar>,
 ) -> Result<()> {
     if update_inputs.is_empty() {
         return Ok(());
     }
     match run_update_chunk(dry, update_inputs) {
         Ok(()) => {
-            pb.inc(update_inputs.len() as u64);
+            if let Some(progress_bar) = progress_bar {
+                progress_bar.inc(update_inputs.len() as u64);
+            }
             Ok(())
         }
         Err(e) if is_resource_limit_error(&e) && update_inputs.len() > 1 => {
@@ -272,8 +307,8 @@ fn run_update_chunk_with_retry(
             );
             let mid = update_inputs.len() / 2;
             let (left, right) = update_inputs.split_at(mid);
-            run_update_chunk_with_retry(dry, left, pb)?;
-            run_update_chunk_with_retry(dry, right, pb)?;
+            run_update_chunk_with_retry(dry, left, progress_bar)?;
+            run_update_chunk_with_retry(dry, right, progress_bar)?;
             Ok(())
         }
         Err(e) => Err(e),
@@ -287,30 +322,40 @@ fn run_update_mutations(
     max_ops: usize,
     max_chars: usize,
     prefer_single: bool,
+    render_progress: bool,
 ) -> Result<()> {
     if update_inputs.is_empty() {
         return Ok(());
     }
     let total_updates = update_inputs.len();
-    let pb = ProgressBar::new(total_updates as u64);
-    pb.set_style(
-        ProgressStyle::with_template(&format!("{{spinner}} {} {{pos}}/{{len}} PR(s)…", label))
-            .unwrap()
-            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
-    );
-    pb.enable_steady_tick(Duration::from_millis(120));
+    let progress_bar = if render_progress {
+        let progress_bar = ProgressBar::new(total_updates as u64);
+        progress_bar.set_style(
+            ProgressStyle::with_template(&format!("{{spinner}} {} {{pos}}/{{len}} PR(s)…", label))
+                .unwrap()
+                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+        );
+        progress_bar.enable_steady_tick(Duration::from_millis(120));
+        Some(progress_bar)
+    } else {
+        None
+    };
     let chunks = if prefer_single && mutation_len_for_inputs(&update_inputs) <= max_chars {
         vec![update_inputs]
     } else {
         chunk_update_inputs(&update_inputs, max_ops, max_chars)
     };
     for chunk in chunks {
-        if let Err(e) = run_update_chunk_with_retry(dry, &chunk, &pb) {
-            pb.finish_and_clear();
+        if let Err(e) = run_update_chunk_with_retry(dry, &chunk, progress_bar.as_ref()) {
+            if let Some(progress_bar) = &progress_bar {
+                progress_bar.finish_and_clear();
+            }
             return Err(e);
         }
     }
-    pb.finish_and_clear();
+    if let Some(progress_bar) = &progress_bar {
+        progress_bar.finish_and_clear();
+    }
     Ok(())
 }
 
@@ -321,16 +366,38 @@ fn ignored_boundary_warning(skipped_handles: &[String]) -> String {
     )
 }
 
-/// Bootstrap/refresh stack from already-parsed PR groups.
-///
-/// `groups` must be in local stack order (bottom-up); that order is still used for base
-/// chaining and local PR numbering even when display is reversed. `list_order` controls
-/// the order in which groups are visited for rebuild logging and list output. If a caller
-/// shuffles `groups`, PR base updates will target the wrong branches. Groups above the first
-/// ignored block are kept local-only because publishing them would drag the ignored commits
-/// into their GitHub diffs.
+fn skipped_group_data(skipped_handles: &[String]) -> Vec<SkippedUpdateGroupData> {
+    skipped_handles
+        .iter()
+        .map(|stable_handle| SkippedUpdateGroupData {
+            stable_handle: stable_handle.clone(),
+            reason: UpdateSkippedReason::IgnoredBoundary,
+        })
+        .collect()
+}
+
+fn stable_handle_text(tag: &str) -> String {
+    format!("pr:{tag}")
+}
+
+fn update_warnings(skipped_handles: &[String]) -> Vec<String> {
+    if skipped_handles.is_empty() {
+        Vec::new()
+    } else {
+        vec![ignored_boundary_warning(skipped_handles)]
+    }
+}
+
+fn empty_update_execution(skipped_handles: &[String]) -> UpdateExecutionData {
+    UpdateExecutionData {
+        warnings: update_warnings(skipped_handles),
+        skipped_groups: skipped_group_data(skipped_handles),
+        groups: Vec::new(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
-pub fn build_from_groups(
+fn build_from_groups_internal(
     base: &str,
     prefix: &str,
     skipped_handles: &[String],
@@ -342,7 +409,8 @@ pub fn build_from_groups(
     list_order: ListOrder,
     allow_branch_reuse: bool,
     branch_reuse_guard_days: u32,
-) -> Result<()> {
+    render_progress: bool,
+) -> Result<UpdateExecutionData> {
     if groups.is_empty() {
         if skipped_handles.is_empty() {
             info!("No groups discovered; nothing to do.");
@@ -350,10 +418,9 @@ pub fn build_from_groups(
             warn!("{}", ignored_boundary_warning(skipped_handles));
             info!("No pushable groups remain after applying the ignored-block rule.");
         }
-        return Ok(());
+        return Ok(empty_update_execution(skipped_handles));
     }
 
-    // Apply extent limits
     groups = apply_limit_groups(groups, limit)?;
     if !skipped_handles.is_empty() {
         warn!("{}", ignored_boundary_warning(skipped_handles));
@@ -364,25 +431,28 @@ pub fn build_from_groups(
         } else {
             info!("No pushable groups remain after applying the ignored-block rule.");
         }
-        return Ok(());
+        return Ok(empty_update_execution(skipped_handles));
     }
     let total_groups = groups.len();
     let branch_identities = group_branch_identities(&groups, prefix)?;
+    let desired_base_by_head: HashMap<String, String> =
+        common::build_head_base_chain(base, &groups, prefix)?
+            .into_iter()
+            .collect();
 
     info!("Preparing {} group(s)…", groups.len());
 
-    // Build bottom→top and collect PR refs for the visual update pass.
-    let mut just_created_numbers: Vec<u64> = vec![];
     let heads: Vec<String> = branch_identities
         .iter()
         .map(|identity| identity.exact.clone())
         .collect();
-    let pr_list = list_open_prs_for_heads(&heads)?;
     let mut prs_by_head: HashMap<CanonicalBranchConflictKey, u64> = HashMap::new();
     let mut current_base_by_number: HashMap<u64, String> = HashMap::new();
-    for p in pr_list {
-        prs_by_head.insert(head_key(&p.head), p.number);
-        current_base_by_number.insert(p.number, p.base);
+    if !no_pr {
+        for pr in list_open_prs_for_heads(&heads)? {
+            prs_by_head.insert(head_key(&pr.head), pr.number);
+            current_base_by_number.insert(pr.number, pr.base);
+        }
     }
     enforce_branch_reuse_guard(
         no_pr,
@@ -391,34 +461,16 @@ pub fn build_from_groups(
         &heads,
         &prs_by_head,
     )?;
-    // Allow force-push within the selected scope when branch diverged from remote
 
-    // Batch fetch remote SHAs for all target branches
     let mut branch_names = heads.clone();
-    // Ensure we also include the repository base branch for remote SHA comparisons
     let base_ref_for_remote = sanitize_gh_base_ref(base);
     if !branch_names.contains(&base_ref_for_remote) {
         branch_names.push(base_ref_for_remote);
     }
-    let remote_map = get_remote_branches_sha(&branch_names)?; // branch -> sha
-
-    // Stage push actions to batch git push calls
-    #[derive(Clone, Copy, PartialEq)]
-    enum PushKind {
-        Skip,
-        FastForward,
-        Force,
-    }
-    struct PlannedPush {
-        branch: String,
-        target_sha: String,
-        kind: PushKind,
-    }
-    let mut planned: Vec<PlannedPush> = vec![];
+    let remote_map = get_remote_branches_sha(&branch_names)?;
 
     let display_indices = list_order.display_indices(groups.len());
     for (display_idx, group_idx) in display_indices.iter().enumerate() {
-        let g = &groups[*group_idx];
         let branch = branch_identities[*group_idx].exact.clone();
         info!(
             "({}/{}) Rebuilding branch {}",
@@ -426,61 +478,59 @@ pub fn build_from_groups(
             total_groups,
             branch
         );
+    }
 
-        // Use local commit SHA as source of truth; avoid rewriting commits when possible
+    let mut planned: Vec<PlannedPush> = Vec::with_capacity(groups.len());
+    for (group, identity) in groups.iter().zip(branch_identities.iter()) {
+        let branch = identity.exact.clone();
         let remote_head = remote_map.get(&branch).cloned();
-        let target_sha = g
+        let target_sha = group
             .commits
             .last()
             .cloned()
-            .ok_or_else(|| anyhow!("Group {} has no commits", g.tag))?;
+            .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
         let kind = if remote_head.as_deref() == Some(target_sha.as_str()) {
             PushKind::Skip
         } else if let Some(ref remote_sha) = remote_head {
-            let ff_ok = git_is_ancestor(remote_sha, &target_sha)?;
-            if ff_ok {
+            if git_is_ancestor(remote_sha, &target_sha)? {
                 PushKind::FastForward
             } else {
                 PushKind::Force
             }
         } else {
-            // No remote exists; create the branch
             PushKind::FastForward
         };
         planned.push(PlannedPush {
-            branch: branch.clone(),
-            target_sha: target_sha.clone(),
+            branch,
+            target_sha,
+            remote_exists: remote_head.is_some(),
             kind,
         });
     }
 
-    // Before pushing: If not all PRs are already chained correctly, temporarily set all existing PRs to the repo base
     if !no_pr {
-        // Gather existing PR numbers and head branches in the local stack order (bottom→top)
         let mut numbers_full_pre: Vec<u64> = vec![];
         let mut head_by_number_pre: HashMap<u64, String> = HashMap::new();
         for identity in &branch_identities {
-            if let Some(n) = pr_number_for_head(&prs_by_head, &identity.exact) {
-                numbers_full_pre.push(n);
-                head_by_number_pre.insert(n, identity.exact.clone());
+            if let Some(number) = pr_number_for_head(&prs_by_head, &identity.exact) {
+                numbers_full_pre.push(number);
+                head_by_number_pre.insert(number, identity.exact.clone());
             }
         }
         if !numbers_full_pre.is_empty() {
-            // Compute desired chained base per existing PR using local groups
             let mut desired_base_by_number_pre: HashMap<u64, String> = HashMap::new();
-            for (head, want_base) in common::build_head_base_chain(base, &groups, prefix)? {
-                if let Some(num) = pr_number_for_head(&prs_by_head, &head) {
-                    desired_base_by_number_pre.insert(num, want_base.clone());
+            for (head, want_base) in &desired_base_by_head {
+                if let Some(number) = pr_number_for_head(&prs_by_head, head) {
+                    desired_base_by_number_pre.insert(number, want_base.clone());
                 }
             }
 
-            // Check if all existing PRs already point to correct base
             let mut all_correct = true;
-            for (num, want_base) in &desired_base_by_number_pre {
-                let want_base_s = sanitize_gh_base_ref(want_base);
+            for (number, want_base) in &desired_base_by_number_pre {
+                let want_base_ref = sanitize_gh_base_ref(want_base);
                 if current_base_by_number
-                    .get(num)
-                    .map(|b| sanitize_gh_base_ref(b) != want_base_s)
+                    .get(number)
+                    .map(|base_ref| sanitize_gh_base_ref(base_ref) != want_base_ref)
                     .unwrap_or(true)
                 {
                     all_correct = false;
@@ -489,22 +539,19 @@ pub fn build_from_groups(
             }
 
             if !all_correct {
-                // Temporarily set base of all existing PRs to the repo base (e.g., main)
                 let bodies_by_number_pre = fetch_pr_bodies_graphql(&numbers_full_pre)?;
                 let mut base_updates_pre: Vec<String> = Vec::new();
-                for (num, info) in bodies_by_number_pre.iter() {
-                    // Skip if already on base
+                for (number, info) in bodies_by_number_pre.iter() {
                     let base_target = sanitize_gh_base_ref(base);
                     if current_base_by_number
-                        .get(num)
-                        .map(|b| sanitize_gh_base_ref(b) == base_target)
+                        .get(number)
+                        .map(|base_ref| sanitize_gh_base_ref(base_ref) == base_target)
                         .unwrap_or(false)
                     {
                         continue;
                     }
-                    // Avoid GitHub error when base/head are identical on remote (no new commits)
                     let mut shas_equal = false;
-                    if let Some(head_branch) = head_by_number_pre.get(num) {
+                    if let Some(head_branch) = head_by_number_pre.get(number) {
                         if let (Some(head_sha), Some(base_sha)) =
                             (remote_map.get(head_branch), remote_map.get(&base_target))
                         {
@@ -530,191 +577,250 @@ pub fn build_from_groups(
                         MAX_BASE_UPDATES_PER_MUTATION,
                         MAX_BASE_MUTATION_CHARS,
                         true,
+                        render_progress,
                     )?;
                 }
             }
         }
     }
 
-    // Execute batched pushes: first fast-forward, then force-with-lease
     let ff_refspecs: Vec<String> = planned
         .iter()
-        .filter(|p| p.kind == PushKind::FastForward)
-        .map(|p| format!("{}:refs/heads/{}", p.target_sha, p.branch))
+        .filter(|planned_push| planned_push.kind == PushKind::FastForward)
+        .map(|planned_push| {
+            format!(
+                "{}:refs/heads/{}",
+                planned_push.target_sha, planned_push.branch
+            )
+        })
         .collect();
     if !ff_refspecs.is_empty() {
-        // Build argv: ["push", "origin", refspecs...]
         let mut argv: Vec<String> = vec!["push".into(), "origin".into()];
         argv.extend(ff_refspecs.clone());
-        let args: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
-        let pb = ProgressBar::new_spinner();
-        pb.set_style(
-            ProgressStyle::with_template("{spinner} Pushing {pos} branch(es) (-ff)…")
-                .unwrap()
-                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
-        );
-        pb.set_position(ff_refspecs.len() as u64);
-        pb.enable_steady_tick(Duration::from_millis(120));
-        let res = git_rw(dry, &args);
-        pb.finish_and_clear();
-        res?;
+        let args: Vec<&str> = argv.iter().map(|item| item.as_str()).collect();
+        if render_progress {
+            let progress_bar = ProgressBar::new_spinner();
+            progress_bar.set_style(
+                ProgressStyle::with_template("{spinner} Pushing {pos} branch(es) (-ff)…")
+                    .unwrap()
+                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+            );
+            progress_bar.set_position(ff_refspecs.len() as u64);
+            progress_bar.enable_steady_tick(Duration::from_millis(120));
+            let result = git_rw(dry, &args);
+            progress_bar.finish_and_clear();
+            result?;
+        } else {
+            git_rw(dry, &args)?;
+        }
     }
-    // Perform force-with-lease for diverged branches in scope
+
     let force_refspecs: Vec<String> = planned
         .iter()
-        .filter(|p| p.kind == PushKind::Force)
-        .map(|p| format!("{}:refs/heads/{}", p.target_sha, p.branch))
+        .filter(|planned_push| planned_push.kind == PushKind::Force)
+        .map(|planned_push| {
+            format!(
+                "{}:refs/heads/{}",
+                planned_push.target_sha, planned_push.branch
+            )
+        })
         .collect();
     if !force_refspecs.is_empty() {
-        // Use explicit lease SHAs so we don't depend on remote-tracking refs being up-to-date.
         let force_leases: Vec<String> = planned
             .iter()
-            .filter(|p| p.kind == PushKind::Force)
-            .filter_map(|p| {
-                remote_map
-                    .get(&p.branch)
-                    .map(|sha| format!("--force-with-lease=refs/heads/{}:{}", p.branch, sha))
+            .filter(|planned_push| planned_push.kind == PushKind::Force)
+            .filter_map(|planned_push| {
+                remote_map.get(&planned_push.branch).map(|sha| {
+                    format!(
+                        "--force-with-lease=refs/heads/{}:{}",
+                        planned_push.branch, sha
+                    )
+                })
             })
             .collect();
         let mut argv: Vec<String> = vec!["push".into(), "origin".into()];
         if force_leases.is_empty() {
-            // Fallback to default lease behavior if we couldn't resolve remote SHAs.
             argv.push("--force-with-lease".into());
         } else {
             argv.extend(force_leases);
         }
         argv.extend(force_refspecs.clone());
-        let args: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
-        let pb = ProgressBar::new_spinner();
-        pb.set_style(
-            ProgressStyle::with_template("{spinner} Pushing {pos} branch(es) (-force-with-lease)…")
+        let args: Vec<&str> = argv.iter().map(|item| item.as_str()).collect();
+        if render_progress {
+            let progress_bar = ProgressBar::new_spinner();
+            progress_bar.set_style(
+                ProgressStyle::with_template(
+                    "{spinner} Pushing {pos} branch(es) (-force-with-lease)…",
+                )
                 .unwrap()
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
-        );
-        pb.set_position(force_refspecs.len() as u64);
-        pb.enable_steady_tick(Duration::from_millis(120));
-        let res = git_rw(dry, &args);
-        pb.finish_and_clear();
-        res?;
+            );
+            progress_bar.set_position(force_refspecs.len() as u64);
+            progress_bar.enable_steady_tick(Duration::from_millis(120));
+            let result = git_rw(dry, &args);
+            progress_bar.finish_and_clear();
+            result?;
+        } else {
+            git_rw(dry, &args)?;
+        }
     }
 
-    // After pushes, (create or) update PRs
+    let mut pr_numbers_by_group: Vec<Option<u64>> = vec![None; groups.len()];
+    let mut pr_actions_by_group: Vec<UpdatePrAction> =
+        vec![UpdatePrAction::NotRequested; groups.len()];
+    let mut base_actions_by_group: Vec<UpdateEditAction> = vec![
+        if no_pr {
+            UpdateEditAction::NotRequested
+        } else {
+            UpdateEditAction::Unchanged
+        };
+        groups.len()
+    ];
+    let mut description_actions_by_group: Vec<UpdateEditAction> = vec![
+        if no_pr {
+            UpdateEditAction::NotRequested
+        } else {
+            UpdateEditAction::Unchanged
+        };
+        groups.len()
+    ];
+    let mut created_without_number: HashSet<usize> = HashSet::new();
     let mut parent_branch = base.to_string();
-    for (g, identity) in groups.iter().zip(branch_identities.iter()) {
+    for (group_idx, (group, identity)) in groups.iter().zip(branch_identities.iter()).enumerate() {
         let branch = identity.exact.clone();
         if !no_pr {
             let was_known = prs_by_head.contains_key(&identity.conflict_key);
-            let num = upsert_pr_cached(
-                &branch,
-                &sanitize_gh_base_ref(&parent_branch),
-                &g.pr_title()?,
-                &g.pr_body()?,
-                dry,
-                &mut prs_by_head,
-            )?;
-            if !was_known {
-                just_created_numbers.push(num);
+            if dry && !was_known {
+                pr_actions_by_group[group_idx] = UpdatePrAction::Created;
+                created_without_number.insert(group_idx);
+            } else {
+                let number = upsert_pr_cached(
+                    &branch,
+                    &sanitize_gh_base_ref(&parent_branch),
+                    &group.pr_title()?,
+                    &group.pr_body()?,
+                    dry,
+                    &mut prs_by_head,
+                )?;
+                pr_numbers_by_group[group_idx] = Some(number);
+                pr_actions_by_group[group_idx] = if was_known {
+                    UpdatePrAction::Existing
+                } else {
+                    current_base_by_number.insert(number, sanitize_gh_base_ref(&parent_branch));
+                    UpdatePrAction::Created
+                };
             }
         }
         parent_branch = branch;
     }
 
     if !no_pr {
-        // Derive full stack order purely from local groups (bottom→top)
-        let mut numbers_full: Vec<u64> = vec![];
-        for identity in &branch_identities {
-            if let Some(n) = pr_number_for_head(&prs_by_head, &identity.exact) {
-                numbers_full.push(n);
-            }
-        }
-        // Build desired stack blocks and base refs from local commits
+        let numbers_full: Vec<u64> = pr_numbers_by_group.iter().flatten().copied().collect();
         let mut desired_stack_by_number: HashMap<u64, String> = HashMap::new();
         let mut base_body_by_number: HashMap<u64, String> = HashMap::new();
         let mut desired_base_by_number: HashMap<u64, String> = HashMap::new();
-        let chain = common::build_head_base_chain(base, &groups, prefix)?;
         let numbers_rev: Vec<u64> = numbers_full.iter().cloned().rev().collect();
-        for (head_branch, want_base_ref) in chain {
-            if let Some(num) = pr_number_for_head(&prs_by_head, &head_branch) {
-                desired_base_by_number.insert(num, want_base_ref.clone());
-                // Stack visual (optional rewrite)
-                if let Some((g, _identity)) = groups
-                    .iter()
-                    .zip(branch_identities.iter())
-                    .find(|(_group, identity)| identity.exact == head_branch)
-                {
-                    let base = g.pr_body_base()?;
-                    base_body_by_number.insert(num, base);
-                    let mut lines = String::new();
-                    for n in &numbers_rev {
-                        let marker = if *n == num {
-                            "➡"
-                        } else {
-                            crate::format::EM_SPACE
-                        };
-                        lines.push_str(&format!("- {} #{}\n", marker, n));
-                    }
-                    let stack_block = format!(
-                        "<!-- spr-stack:start -->\n**Stack**:\n{}\n\n⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*\n<!-- spr-stack:end -->",
-                        lines.trim_end(),
-                    );
-                    desired_stack_by_number.insert(num, stack_block);
+        for (group_idx, identity) in branch_identities.iter().enumerate() {
+            if let Some(number) = pr_numbers_by_group[group_idx] {
+                let want_base_ref = desired_base_by_head
+                    .get(&identity.exact)
+                    .cloned()
+                    .ok_or_else(|| anyhow!("Missing desired base ref for {}", identity.exact))?;
+                desired_base_by_number.insert(number, want_base_ref);
+                let group = &groups[group_idx];
+                let base_body = group.pr_body_base()?;
+                base_body_by_number.insert(number, base_body);
+                let mut lines = String::new();
+                for pr_number in &numbers_rev {
+                    let marker = if *pr_number == number {
+                        "➡"
+                    } else {
+                        crate::format::EM_SPACE
+                    };
+                    lines.push_str(&format!("- {} #{}\n", marker, pr_number));
                 }
+                let stack_block = format!(
+                    "<!-- spr-stack:start -->\n**Stack**:\n{}\n\n⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*\n<!-- spr-stack:end -->",
+                    lines.trim_end(),
+                );
+                desired_stack_by_number.insert(number, stack_block);
             }
         }
 
-        // Fetch PR ids/bodies for union of all PRs we may rewrite bodies for
-        let mut fetch_set: std::collections::HashSet<u64> = numbers_full.iter().cloned().collect();
-        for &n in desired_stack_by_number.keys() {
-            fetch_set.insert(n);
+        let mut fetch_set: HashSet<u64> = numbers_full.iter().cloned().collect();
+        for &number in desired_stack_by_number.keys() {
+            fetch_set.insert(number);
         }
-        for &n in desired_base_by_number.keys() {
-            fetch_set.insert(n);
+        for &number in desired_base_by_number.keys() {
+            fetch_set.insert(number);
         }
         let fetch_list: Vec<u64> = fetch_set.into_iter().collect();
-        let bodies_by_number = fetch_pr_bodies_graphql(&fetch_list)?;
+        let bodies_by_number = if fetch_list.is_empty() {
+            HashMap::new()
+        } else {
+            fetch_pr_bodies_graphql(&fetch_list)?
+        };
+        let group_index_by_number: HashMap<u64, usize> = pr_numbers_by_group
+            .iter()
+            .enumerate()
+            .filter_map(|(group_idx, maybe_number)| maybe_number.map(|number| (number, group_idx)))
+            .collect();
         let mut body_updates: Vec<String> = Vec::new();
         let mut base_updates: Vec<String> = Vec::new();
-        // Bodies: always update (full or stack-only based on config)
-        for (&num, stack_block) in &desired_stack_by_number {
-            if let Some(info) = bodies_by_number.get(&num) {
-                match pr_description_mode {
-                    PrDescriptionMode::Overwrite => {
-                        if let Some(base) = base_body_by_number.get(&num) {
-                            let body = if base.trim().is_empty() {
+        if dry && !created_without_number.is_empty() {
+            for group_idx in group_index_by_number.values().copied() {
+                description_actions_by_group[group_idx] = UpdateEditAction::Updated;
+            }
+        } else {
+            for (&number, stack_block) in &desired_stack_by_number {
+                if let Some(info) = bodies_by_number.get(&number) {
+                    let desired_body = if pr_description_mode == PrDescriptionMode::Overwrite {
+                        if let Some(base_body) = base_body_by_number.get(&number) {
+                            if base_body.trim().is_empty() {
                                 stack_block.clone()
                             } else {
-                                format!("{}\n\n{}", base, stack_block)
-                            };
-                            let fields = [
-                                format!("pullRequestId:\"{}\"", info.id),
-                                format!("body:\"{}\"", graphql_escape(&body)),
-                            ];
-                            body_updates.push(fields.join(", "));
+                                format!("{}\n\n{}", base_body, stack_block)
+                            }
+                        } else {
+                            continue;
                         }
-                    }
-                    PrDescriptionMode::StackOnly => {
-                        let body = update_stack_block(&info.body, stack_block);
+                    } else {
+                        update_stack_block(&info.body, stack_block)
+                    };
+                    if desired_body != info.body {
+                        if let Some(&group_idx) = group_index_by_number.get(&number) {
+                            description_actions_by_group[group_idx] = UpdateEditAction::Updated;
+                        }
                         let fields = [
                             format!("pullRequestId:\"{}\"", info.id),
-                            format!("body:\"{}\"", graphql_escape(&body)),
+                            format!("body:\"{}\"", graphql_escape(&desired_body)),
                         ];
                         body_updates.push(fields.join(", "));
                     }
                 }
             }
         }
-        // Bases: set post-push to ensure final linkage
-        for (&num, want_base) in &desired_base_by_number {
-            if let Some(info) = bodies_by_number.get(&num) {
-                let fields = [
-                    format!("pullRequestId:\"{}\"", info.id),
-                    format!(
-                        "baseRefName:\"{}\"",
-                        graphql_escape(&sanitize_gh_base_ref(want_base))
-                    ),
-                ];
-                base_updates.push(fields.join(", "));
+        for (&number, want_base) in &desired_base_by_number {
+            if let Some(info) = bodies_by_number.get(&number) {
+                let desired_base_ref = sanitize_gh_base_ref(want_base);
+                let needs_update = current_base_by_number
+                    .get(&number)
+                    .map(|base_ref| sanitize_gh_base_ref(base_ref) != desired_base_ref.as_str())
+                    .unwrap_or(true);
+                if needs_update {
+                    if let Some(&group_idx) = group_index_by_number.get(&number) {
+                        base_actions_by_group[group_idx] = UpdateEditAction::Updated;
+                    }
+                    let fields = [
+                        format!("pullRequestId:\"{}\"", info.id),
+                        format!("baseRefName:\"{}\"", graphql_escape(&desired_base_ref)),
+                    ];
+                    base_updates.push(fields.join(", "));
+                }
             }
+        }
+        for group_idx in created_without_number {
+            description_actions_by_group[group_idx] = UpdateEditAction::Updated;
         }
         if !base_updates.is_empty() || !body_updates.is_empty() {
             if !base_updates.is_empty() {
@@ -725,6 +831,7 @@ pub fn build_from_groups(
                     MAX_BASE_UPDATES_PER_MUTATION,
                     MAX_BASE_MUTATION_CHARS,
                     true,
+                    render_progress,
                 )?;
             }
             if !body_updates.is_empty() {
@@ -735,6 +842,7 @@ pub fn build_from_groups(
                     MAX_BODY_UPDATES_PER_MUTATION,
                     MAX_BODY_MUTATION_CHARS,
                     false,
+                    render_progress,
                 )?;
             }
         } else {
@@ -742,37 +850,127 @@ pub fn build_from_groups(
         }
     }
 
-    // Print full stack PR list in bottom→top order: "- <url> - <title>"
     if !no_pr {
         let mut ordered: Vec<(u64, String)> = vec![];
         let display_indices = list_order.display_indices(groups.len());
         for group_idx in display_indices {
-            let g = &groups[group_idx];
+            let group = &groups[group_idx];
             let head_branch = &branch_identities[group_idx].exact;
-            if let Some(n) = pr_number_for_head(&prs_by_head, head_branch) {
-                // Use local group title (source of truth for desired title)
-                let title = g.pr_title().unwrap_or_else(|_| String::new());
-                ordered.push((n, title));
+            if let Some(number) = pr_number_for_head(&prs_by_head, head_branch) {
+                let title = group.pr_title().unwrap_or_else(|_| String::new());
+                ordered.push((number, title));
             }
         }
         if !ordered.is_empty() {
             if let Ok((owner, name)) = get_repo_owner_name() {
                 info!("PRs:");
-                for (n, title) in ordered {
-                    let url = format!("https://github.com/{}/{}/pull/{}", owner, name, n);
+                for (number, title) in ordered {
+                    let url = format!("https://github.com/{}/{}/pull/{}", owner, name, number);
                     info!("  {} - {}", url, title);
                 }
             }
         }
     }
 
+    let remote_url_prefix = get_repo_owner_name()
+        .ok()
+        .map(|(owner, name)| format!("https://github.com/{owner}/{name}/pull/"));
+    let groups = groups
+        .iter()
+        .zip(branch_identities.iter())
+        .zip(planned.iter())
+        .enumerate()
+        .map(
+            |(group_idx, ((group, identity), planned_push))| UpdateGroupData {
+                local_pr_number: group_idx + 1,
+                stable_handle: stable_handle_text(&group.tag),
+                head_branch: identity.exact.clone(),
+                base_ref: desired_base_by_head
+                    .get(&identity.exact)
+                    .cloned()
+                    .unwrap_or_else(|| base.to_string()),
+                title: group.pr_title().unwrap_or_else(|_| String::new()),
+                target_sha: planned_push.target_sha.clone(),
+                push_action: UpdatePushAction::from_planned_push(planned_push),
+                pr_action: pr_actions_by_group[group_idx],
+                base_ref_action: base_actions_by_group[group_idx],
+                description_action: description_actions_by_group[group_idx],
+                remote_pr_number: pr_numbers_by_group[group_idx],
+                remote_pr_url: match (remote_url_prefix.as_ref(), pr_numbers_by_group[group_idx]) {
+                    (Some(prefix), Some(number)) => Some(format!("{prefix}{number}")),
+                    _ => None,
+                },
+            },
+        )
+        .collect();
+    Ok(UpdateExecutionData {
+        warnings: update_warnings(skipped_handles),
+        skipped_groups: skipped_group_data(skipped_handles),
+        groups,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_from_groups_with_summary(
+    base: &str,
+    prefix: &str,
+    skipped_handles: &[String],
+    no_pr: bool,
+    dry: bool,
+    pr_description_mode: PrDescriptionMode,
+    limit: Option<Limit>,
+    groups: Vec<Group>,
+    list_order: ListOrder,
+    allow_branch_reuse: bool,
+    branch_reuse_guard_days: u32,
+) -> Result<UpdateExecutionData> {
+    build_from_groups_internal(
+        base,
+        prefix,
+        skipped_handles,
+        no_pr,
+        dry,
+        pr_description_mode,
+        limit,
+        groups,
+        list_order,
+        allow_branch_reuse,
+        branch_reuse_guard_days,
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_from_groups(
+    base: &str,
+    prefix: &str,
+    skipped_handles: &[String],
+    no_pr: bool,
+    dry: bool,
+    pr_description_mode: PrDescriptionMode,
+    limit: Option<Limit>,
+    groups: Vec<Group>,
+    list_order: ListOrder,
+    allow_branch_reuse: bool,
+    branch_reuse_guard_days: u32,
+) -> Result<()> {
+    build_from_groups_internal(
+        base,
+        prefix,
+        skipped_handles,
+        no_pr,
+        dry,
+        pr_description_mode,
+        limit,
+        groups,
+        list_order,
+        allow_branch_reuse,
+        branch_reuse_guard_days,
+        true,
+    )?;
     Ok(())
 }
 
-/// Bootstrap/refresh stack from pr:<tag> markers on `from` vs merge-base(base, from).
-///
-/// This derives groups in local stack order and forwards `list_order` so rebuild progress
-/// and printed lists follow the same display order as `spr list`.
 #[allow(clippy::too_many_arguments)]
 pub fn build_from_tags(
     base: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,11 +5,11 @@
 
 use anyhow::{anyhow, Context, Result};
 use clap::ValueEnum;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 #[value(rename_all = "snake_case")]
 pub enum PrDescriptionMode {

--- a/src/json_command.rs
+++ b/src/json_command.rs
@@ -1,0 +1,79 @@
+use serde::Serialize;
+use std::ffi::{OsStr, OsString};
+
+pub const EXIT_SUCCESS: i32 = 0;
+pub const EXIT_FAILURE: i32 = 1;
+pub const EXIT_SUSPENDED: i32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum JsonCommand {
+    Cli,
+    Restack,
+    Absorb,
+    Move,
+    FixPr,
+    ResolveStack,
+    Resume,
+    Land,
+    List,
+    Status,
+    Update,
+    Prep,
+    RelinkPrs,
+    Cleanup,
+}
+
+pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
+    let mut skip_value = false;
+    for arg in args.iter().skip(1) {
+        if skip_value {
+            skip_value = false;
+        } else if let Some(arg) = arg.to_str() {
+            if arg == "--cd"
+                || arg == "--base"
+                || arg == "--prefix"
+                || arg == "--until"
+                || arg == "--exact"
+                || arg == "-b"
+            {
+                skip_value = true;
+            } else if arg == "restack" {
+                return JsonCommand::Restack;
+            } else if arg == "absorb" {
+                return JsonCommand::Absorb;
+            } else if arg == "move" || arg == "mv" {
+                return JsonCommand::Move;
+            } else if arg == "fix-pr" || arg == "fix" {
+                return JsonCommand::FixPr;
+            } else if arg == "resolve-stack" {
+                return JsonCommand::ResolveStack;
+            } else if arg == "resume" {
+                return JsonCommand::Resume;
+            } else if arg == "land" {
+                return JsonCommand::Land;
+            } else if arg == "list" || arg == "ls" {
+                return JsonCommand::List;
+            } else if arg == "status" || arg == "stat" {
+                return JsonCommand::Status;
+            } else if arg == "update" || arg == "u" {
+                return JsonCommand::Update;
+            } else if arg == "prep" {
+                return JsonCommand::Prep;
+            } else if arg == "relink-prs" {
+                return JsonCommand::RelinkPrs;
+            } else if arg == "cleanup" || arg == "clean" {
+                return JsonCommand::Cleanup;
+            } else if !arg.starts_with('-') {
+                return JsonCommand::Cli;
+            }
+        }
+    }
+    JsonCommand::Cli
+}
+
+pub fn raw_args_request_json(args: &[OsString]) -> bool {
+    args.iter()
+        .skip(1)
+        .any(|arg| arg.as_os_str() == OsStr::new("--json"))
+}

--- a/src/machine_output.rs
+++ b/src/machine_output.rs
@@ -8,24 +8,11 @@
 use serde::Serialize;
 
 use crate::commands::{RewriteCommandKind, RewriteSuspendedState};
+pub use crate::json_command::{
+    JsonCommand as MachineCommand, EXIT_FAILURE, EXIT_SUCCESS, EXIT_SUSPENDED,
+};
 
 pub const MACHINE_OUTPUT_SCHEMA_VERSION: u32 = 1;
-pub const EXIT_SUCCESS: i32 = 0;
-pub const EXIT_FAILURE: i32 = 1;
-pub const EXIT_SUSPENDED: i32 = 2;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum MachineCommand {
-    Cli,
-    Restack,
-    Absorb,
-    Move,
-    FixPr,
-    ResolveStack,
-    Resume,
-    Land,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{error::ErrorKind, Parser};
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::path::Path;
 
 mod branch_names;
@@ -10,6 +10,7 @@ mod config;
 mod format;
 mod git;
 mod github;
+mod json_command;
 mod limit;
 mod machine_output;
 mod parsing;
@@ -19,6 +20,7 @@ mod selectors;
 mod stack_metadata;
 #[cfg(test)]
 mod test_support;
+mod update_output;
 
 fn resolve_update_pr_limit(
     groups: &[crate::parsing::Group],
@@ -66,8 +68,8 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
             .as_deref()
             .map(crate::commands::looks_like_pr_url)
             .unwrap_or(false),
-        crate::cli::Cmd::Update { .. }
-        | crate::cli::Cmd::List { .. }
+        crate::cli::Cmd::Update { no_pr, .. } => !*no_pr,
+        crate::cli::Cmd::List { .. }
         | crate::cli::Cmd::Status { .. }
         | crate::cli::Cmd::Prep {}
         | crate::cli::Cmd::Land { .. }
@@ -89,6 +91,7 @@ enum CommandOutput {
     Machine(crate::machine_output::MachineOutput),
     ReadOnly(crate::read_only_output::ReadOnlyOutput),
     ResolveStack(crate::commands::ResolveStackOutput),
+    Update(crate::update_output::UpdateOutput),
 }
 
 fn init_tools(needs_gh: bool) -> Result<()> {
@@ -286,6 +289,7 @@ fn run_cli(cli: crate::cli::Cli, output_mode: OutputMode) -> Result<CommandOutpu
             assume_existing_prs,
             pr_description_mode: pr_description_mode_override,
             allow_branch_reuse,
+            json: _,
             extent,
         } => {
             set_dry_run_env(cli.dry_run, assume_existing_prs);
@@ -307,39 +311,89 @@ fn run_cli(cli: crate::cli::Cli, output_mode: OutputMode) -> Result<CommandOutpu
                 let (groups, skipped_handles) =
                     crate::parsing::split_groups_for_update(&leading_ignored, all_groups);
                 crate::branch_names::group_branch_identities(&groups, &prefix)?;
-                let limit = if let Some(extent) = extent {
+                let (limit, resolved_extent) = if let Some(extent) = extent {
                     match extent {
                         crate::cli::Extent::Pr { to, n, legacy_n } => {
-                            Some(resolve_update_pr_limit(&groups, to, n, legacy_n)?)
+                            let limit = resolve_update_pr_limit(&groups, to, n, legacy_n)?;
+                            let count = match limit {
+                                crate::limit::Limit::ByPr(count) => count,
+                                crate::limit::Limit::ByCommits(_) => unreachable!(),
+                            };
+                            (
+                                Some(limit),
+                                crate::update_output::ResolvedUpdateLimit::ByPr { count },
+                            )
                         }
-                        crate::cli::Extent::Commits { n } => {
-                            Some(crate::limit::Limit::ByCommits(n))
-                        }
+                        crate::cli::Extent::Commits { n } => (
+                            Some(crate::limit::Limit::ByCommits(n)),
+                            crate::update_output::ResolvedUpdateLimit::ByCommits { count: n },
+                        ),
                     }
                 } else {
-                    None
+                    (None, crate::update_output::ResolvedUpdateLimit::All)
                 };
-                crate::commands::build_from_groups(
-                    &base,
-                    &prefix,
-                    &skipped_handles,
-                    no_pr,
-                    cli.dry_run,
-                    pr_description_mode,
-                    limit,
-                    groups,
-                    list_order,
-                    allow_branch_reuse,
-                    branch_reuse_guard_days,
-                )?;
-                if !cli.dry_run {
-                    crate::stack_metadata::refresh_metadata_for_current_checkout(
-                        &metadata_refresh_context.base,
-                        &metadata_refresh_context.prefix,
-                        &metadata_refresh_context.ignore_tag,
+                if output_mode == OutputMode::Json {
+                    let execution = crate::commands::build_from_groups_with_summary(
+                        &base,
+                        &prefix,
+                        &skipped_handles,
+                        no_pr,
+                        cli.dry_run,
+                        pr_description_mode,
+                        limit,
+                        groups,
+                        list_order,
+                        allow_branch_reuse,
+                        branch_reuse_guard_days,
                     )?;
+                    let summary = crate::update_output::UpdateSummaryData::from_execution(
+                        crate::update_output::UpdateRepoContext {
+                            base: base.clone(),
+                            from,
+                            prefix: prefix.clone(),
+                            ignore_tag: ignore_tag.clone(),
+                        },
+                        crate::update_output::UpdateOptions {
+                            dry_run: cli.dry_run,
+                            no_pr,
+                            pr_description_mode,
+                        },
+                        resolved_extent,
+                        execution,
+                    );
+                    if !cli.dry_run {
+                        crate::stack_metadata::refresh_metadata_for_current_checkout(
+                            &metadata_refresh_context.base,
+                            &metadata_refresh_context.prefix,
+                            &metadata_refresh_context.ignore_tag,
+                        )?;
+                    }
+                    Ok(CommandOutput::Update(
+                        crate::update_output::UpdateOutput::summary(summary),
+                    ))
+                } else {
+                    crate::commands::build_from_groups(
+                        &base,
+                        &prefix,
+                        &skipped_handles,
+                        no_pr,
+                        cli.dry_run,
+                        pr_description_mode,
+                        limit,
+                        groups,
+                        list_order,
+                        allow_branch_reuse,
+                        branch_reuse_guard_days,
+                    )?;
+                    if !cli.dry_run {
+                        crate::stack_metadata::refresh_metadata_for_current_checkout(
+                            &metadata_refresh_context.base,
+                            &metadata_refresh_context.prefix,
+                            &metadata_refresh_context.ignore_tag,
+                        )?;
+                    }
+                    Ok(CommandOutput::None)
                 }
-                Ok(CommandOutput::None)
             }
         }
         crate::cli::Cmd::Restack {
@@ -621,9 +675,7 @@ fn init_logging(verbose: bool, output_mode: OutputMode) {
 }
 
 fn raw_args_request_json(args: &[OsString]) -> bool {
-    args.iter()
-        .skip(1)
-        .any(|arg| arg.as_os_str() == OsStr::new("--json"))
+    crate::json_command::raw_args_request_json(args)
 }
 
 fn read_only_command_for_cli(
@@ -679,39 +731,7 @@ fn read_only_command_for_raw_args(
 }
 
 fn machine_command_for_raw_args(args: &[OsString]) -> crate::machine_output::MachineCommand {
-    let mut skip_value = false;
-    for arg in args.iter().skip(1) {
-        if skip_value {
-            skip_value = false;
-        } else if let Some(arg) = arg.to_str() {
-            if arg == "--cd"
-                || arg == "--base"
-                || arg == "--prefix"
-                || arg == "--until"
-                || arg == "--exact"
-                || arg == "-b"
-            {
-                skip_value = true;
-            } else if arg == "restack" {
-                return crate::machine_output::MachineCommand::Restack;
-            } else if arg == "absorb" {
-                return crate::machine_output::MachineCommand::Absorb;
-            } else if arg == "move" || arg == "mv" {
-                return crate::machine_output::MachineCommand::Move;
-            } else if arg == "fix-pr" || arg == "fix" {
-                return crate::machine_output::MachineCommand::FixPr;
-            } else if arg == "resolve-stack" {
-                return crate::machine_output::MachineCommand::ResolveStack;
-            } else if arg == "resume" {
-                return crate::machine_output::MachineCommand::Resume;
-            } else if arg == "land" {
-                return crate::machine_output::MachineCommand::Land;
-            } else if !arg.starts_with('-') {
-                return crate::machine_output::MachineCommand::Cli;
-            }
-        }
-    }
-    crate::machine_output::MachineCommand::Cli
+    crate::json_command::command_for_raw_args(args)
 }
 
 #[derive(Debug)]
@@ -792,6 +812,12 @@ fn main() {
                     println!("{}", serde_json::to_string(&output).unwrap());
                 }
             }
+            CommandOutput::Update(output) => {
+                if output_mode == OutputMode::Json {
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                    std::process::exit(output.exit_code());
+                }
+            }
             CommandOutput::ResolveStack(output) => {
                 if output_mode == OutputMode::Json {
                     println!("{}", serde_json::to_string(&output).unwrap());
@@ -832,12 +858,12 @@ fn machine_command_for_cli(cmd: &crate::cli::Cmd) -> crate::machine_output::Mach
         crate::cli::Cmd::Land { .. } => crate::machine_output::MachineCommand::Land,
         crate::cli::Cmd::FixPr { .. } => crate::machine_output::MachineCommand::FixPr,
         crate::cli::Cmd::Move { .. } => crate::machine_output::MachineCommand::Move,
-        crate::cli::Cmd::Update { .. }
-        | crate::cli::Cmd::Prep {}
-        | crate::cli::Cmd::List { .. }
-        | crate::cli::Cmd::Status { .. }
-        | crate::cli::Cmd::RelinkPrs {}
-        | crate::cli::Cmd::Cleanup {} => crate::machine_output::MachineCommand::Restack,
+        crate::cli::Cmd::Update { .. } => crate::machine_output::MachineCommand::Update,
+        crate::cli::Cmd::Prep {} => crate::machine_output::MachineCommand::Prep,
+        crate::cli::Cmd::List { .. } => crate::machine_output::MachineCommand::List,
+        crate::cli::Cmd::Status { .. } => crate::machine_output::MachineCommand::Status,
+        crate::cli::Cmd::RelinkPrs {} => crate::machine_output::MachineCommand::RelinkPrs,
+        crate::cli::Cmd::Cleanup {} => crate::machine_output::MachineCommand::Cleanup,
     }
 }
 
@@ -856,7 +882,9 @@ mod tests {
     use crate::selectors::{GroupSelector, StableHandle};
     use crate::test_support::{
         commit_file, git, init_case_conflicting_stack_repo, init_repo as init_stack_repo, lock_cwd,
+        write_file, DirGuard,
     };
+    use crate::update_output::{ResolvedUpdateLimit, UpdatePayload};
     use clap::Parser;
     use std::env;
     use std::ffi::OsString;
@@ -1001,6 +1029,34 @@ mod tests {
     }
 
     #[test]
+    fn update_without_no_pr_requires_github_cli() {
+        assert!(command_requires_gh(&crate::cli::Cmd::Update {
+            from: "HEAD".to_string(),
+            no_pr: false,
+            restack: false,
+            assume_existing_prs: false,
+            pr_description_mode: None,
+            allow_branch_reuse: false,
+            json: false,
+            extent: None,
+        }));
+    }
+
+    #[test]
+    fn update_no_pr_stays_git_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::Update {
+            from: "HEAD".to_string(),
+            no_pr: true,
+            restack: false,
+            assume_existing_prs: false,
+            pr_description_mode: None,
+            allow_branch_reuse: false,
+            json: true,
+            extent: None,
+        }));
+    }
+
+    #[test]
     fn resolve_stack_without_pr_url_stays_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::ResolveStack {
             target: Some("dank-spr/alpha".to_string()),
@@ -1026,6 +1082,52 @@ mod tests {
             .unwrap();
         assert!(status.success(), "git init failed");
         dir
+    }
+
+    fn init_update_stack_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path().join("repo");
+        fs::create_dir(&repo).expect("create repo dir");
+        git(&repo, ["init", "-b", "main"].as_slice());
+        git(
+            &repo,
+            ["config", "user.email", "spr@example.com"].as_slice(),
+        );
+        git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        write_file(&repo, "README.md", "init\n");
+        git(&repo, ["add", "README.md"].as_slice());
+        git(&repo, ["commit", "-m", "init"].as_slice());
+
+        let origin = dir.path().join("origin.git");
+        git(
+            &repo,
+            ["init", "--bare", origin.to_str().unwrap()].as_slice(),
+        );
+        git(
+            &repo,
+            ["remote", "add", "origin", origin.to_str().unwrap()].as_slice(),
+        );
+        git(&repo, ["push", "-u", "origin", "main"].as_slice());
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\n",
+            "feat: alpha start pr:alpha",
+        );
+        commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\n",
+            "feat: alpha follow-up",
+        );
+        commit_file(&repo, "beta.txt", "beta-1\n", "feat: beta start pr:beta");
+        dir
+    }
+
+    fn install_failing_gh_wrapper() -> (TempDir, EnvVarGuard) {
+        install_gh_wrapper("#!/bin/sh\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n")
     }
 
     #[test]
@@ -1068,6 +1170,40 @@ mod tests {
             machine_command_for_raw_args(&args),
             MachineCommand::ResolveStack
         );
+    }
+
+    #[test]
+    fn machine_command_for_raw_args_detects_status() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("status"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(machine_command_for_raw_args(&args), MachineCommand::Status);
+    }
+
+    #[test]
+    fn machine_command_for_raw_args_detects_list_alias() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("ls"),
+            OsString::from("pr"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(machine_command_for_raw_args(&args), MachineCommand::List);
+    }
+
+    #[test]
+    fn machine_command_for_raw_args_detects_update() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("update"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(machine_command_for_raw_args(&args), MachineCommand::Update);
     }
 
     #[test]
@@ -1151,6 +1287,30 @@ mod tests {
                     other => panic!("unexpected read-only payload: {:?}", other),
                 }
             }
+            other => panic!("unexpected parse-failure output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_failure_with_update_json_uses_update_command_identity() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("update"),
+            OsString::from("--json"),
+            OsString::from("pr"),
+            OsString::from("--bogus"),
+        ];
+        let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
+        let output =
+            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+
+        match output {
+            JsonParseFailureOutput::Machine(output) => match output.payload {
+                MachinePayload::Error { command, .. } => {
+                    assert_eq!(command, MachineCommand::Update);
+                }
+                other => panic!("unexpected parse-failure payload: {:?}", other),
+            },
             other => panic!("unexpected parse-failure output: {:?}", other),
         }
     }
@@ -1629,6 +1789,183 @@ mod tests {
                     assert!(gh_log.is_empty());
                 }
                 other => panic!("unexpected read-only payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_json_no_pr_summary_stays_git_only_and_reports_full_extent() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--dry-run",
+            "update",
+            "--json",
+            "--no-pr",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::Update(output) => match output.payload {
+                UpdatePayload::Summary { data } => {
+                    assert_eq!(data.repo.base, "main");
+                    assert_eq!(data.repo.from, "HEAD");
+                    assert_eq!(data.repo.prefix, "dank-spr/");
+                    assert_eq!(data.repo.ignore_tag, "ignore");
+                    assert!(data.options.dry_run);
+                    assert!(data.options.no_pr);
+                    assert_eq!(data.extent, ResolvedUpdateLimit::All);
+                    assert!(data.warnings.is_empty());
+                    assert!(data.skipped_groups.is_empty());
+                    assert_eq!(data.groups.len(), 2);
+                    assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+                    assert_eq!(
+                        data.groups[0].push_action,
+                        crate::update_output::UpdatePushAction::CreateBranch
+                    );
+                    assert_eq!(
+                        data.groups[0].pr_action,
+                        crate::update_output::UpdatePrAction::NotRequested
+                    );
+                    assert_eq!(
+                        data.groups[0].description_action,
+                        crate::update_output::UpdateEditAction::NotRequested
+                    );
+                    assert_eq!(data.groups[1].stable_handle, "pr:beta");
+                    assert_eq!(data.groups[1].base_ref, "dank-spr/alpha");
+                }
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_json_pr_selector_reports_resolved_pr_extent() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--dry-run",
+            "update",
+            "--json",
+            "--no-pr",
+            "pr",
+            "--to",
+            "beta",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::Update(output) => match output.payload {
+                UpdatePayload::Summary { data } => {
+                    assert_eq!(data.extent, ResolvedUpdateLimit::ByPr { count: 2 });
+                    assert_eq!(data.groups.len(), 2);
+                }
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_json_legacy_pr_limit_reports_resolved_pr_extent() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--dry-run",
+            "update",
+            "--json",
+            "--no-pr",
+            "pr",
+            "1",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::Update(output) => match output.payload {
+                UpdatePayload::Summary { data } => {
+                    assert_eq!(data.extent, ResolvedUpdateLimit::ByPr { count: 1 });
+                    assert_eq!(data.groups.len(), 1);
+                    assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+                }
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_json_commit_extent_reports_resolved_commit_limit() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--dry-run",
+            "update",
+            "--json",
+            "--no-pr",
+            "commits",
+            "2",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputMode::Json).unwrap();
+
+        match output {
+            CommandOutput::Update(output) => match output.payload {
+                UpdatePayload::Summary { data } => {
+                    assert_eq!(data.extent, ResolvedUpdateLimit::ByCommits { count: 2 });
+                    assert_eq!(data.groups.len(), 1);
+                    assert_eq!(data.groups[0].stable_handle, "pr:alpha");
+                    assert_eq!(data.groups[0].target_sha.len(), 40);
+                }
             },
             other => panic!("unexpected command output: {:?}", other),
         }

--- a/src/update_output.rs
+++ b/src/update_output.rs
@@ -1,0 +1,145 @@
+use serde::Serialize;
+
+use crate::config::PrDescriptionMode;
+use crate::json_command::{JsonCommand, EXIT_SUCCESS};
+
+const UPDATE_OUTPUT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UpdateOutput {
+    pub schema_version: u32,
+    pub command: JsonCommand,
+    #[serde(flatten)]
+    pub payload: UpdatePayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum UpdatePayload {
+    Summary { data: UpdateSummaryData },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UpdateSummaryData {
+    pub repo: UpdateRepoContext,
+    pub options: UpdateOptions,
+    pub extent: ResolvedUpdateLimit,
+    pub warnings: Vec<String>,
+    pub skipped_groups: Vec<SkippedUpdateGroupData>,
+    pub groups: Vec<UpdateGroupData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UpdateRepoContext {
+    pub base: String,
+    pub from: String,
+    pub prefix: String,
+    pub ignore_tag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UpdateOptions {
+    pub dry_run: bool,
+    pub no_pr: bool,
+    pub pr_description_mode: PrDescriptionMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResolvedUpdateLimit {
+    All,
+    ByPr { count: usize },
+    ByCommits { count: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateExecutionData {
+    pub warnings: Vec<String>,
+    pub skipped_groups: Vec<SkippedUpdateGroupData>,
+    pub groups: Vec<UpdateGroupData>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdatePushAction {
+    Unchanged,
+    CreateBranch,
+    FastForwardBranch,
+    ForcePushBranch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdatePrAction {
+    NotRequested,
+    Created,
+    Existing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateEditAction {
+    NotRequested,
+    Unchanged,
+    Updated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateSkippedReason {
+    IgnoredBoundary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkippedUpdateGroupData {
+    pub stable_handle: String,
+    pub reason: UpdateSkippedReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UpdateGroupData {
+    pub local_pr_number: usize,
+    pub stable_handle: String,
+    pub head_branch: String,
+    pub base_ref: String,
+    pub title: String,
+    pub target_sha: String,
+    pub push_action: UpdatePushAction,
+    pub pr_action: UpdatePrAction,
+    pub base_ref_action: UpdateEditAction,
+    pub description_action: UpdateEditAction,
+    pub remote_pr_number: Option<u64>,
+    pub remote_pr_url: Option<String>,
+}
+
+impl UpdateSummaryData {
+    pub fn from_execution(
+        repo: UpdateRepoContext,
+        options: UpdateOptions,
+        extent: ResolvedUpdateLimit,
+        execution: UpdateExecutionData,
+    ) -> Self {
+        Self {
+            repo,
+            options,
+            extent,
+            warnings: execution.warnings,
+            skipped_groups: execution.skipped_groups,
+            groups: execution.groups,
+        }
+    }
+}
+
+impl UpdateOutput {
+    pub fn summary(data: UpdateSummaryData) -> Self {
+        Self {
+            schema_version: UPDATE_OUTPUT_SCHEMA_VERSION,
+            command: JsonCommand::Update,
+            payload: UpdatePayload::Summary { data },
+        }
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        EXIT_SUCCESS
+    }
+}


### PR DESCRIPTION
# Problem Solved
`spr update` mutates branches and PR metadata, but it reported planned and performed actions only through human logs. Automation could not reliably distinguish create, update, skip, guardrail, base-ref, body, or no-PR behavior without parsing prose.

# Mental model
`update` is the remote synchronizer for an already-parsed local stack. Its JSON mode is a publish summary: one object describes the selected extent and every branch/PR action SPR planned or performed.

# Non-goals
- Do not change the human progress logs for ordinary update runs.
- Do not change rewrite lifecycle JSON.
- Do not require `gh` when `spr update --no-pr` only needs Git branch-publication state.

# Tradeoffs
Returning typed action data requires the publish path to carry summaries alongside its existing side effects. In exchange, dry-run and real update use the same decision vocabulary, and callers can reason about PR publishing without reimplementing SPR selection rules.

# Architecture
Add update-summary output types, thread per-group update decisions out of `commands/update`, wire update JSON through CLI/main dispatch, preserve selector-specific `update pr` and `update commits` validation, and keep branch-publication classification tied to Git remote state.

# Observability
`spr update --json` emits one stdout object with repo context, effective options, resolved update limit, skipped groups above ignored boundaries, warnings, and per-group push/PR/base/body/description actions.

# Tests
Covered by update-summary unit tests, JSON CLI dispatch and parse coverage, fixture-style JSON update runs, no-PR command-requirement coverage, and validation from the original implementation branch: `cargo fmt`, `cargo clippy --tests`, and `cargo test`.

<!-- spr-stack:start -->
**Stack**:
-   #129
-   #128
-   #127
-   #126
-   #125
-   #124
-   #123
- ➡ #122

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->