### PR TITLE
drop-merged-prefix: shorten local stacks after merged bottom PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Behavior:
 ### spr restack
 
 Restack the local stack by rebuilding commits after the bottom N PR groups onto the latest base.
+Use this for local open-stack reshaping, such as reordering PR groups or rebuilding the remaining
+open groups onto base. If bottom PRs already merged on GitHub and you want the local stack to catch
+up, prefer `spr drop-merged-prefix`.
 
 Options:
 
@@ -218,6 +221,35 @@ Behavior:
 - `halt` (default) suspends on conflict, leaves the temp restack worktree and branch in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`.
 - `rollback` preserves the historical cleanup-on-conflict behavior and attempts to remove the temp restack worktree and branch (cleanup failures may require manual cleanup).
 - When restack suspends, resolve conflicts inside the printed temp worktree path, stage the resolution, and run the printed `spr resume <path>` command. Resolving in your original worktree does not advance the suspended cherry-pick.
+
+### spr drop-merged-prefix
+
+Drop the bottom local PR groups whose GitHub PRs already merged, without landing or updating any
+GitHub PR.
+Prefer this when one or more bottom PRs already merged on GitHub and your local stack still
+contains them. This is post-merge local cleanup; `spr restack` remains the general local rewrite
+tool for reshaping the remaining open stack.
+
+Typical workflow:
+
+```bash
+# After GitHub auto-merges the bottom PR:
+git fetch origin
+spr drop-merged-prefix --safe
+spr status
+spr update
+```
+
+Behavior:
+
+- Reads open/merged GitHub PR state for the local stack's synthetic PR branches
+- Selects only the contiguous bottom prefix whose PRs are `MERGED`; if the bottom PR is still open, nothing is rewritten
+- Fetches each dropped PR's GitHub merge commit OID and verifies that commit is already an ancestor of the configured SPR base, such as `origin/main`
+- Uses a fast native Git rewrite for the common case, so the checked-out stack branch starts at the first still-open PR group on top of the updated base
+- Falls back to the existing `spr restack` replay when it must preserve ignored local commits from the dropped prefix, or when native rebase cannot complete cleanly
+- With `--safe`, creates a local backup tag named like `backup/drop-merged-prefix/<current-branch>-<short-sha>` before moving the branch
+- Does not merge, close, retarget, comment on, push, or otherwise mutate GitHub PRs
+- Does not run `spr update`; run it afterwards to publish the remaining open PR branch updates
 
 ### spr absorb
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,6 +128,19 @@ pub enum Cmd {
         output: OutputArgs,
     },
 
+    /// Drop bottom PR groups whose GitHub PRs already merged, without landing or mutating PRs
+    #[command(
+        long_about = "Drop bottom PR groups whose GitHub PRs already merged, without landing or mutating PRs.\n\n`spr drop-merged-prefix` is local post-merge maintenance. It reads GitHub PR state, verifies each dropped PR's GitHub merge commit is contained in the configured SPR base, and then rewrites only the checked-out local stack.\n\nIt does not merge, close, retarget, comment on, or push GitHub PRs. After inspecting the rewritten stack, run `spr update` to publish remaining PR branch updates."
+    )]
+    DropMergedPrefix {
+        /// Create a local backup tag at current HEAD before rewriting
+        #[arg(long)]
+        safe: bool,
+
+        #[command(flatten)]
+        output: OutputArgs,
+    },
+
     /// Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch
     #[command(
         long_about = "Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.\n\nIf you append commits to the end of a local PR branch such as `user-spr/alpha`, run `spr absorb` while the stack branch is checked out. `spr` rebuilds the local stack so the new commits become part of the matching PR group. The PR-group order stays the same.\n\nThis command is local-only: it rewrites the current stack branch, creates a backup tag, and does not update GitHub. After checking the result, run `spr update`.\n\nOnly exact local branches named `prefix + tag` are considered. If one of those branches still points at rewritten-equivalent stack commits, `spr absorb` accepts that prefix only when the branch still descends from the same stack merge-base and the matched pre-tail commit ends at the same tree as the canonical stack prefix. A no-op rewritten match is reported as `skip (rewritten-equivalent prefix)`, and only commits appended above that proven prefix are absorbed. `spr absorb` also refuses to operate when two live PR groups would derive synthetic branch names that differ only by case.\n\nExample:\n- The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`.\n- Check out `user-spr/alpha` and append 2 commits.\n- Check out the stack branch.\n- Run `spr absorb`.\n- Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same.\n- Then run `spr update`.\n\nOn cherry-pick conflict, `spr absorb` leaves the temp rewrite worktree in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and run the printed resume command.\n\nAdvanced:\n- By default, absorb blocks copied later commits when replaying the stack would become empty or ambiguous.\n- `--allow-replayed-duplicates` allows an earlier copied non-seed follow-up commit to coexist with its later replayed copy by keeping both commits in the rewritten stack."
@@ -253,6 +266,7 @@ impl Cmd {
     pub fn output_format(&self) -> OutputFormat {
         match self {
             Self::Restack { output, .. }
+            | Self::DropMergedPrefix { output, .. }
             | Self::Absorb { output, .. }
             | Self::ResolveStack { output, .. }
             | Self::Resume { output, .. }
@@ -348,6 +362,18 @@ mod tests {
     }
 
     #[test]
+    fn drop_merged_prefix_help_text_says_local_post_merge_maintenance() {
+        let mut cli = Cli::command();
+        let command = cli.find_subcommand_mut("drop-merged-prefix").unwrap();
+        let long_about = command.get_long_about().unwrap().to_string();
+
+        assert!(long_about.contains("local post-merge maintenance"));
+        assert!(long_about.contains("without landing or mutating PRs"));
+        assert!(long_about.contains("does not merge, close, retarget, comment on, or push"));
+        assert!(long_about.contains("run `spr update`"));
+    }
+
+    #[test]
     fn resume_command_parses_explicit_path() {
         let cli = Cli::try_parse_from([
             "spr",
@@ -381,6 +407,9 @@ mod tests {
     fn rewrite_commands_report_json_mode() {
         let restack = Cli::try_parse_from(["spr", "restack", "--after", "1", "--json"]).unwrap();
         assert_eq!(restack.cmd.output_format(), OutputFormat::Json);
+
+        let drop_merged = Cli::try_parse_from(["spr", "drop-merged-prefix", "--json"]).unwrap();
+        assert_eq!(drop_merged.cmd.output_format(), OutputFormat::Json);
 
         let land = Cli::try_parse_from(["spr", "land", "--json"]).unwrap();
         assert_eq!(land.cmd.output_format(), OutputFormat::Json);

--- a/src/commands/drop_merged_prefix.rs
+++ b/src/commands/drop_merged_prefix.rs
@@ -1,0 +1,663 @@
+//! Drop already-merged bottom PR groups from the local stack.
+//!
+//! This command is post-merge local maintenance. It detects the contiguous bottom
+//! prefix whose GitHub PRs are already merged, verifies those GitHub merge commits
+//! are reachable from the configured base, and then rewrites only the checked-out
+//! local stack. It never lands, closes, retargets, comments on, or pushes PRs.
+
+use anyhow::{anyhow, bail, Context, Result};
+use std::collections::HashMap;
+use tracing::{info, warn};
+
+use crate::branch_names::group_branch_identities;
+use crate::commands::common::{self, DirtyWorktreeOutcome};
+use crate::commands::restack_after_count;
+use crate::commands::rewrite_resume::RewriteCommandOutcome;
+use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+use crate::git::{git_is_ancestor, git_rw};
+use crate::github::{
+    fetch_merged_pr_merge_commit_oids, list_open_or_merged_prs_for_heads, PrInfoWithState, PrState,
+};
+use crate::parsing::{derive_local_groups_with_ignored, Group};
+use crate::stack_metadata::RefreshMetadataContext;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MergedPrefixCandidate {
+    tag: String,
+    head: String,
+    pr_number: u64,
+    local_tip: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DropMergedRewriteStrategy {
+    FastRebase,
+    FastResetAll,
+    RestackFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DropMergedPrefixPlan {
+    dropped: Vec<MergedPrefixCandidate>,
+    boundary_commit: String,
+    merge_commit_oids: Vec<String>,
+    remaining_group_count: usize,
+    strategy: DropMergedRewriteStrategy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FastLocalRewriteOutcome {
+    Completed,
+    FallbackRequired,
+}
+
+impl DirtyWorktreeOutcome for FastLocalRewriteOutcome {
+    fn keeps_dirty_worktree_restore_deferred(&self) -> bool {
+        false
+    }
+}
+
+fn select_bottom_merged_prefix(
+    groups: &[Group],
+    heads: &[String],
+    remote_prs: &[PrInfoWithState],
+) -> Result<Vec<MergedPrefixCandidate>> {
+    if groups.len() != heads.len() {
+        bail!(
+            "internal error: {} local groups but {} synthetic branch heads",
+            groups.len(),
+            heads.len()
+        );
+    }
+    let remote_prs_by_head: HashMap<&str, &PrInfoWithState> =
+        remote_prs.iter().map(|pr| (pr.head.as_str(), pr)).collect();
+    let mut selected = Vec::new();
+    for (group, head) in groups.iter().zip(heads) {
+        let remote_pr = remote_prs_by_head.get(head.as_str()).copied();
+        if let Some(remote_pr) = remote_pr {
+            if remote_pr.state == PrState::Merged {
+                let local_tip = group.commits.last().cloned().ok_or_else(|| {
+                    anyhow!("local PR group pr:{} has no local commits", group.tag)
+                })?;
+                selected.push(MergedPrefixCandidate {
+                    tag: group.tag.clone(),
+                    head: head.clone(),
+                    pr_number: remote_pr.number,
+                    local_tip,
+                });
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    Ok(selected)
+}
+
+fn build_drop_merged_prefix_plan(
+    leading_ignored: &[String],
+    groups: &[Group],
+    selected: &[MergedPrefixCandidate],
+    merge_commit_oids_by_pr_number: &HashMap<u64, String>,
+) -> Result<DropMergedPrefixPlan> {
+    let boundary_commit = selected
+        .last()
+        .map(|candidate| candidate.local_tip.clone())
+        .ok_or_else(|| anyhow!("No bottom merged PR groups found."))?;
+    let merge_commit_oids = selected
+        .iter()
+        .map(|candidate| {
+            merge_commit_oids_by_pr_number
+                .get(&candidate.pr_number)
+                .cloned()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Merged GitHub PR #{} has no merge commit OID",
+                        candidate.pr_number
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let drop_count = selected.len();
+    let remaining_group_count = groups.len().saturating_sub(drop_count);
+    let dropped_prefix_has_ignored_work = !leading_ignored.is_empty()
+        || groups
+            .iter()
+            .take(drop_count)
+            .any(|group| !group.ignored_after.is_empty());
+    let strategy = if dropped_prefix_has_ignored_work {
+        DropMergedRewriteStrategy::RestackFallback
+    } else if remaining_group_count == 0 {
+        DropMergedRewriteStrategy::FastResetAll
+    } else {
+        DropMergedRewriteStrategy::FastRebase
+    };
+    Ok(DropMergedPrefixPlan {
+        dropped: selected.to_vec(),
+        boundary_commit,
+        merge_commit_oids,
+        remaining_group_count,
+        strategy,
+    })
+}
+
+fn verify_merge_commits_are_in_base(plan: &DropMergedPrefixPlan, base: &str) -> Result<()> {
+    for (candidate, merge_commit_oid) in plan.dropped.iter().zip(&plan.merge_commit_oids) {
+        if !git_is_ancestor(merge_commit_oid, base)? {
+            bail!(
+                "Merged GitHub PR #{} ({}) has merge commit {}, but that commit is not an ancestor of SPR base {}. Fetch/update the configured base before dropping local groups.",
+                candidate.pr_number,
+                candidate.head,
+                merge_commit_oid,
+                base
+            );
+        }
+    }
+    Ok(())
+}
+
+fn log_drop_plan(plan: &DropMergedPrefixPlan, dry: bool, base: &str) {
+    let handles = plan
+        .dropped
+        .iter()
+        .map(|candidate| format!("pr:{} (#{})", candidate.tag, candidate.pr_number))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mode = if dry {
+        "DRY-RUN: would drop"
+    } else {
+        "Dropping"
+    };
+    info!(
+        "{} bottom merged PR prefix: {} onto {} (remaining PR groups: {}, strategy: {:?})",
+        mode, handles, base, plan.remaining_group_count, plan.strategy
+    );
+}
+
+fn run_native_rebase(
+    dry: bool,
+    base: &str,
+    boundary_commit: &str,
+    cur_branch: &str,
+) -> Result<FastLocalRewriteOutcome> {
+    if dry {
+        let _ = git_rw(
+            true,
+            ["rebase", "--onto", base, boundary_commit, cur_branch].as_slice(),
+        )?;
+        Ok(FastLocalRewriteOutcome::Completed)
+    } else if let Err(rebase_err) = git_rw(
+        false,
+        ["rebase", "--onto", base, boundary_commit, cur_branch].as_slice(),
+    ) {
+        if let Err(abort_err) = git_rw(false, ["rebase", "--abort"].as_slice()) {
+            let repo = crate::git::repo_root()?.unwrap_or_else(|| ".".to_string());
+            Err(rebase_err).with_context(|| {
+                format!(
+                    "native drop-merged-prefix rebase failed, and `git rebase --abort` also failed: {abort_err:#}. Inspect {} and run `git rebase --abort` there before retrying.",
+                    repo
+                )
+            })
+        } else {
+            warn!(
+                "Native drop-merged-prefix rebase failed and was aborted; falling back to existing restack replay: {rebase_err:#}"
+            );
+            Ok(FastLocalRewriteOutcome::FallbackRequired)
+        }
+    } else {
+        Ok(FastLocalRewriteOutcome::Completed)
+    }
+}
+
+fn execute_fast_local_rewrite(
+    metadata_context: &RefreshMetadataContext,
+    plan: &DropMergedPrefixPlan,
+    safe: bool,
+    dry: bool,
+    dirty_worktree_policy: DirtyWorktreePolicy,
+) -> Result<FastLocalRewriteOutcome> {
+    common::with_dirty_worktree_policy(
+        dry,
+        "spr drop-merged-prefix",
+        dirty_worktree_policy,
+        |_deferred_dirty_worktree_restore| {
+            let (cur_branch, short) = common::get_current_branch_and_short()?;
+            if safe {
+                let _ = common::create_backup_tag(dry, "drop-merged-prefix", &cur_branch, &short)?;
+            }
+            let outcome = match plan.strategy {
+                DropMergedRewriteStrategy::FastResetAll => {
+                    common::reset_current_branch_to(dry, &metadata_context.base)?;
+                    FastLocalRewriteOutcome::Completed
+                }
+                DropMergedRewriteStrategy::FastRebase => run_native_rebase(
+                    dry,
+                    &metadata_context.base,
+                    &plan.boundary_commit,
+                    &cur_branch,
+                )?,
+                DropMergedRewriteStrategy::RestackFallback => {
+                    unreachable!("restack fallback is executed outside the fast-rewrite path")
+                }
+            };
+            if outcome == FastLocalRewriteOutcome::Completed && !dry {
+                crate::stack_metadata::refresh_metadata_for_current_checkout(
+                    &metadata_context.base,
+                    &metadata_context.prefix,
+                    &metadata_context.ignore_tag,
+                )?;
+            }
+            Ok(outcome)
+        },
+    )
+}
+
+pub fn drop_merged_prefix(
+    metadata_context: &RefreshMetadataContext,
+    safe: bool,
+    dry: bool,
+    restack_conflict_policy: RestackConflictPolicy,
+    dirty_worktree_policy: DirtyWorktreePolicy,
+) -> Result<RewriteCommandOutcome> {
+    git_rw(dry, ["fetch", "origin"].as_slice())?;
+
+    let (_merge_base, leading_ignored, groups) =
+        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
+    if groups.is_empty() {
+        bail!("No local PR groups found; nothing to drop.");
+    }
+    let heads = group_branch_identities(&groups, &metadata_context.prefix)?
+        .into_iter()
+        .map(|identity| identity.exact)
+        .collect::<Vec<_>>();
+    let remote_prs = list_open_or_merged_prs_for_heads(&heads)?;
+    let selected = select_bottom_merged_prefix(&groups, &heads, &remote_prs)?;
+    if selected.is_empty() {
+        bail!("No bottom merged PR groups found.");
+    }
+    let pr_numbers = selected
+        .iter()
+        .map(|candidate| candidate.pr_number)
+        .collect::<Vec<_>>();
+    let merge_commit_oids_by_pr_number = fetch_merged_pr_merge_commit_oids(&pr_numbers)?;
+    let plan = build_drop_merged_prefix_plan(
+        &leading_ignored,
+        &groups,
+        &selected,
+        &merge_commit_oids_by_pr_number,
+    )?;
+    verify_merge_commits_are_in_base(&plan, &metadata_context.base)?;
+    log_drop_plan(&plan, dry, &metadata_context.base);
+
+    let fast_outcome = if plan.strategy == DropMergedRewriteStrategy::RestackFallback {
+        FastLocalRewriteOutcome::FallbackRequired
+    } else {
+        execute_fast_local_rewrite(metadata_context, &plan, safe, dry, dirty_worktree_policy)?
+    };
+    if fast_outcome == FastLocalRewriteOutcome::FallbackRequired {
+        restack_after_count(
+            metadata_context,
+            plan.dropped.len(),
+            safe,
+            dry,
+            restack_conflict_policy,
+            dirty_worktree_policy,
+        )
+    } else {
+        info!(
+            "Dropped {} merged PR group(s). Run `spr update` to publish remaining PR branch updates.",
+            plan.dropped.len()
+        );
+        Ok(RewriteCommandOutcome::Completed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_drop_merged_prefix_plan, drop_merged_prefix, select_bottom_merged_prefix,
+        verify_merge_commits_are_in_base, DropMergedRewriteStrategy, MergedPrefixCandidate,
+    };
+    use crate::commands::RewriteCommandOutcome;
+    use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+    use crate::github::{PrInfoWithState, PrState};
+    use crate::parsing::Group;
+    use crate::stack_metadata::RefreshMetadataContext;
+    use crate::test_support::{commit_file, git, lock_cwd, write_file, DirGuard};
+    use std::collections::HashMap;
+    use std::env;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn group(tag: &str, commits: &[&str]) -> Group {
+        Group {
+            tag: tag.to_string(),
+            subjects: vec![format!("feat: {tag}")],
+            commits: commits.iter().map(|commit| (*commit).to_string()).collect(),
+            first_message: Some(format!("feat: {tag} pr:{tag}")),
+            ignored_after: Vec::new(),
+        }
+    }
+
+    fn remote_pr(number: u64, head: &str, state: PrState) -> PrInfoWithState {
+        PrInfoWithState {
+            number,
+            head: head.to_string(),
+            base: "main".to_string(),
+            state,
+            url: format!("https://github.com/o/r/pull/{number}"),
+        }
+    }
+
+    fn selected_candidate(
+        tag: &str,
+        head: &str,
+        pr_number: u64,
+        local_tip: &str,
+    ) -> MergedPrefixCandidate {
+        MergedPrefixCandidate {
+            tag: tag.to_string(),
+            head: head.to_string(),
+            pr_number,
+            local_tip: local_tip.to_string(),
+        }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            let original = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(original) = &self.original {
+                env::set_var(self.key, original);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn install_gh_wrapper(
+        exact_open_json: &Path,
+        exact_merged_json: &Path,
+        merged_number_json: &Path,
+    ) -> (TempDir, EnvVarGuard) {
+        let wrapper_dir = tempfile::tempdir().unwrap();
+        let script_path = wrapper_dir.path().join("gh");
+        fs::write(
+            &script_path,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"pullRequest(number: 10)\"*\"mergeCommit\"*) cat \"{}\" ;;\n    *\"states:[OPEN]\"*) cat \"{}\" ;;\n    *\"states:[MERGED]\"*) cat \"{}\" ;;\n    *\"is:pr is:open head:\"*) echo '{{\"data\":{{\"pr0\":{{\"nodes\":[]}},\"pr1\":{{\"nodes\":[]}}}}}}' ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n  echo '[]'\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+                merged_number_json.display(),
+                exact_open_json.display(),
+                exact_merged_json.display(),
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).unwrap();
+        let path_guard = EnvVarGuard::set(
+            "PATH",
+            format!(
+                "{}:{}",
+                wrapper_dir.path().display(),
+                env::var("PATH").unwrap_or_default()
+            ),
+        );
+        (wrapper_dir, path_guard)
+    }
+
+    #[test]
+    fn select_bottom_merged_prefix_keeps_only_contiguous_merged_bottom() {
+        let groups = vec![
+            group("alpha", &["a1", "a2"]),
+            group("beta", &["b1"]),
+            group("gamma", &["g1"]),
+        ];
+        let heads = vec![
+            "test-spr/alpha".to_string(),
+            "test-spr/beta".to_string(),
+            "test-spr/gamma".to_string(),
+        ];
+        let selected = select_bottom_merged_prefix(
+            &groups,
+            &heads,
+            &[
+                remote_pr(10, "test-spr/alpha", PrState::Merged),
+                remote_pr(11, "test-spr/beta", PrState::Merged),
+                remote_pr(12, "test-spr/gamma", PrState::Open),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            selected,
+            vec![
+                selected_candidate("alpha", "test-spr/alpha", 10, "a2"),
+                selected_candidate("beta", "test-spr/beta", 11, "b1"),
+            ]
+        );
+    }
+
+    #[test]
+    fn select_bottom_merged_prefix_returns_empty_when_bottom_pr_is_open() {
+        let groups = vec![group("alpha", &["a1"]), group("beta", &["b1"])];
+        let heads = vec!["test-spr/alpha".to_string(), "test-spr/beta".to_string()];
+        let selected = select_bottom_merged_prefix(
+            &groups,
+            &heads,
+            &[
+                remote_pr(10, "test-spr/alpha", PrState::Open),
+                remote_pr(11, "test-spr/beta", PrState::Merged),
+            ],
+        )
+        .unwrap();
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn build_plan_requires_merge_commit_oid_for_each_selected_pr() {
+        let groups = vec![group("alpha", &["a1"]), group("beta", &["b1"])];
+        let selected = vec![selected_candidate("alpha", "test-spr/alpha", 10, "a1")];
+        let err =
+            build_drop_merged_prefix_plan(&[], &groups, &selected, &HashMap::new()).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("Merged GitHub PR #10 has no merge commit OID"));
+    }
+
+    #[test]
+    fn build_plan_chooses_restack_fallback_when_dropped_prefix_has_ignored_commit() {
+        let mut alpha = group("alpha", &["a1"]);
+        alpha.ignored_after = vec!["i1".to_string()];
+        let groups = vec![alpha, group("beta", &["b1"])];
+        let selected = vec![selected_candidate("alpha", "test-spr/alpha", 10, "a1")];
+        let plan = build_drop_merged_prefix_plan(
+            &[],
+            &groups,
+            &selected,
+            &HashMap::from([(10, "merge-alpha".to_string())]),
+        )
+        .unwrap();
+
+        assert_eq!(plan.boundary_commit, "a1");
+        assert_eq!(plan.merge_commit_oids, vec!["merge-alpha".to_string()]);
+        assert_eq!(plan.remaining_group_count, 1);
+        assert_eq!(plan.strategy, DropMergedRewriteStrategy::RestackFallback);
+    }
+
+    #[test]
+    fn verify_merge_commits_are_in_base_rejects_oid_missing_from_base() {
+        let _lock = lock_cwd();
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _guard = DirGuard::change_to(repo);
+        let base = commit_file(repo, "base.txt", "base\n", "feat: base update");
+        git(repo, ["checkout", "-b", "side", "HEAD^"].as_slice());
+        let unrelated = commit_file(repo, "side.txt", "side\n", "feat: unrelated side");
+        git(repo, ["checkout", "main"].as_slice());
+        let selected = vec![selected_candidate("alpha", "test-spr/alpha", 10, "a1")];
+        let plan = build_drop_merged_prefix_plan(
+            &[],
+            &[group("alpha", &["a1"])],
+            &selected,
+            &HashMap::from([(10, unrelated.clone())]),
+        )
+        .unwrap();
+
+        let err = verify_merge_commits_are_in_base(&plan, &base).unwrap_err();
+
+        assert!(err.to_string().contains("GitHub PR #10"));
+        assert!(err.to_string().contains("is not an ancestor of SPR base"));
+    }
+
+    #[test]
+    fn drop_merged_prefix_fast_rebases_remaining_stack_onto_fetched_base() {
+        let _lock = lock_cwd();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let origin = dir.path().join("origin.git");
+        fs::create_dir(&repo).unwrap();
+        git(&repo, ["init", "-b", "main"].as_slice());
+        git(
+            &repo,
+            ["config", "user.email", "spr@example.com"].as_slice(),
+        );
+        git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        git(
+            &repo,
+            ["init", "--bare", origin.to_str().unwrap()].as_slice(),
+        );
+        git(
+            &repo,
+            [
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/spr-drop-test.git",
+            ]
+            .as_slice(),
+        );
+        git(
+            &repo,
+            [
+                "config",
+                &format!(
+                    "url.{}.insteadOf",
+                    origin.to_str().unwrap().trim_end_matches('/')
+                ),
+                "git@github.com:example/spr-drop-test.git",
+            ]
+            .as_slice(),
+        );
+        write_file(&repo, "README.md", "init\n");
+        git(&repo, ["add", "README.md"].as_slice());
+        git(&repo, ["commit", "-m", "init"].as_slice());
+        git(&repo, ["push", "-u", "origin", "main"].as_slice());
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(&repo, "alpha.txt", "alpha\n", "feat: alpha pr:alpha");
+        commit_file(&repo, "beta.txt", "beta\n", "feat: beta pr:beta");
+        let original_stack_tip = git(&repo, ["rev-parse", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        let original_short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+
+        git(&repo, ["checkout", "main"].as_slice());
+        let merge_alpha = commit_file(&repo, "alpha.txt", "alpha\n", "squash merge PR #10 alpha");
+        git(&repo, ["push", "origin", "main"].as_slice());
+        git(&repo, ["checkout", "stack"].as_slice());
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let exact_open = data_dir.path().join("exact-open.json");
+        let exact_merged = data_dir.path().join("exact-merged.json");
+        let merged_number = data_dir.path().join("merged-number.json");
+        fs::write(
+            &exact_open,
+            r#"{"data":{"repository":{"pr0":{"nodes":[]},"pr1":{"nodes":[{"number":11,"headRefName":"test-spr/beta","baseRefName":"test-spr/alpha","state":"OPEN","mergedAt":null,"closedAt":null,"url":"https://github.com/example/spr-drop-test/pull/11","autoMergeRequest":null}]}}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            &exact_merged,
+            r#"{"data":{"repository":{"pr0":{"nodes":[{"number":10,"headRefName":"test-spr/alpha","baseRefName":"main","state":"MERGED","mergedAt":"2026-04-09T00:00:00Z","closedAt":"2026-04-09T00:00:00Z","url":"https://github.com/example/spr-drop-test/pull/10","autoMergeRequest":null}]}}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            &merged_number,
+            format!(
+                r#"{{"data":{{"repository":{{"pr0":{{"number":10,"state":"MERGED","mergeCommit":{{"oid":"{}"}}}}}}}}}}"#,
+                merge_alpha
+            ),
+        )
+        .unwrap();
+        let (_wrapper, _path_guard) =
+            install_gh_wrapper(&exact_open, &exact_merged, &merged_number);
+        let _guard = DirGuard::change_to(&repo);
+
+        let outcome = drop_merged_prefix(
+            &RefreshMetadataContext {
+                base: "origin/main".to_string(),
+                prefix: "test-spr/".to_string(),
+                ignore_tag: "ignore".to_string(),
+            },
+            true,
+            false,
+            RestackConflictPolicy::Halt,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap();
+
+        assert_eq!(outcome, RewriteCommandOutcome::Completed);
+        assert_eq!(
+            git(
+                &repo,
+                ["log", "--format=%s", "--reverse", "origin/main..HEAD"].as_slice()
+            )
+            .lines()
+            .collect::<Vec<_>>(),
+            vec!["feat: beta pr:beta"]
+        );
+        assert_eq!(
+            fs::read_to_string(repo.join("alpha.txt")).unwrap(),
+            "alpha\n"
+        );
+        assert_eq!(fs::read_to_string(repo.join("beta.txt")).unwrap(), "beta\n");
+        assert_eq!(
+            git(&repo, ["merge-base", "origin/main", "HEAD"].as_slice())
+                .trim()
+                .to_string(),
+            git(&repo, ["rev-parse", "origin/main"].as_slice())
+                .trim()
+                .to_string()
+        );
+        assert_eq!(
+            git(
+                &repo,
+                [
+                    "rev-parse",
+                    &format!("backup/drop-merged-prefix/stack-{original_short}")
+                ]
+                .as_slice()
+            )
+            .trim(),
+            original_stack_tip
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod absorb;
 pub mod cleanup;
 pub mod common;
+pub mod drop_merged_prefix;
 pub mod fix_pr;
 pub mod land;
 pub mod list;
@@ -14,6 +15,7 @@ pub mod update;
 
 pub use absorb::{absorb_branch_tails, AbsorbOptions, CopiedLaterStackCommitPolicy};
 pub use cleanup::{cleanup_remote_branches, print_cleanup_summary};
+pub use drop_merged_prefix::drop_merged_prefix;
 pub use fix_pr::fix_pr_tail;
 pub use land::{land_flatten_until, land_per_pr_until};
 #[allow(unused_imports)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,7 +8,7 @@
 //! latest terminal PR event for a canonical head ref so branch-name reuse can be blocked after
 //! recent merges or closes.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -736,6 +736,60 @@ pub fn fetch_pr_ci_review_status(numbers: &[u64]) -> Result<HashMap<u64, PrCiRev
     Ok(out)
 }
 
+pub fn fetch_merged_pr_merge_commit_oids(numbers: &[u64]) -> Result<HashMap<u64, String>> {
+    let mut out = HashMap::new();
+    if numbers.is_empty() {
+        return Ok(out);
+    }
+    let (owner, name) = get_repo_owner_name()?;
+    let mut query =
+        String::from("query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ ");
+    for (i, number) in numbers.iter().enumerate() {
+        query.push_str(&format!(
+            "pr{}: pullRequest(number: {}) {{ number state mergeCommit {{ oid }} }} ",
+            i, number
+        ));
+    }
+    query.push_str("} }");
+    let json = gh_ro(
+        [
+            "api",
+            "graphql",
+            "-f",
+            &format!("query={}", query),
+            "-F",
+            &format!("owner={}", owner),
+            "-F",
+            &format!("name={}", name),
+        ]
+        .as_slice(),
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&json)?;
+    let repo = &v["data"]["repository"];
+    for (i, number) in numbers.iter().enumerate() {
+        let key = format!("pr{}", i);
+        let node = &repo[&key];
+        if node.is_null() {
+            bail!("GitHub PR #{} was not found", number);
+        }
+        let state = node["state"]
+            .as_str()
+            .ok_or_else(|| anyhow!("GitHub PR #{} result missing state", number))?;
+        if state != "MERGED" {
+            bail!(
+                "GitHub PR #{} is {}, but drop-merged-prefix expected MERGED",
+                number,
+                state
+            );
+        }
+        let oid = node["mergeCommit"]["oid"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Merged GitHub PR #{} has no merge commit OID", number))?;
+        out.insert(*number, oid.to_string());
+    }
+    Ok(out)
+}
+
 pub fn get_repo_owner_name() -> Result<(String, String)> {
     let url = git_ro(["config", "--get", "remote.origin.url"].as_slice())?
         .trim()
@@ -1134,9 +1188,9 @@ pub fn append_warning_to_pr(number: u64, warning: &str, dry: bool) -> Result<()>
 #[cfg(test)]
 mod tests {
     use super::{
-        filter_case_variant_head_search_matches, filter_head_search_matches,
-        list_conflicting_prs_for_heads_search_exhaustive, list_exact_prs_for_heads,
-        list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
+        fetch_merged_pr_merge_commit_oids, filter_case_variant_head_search_matches,
+        filter_head_search_matches, list_conflicting_prs_for_heads_search_exhaustive,
+        list_exact_prs_for_heads, list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
         list_recent_terminal_prs_for_heads, parse_open_pr_automerge_node, resolve_pr_url_head_ref,
         select_latest_merged_pr_match, select_single_open_pr_match, HeadSearchPr, PrState,
         TerminalPrState, EXACT_HEAD_QUERY_LIMIT,
@@ -1267,6 +1321,28 @@ mod tests {
         )
     }
 
+    fn install_gh_number_query_wrapper(
+        response_json: &str,
+    ) -> (TempDir, TempDir, EnvVarGuard, String) {
+        let data_dir = tempfile::tempdir().unwrap();
+        let log_path = data_dir.path().join("gh.log");
+        let response_path = data_dir.path().join("response.json");
+        fs::write(&response_path, response_json).unwrap();
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  cat \"{}\"\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display(),
+            response_path.display()
+        );
+        let (wrapper_dir, path_guard) = install_gh_wrapper(&script);
+
+        (
+            wrapper_dir,
+            data_dir,
+            path_guard,
+            log_path.display().to_string(),
+        )
+    }
+
     #[test]
     fn resolve_pr_url_head_ref_reads_only_head_ref_name() {
         let _lock = lock_cwd();
@@ -1284,6 +1360,64 @@ mod tests {
         assert_eq!(head_ref_name, "dank-spr/example");
         let log = fs::read_to_string(log_path).expect("read gh log");
         assert!(log.contains("pr view https://github.com/o/r/pull/17 --json headRefName"));
+    }
+
+    #[test]
+    fn fetch_merged_pr_merge_commit_oids_queries_numbers_and_returns_oids() {
+        let _lock = lock_cwd();
+        let (_wrapper_dir, _data_dir, _path_guard, log_path) = install_gh_number_query_wrapper(
+            &json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "number": 10,
+                            "state": "MERGED",
+                            "mergeCommit": { "oid": "merge-alpha" }
+                        },
+                        "pr1": {
+                            "number": 11,
+                            "state": "MERGED",
+                            "mergeCommit": { "oid": "merge-beta" }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        );
+
+        let oids = fetch_merged_pr_merge_commit_oids(&[10, 11]).unwrap();
+
+        assert_eq!(oids[&10], "merge-alpha");
+        assert_eq!(oids[&11], "merge-beta");
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("pullRequest(number: 10)"));
+        assert!(log.contains("pullRequest(number: 11)"));
+        assert!(log.contains("mergeCommit { oid }"));
+    }
+
+    #[test]
+    fn fetch_merged_pr_merge_commit_oids_rejects_missing_merge_commit() {
+        let _lock = lock_cwd();
+        let (_wrapper_dir, _data_dir, _path_guard, _log_path) = install_gh_number_query_wrapper(
+            &json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "number": 10,
+                            "state": "MERGED",
+                            "mergeCommit": null
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        );
+
+        let err = fetch_merged_pr_merge_commit_oids(&[10]).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("Merged GitHub PR #10 has no merge commit OID"));
     }
 
     #[test]

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -11,6 +11,7 @@ pub const EXIT_SUSPENDED: i32 = 2;
 pub enum JsonCommand {
     Cli,
     Restack,
+    DropMergedPrefix,
     Absorb,
     Move,
     FixPr,
@@ -128,6 +129,8 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
                 return JsonCommand::ListCommit;
             } else if arg == "restack" {
                 return JsonCommand::Restack;
+            } else if arg == "drop-merged-prefix" {
+                return JsonCommand::DropMergedPrefix;
             } else if arg == "absorb" {
                 return JsonCommand::Absorb;
             } else if arg == "move" || arg == "mv" {
@@ -195,6 +198,17 @@ mod tests {
 
         assert_eq!(command_for_raw_args(&pr_args), JsonCommand::ListPr);
         assert_eq!(command_for_raw_args(&commit_args), JsonCommand::ListCommit);
+    }
+
+    #[test]
+    fn raw_args_detect_drop_merged_prefix_command() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("drop-merged-prefix"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(command_for_raw_args(&args), JsonCommand::DropMergedPrefix);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
         crate::cli::Cmd::List { .. }
         | crate::cli::Cmd::Status { .. }
         | crate::cli::Cmd::Prep { .. }
+        | crate::cli::Cmd::DropMergedPrefix { .. }
         | crate::cli::Cmd::Land { .. }
         | crate::cli::Cmd::RelinkPrs { .. }
         | crate::cli::Cmd::Cleanup { .. }
@@ -391,6 +392,21 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 crate::commands::restack_after(
                     &metadata_refresh_context,
                     &after,
+                    safe,
+                    cli.dry_run,
+                    restack_conflict_policy,
+                    dirty_worktree_policy,
+                )?,
+            )?))
+        }
+        crate::cli::Cmd::DropMergedPrefix { safe, output: _ } => {
+            set_dry_run_env(cli.dry_run, false);
+            Ok(CommandOutput::Machine(ensure_rewrite_completed(
+                output_format,
+                "spr drop-merged-prefix",
+                crate::machine_output::MachineCommand::DropMergedPrefix,
+                crate::commands::drop_merged_prefix(
+                    &metadata_refresh_context,
                     safe,
                     cli.dry_run,
                     restack_conflict_policy,
@@ -782,6 +798,9 @@ fn main() {
 fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonCommand {
     match cmd {
         crate::cli::Cmd::Restack { .. } => crate::machine_output::MachineCommand::Restack,
+        crate::cli::Cmd::DropMergedPrefix { .. } => {
+            crate::machine_output::MachineCommand::DropMergedPrefix
+        }
         crate::cli::Cmd::Absorb { .. } => crate::machine_output::MachineCommand::Absorb,
         crate::cli::Cmd::ResolveStack { .. } => crate::machine_output::MachineCommand::ResolveStack,
         crate::cli::Cmd::Resume { .. } => crate::machine_output::MachineCommand::Resume,
@@ -943,6 +962,14 @@ mod tests {
     fn absorb_is_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::Absorb {
             allow_replayed_duplicates: false,
+            output: OutputArgs::human(),
+        }));
+    }
+
+    #[test]
+    fn drop_merged_prefix_requires_github_cli() {
+        assert!(command_requires_gh(&crate::cli::Cmd::DropMergedPrefix {
+            safe: true,
             output: OutputArgs::human(),
         }));
     }
@@ -1142,6 +1169,20 @@ mod tests {
         ];
 
         assert_eq!(json_command_for_raw_args(&args), JsonCommand::Update);
+    }
+
+    #[test]
+    fn json_command_for_raw_args_detects_drop_merged_prefix() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("drop-merged-prefix"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(
+            json_command_for_raw_args(&args),
+            JsonCommand::DropMergedPrefix
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Problem Solved
After a bottom PR auto-merges on GitHub, the local stack still needs to be shortened so the merged prefix is gone and the remaining open groups stay on top. Today the way to accomplish that is `restack`, but `restack` is slow for this case because it runs the full restack machinery even when the only required change is to remove an already-merged bottom prefix. `drop-merged-prefix` solves the same cleanup problem with a faster post-merge path that removes just that merged local prefix.

# Mental model
`drop-merged-prefix` is post-merge local maintenance. It discovers the contiguous bottom prefix whose PRs are already merged, proves each reported GitHub merge commit is reachable from the resolved SPR base, removes only that local prefix, and leaves publishing the remaining open PR branches to a later `spr update`.

# Non-goals
- Do not merge, close, retarget, comment on, enable auto-merge for, push, or update GitHub PRs.
- Do not trust GitHub `MERGED` state by itself; the configured base ref must contain the merge commit.
- Do not discard local-only ignored blocks to make the fast path work.

# Tradeoffs
The common path uses native branch rewrite/rebase instead of the existing temp-worktree restack. That is cheaper in a large checkout, but it only runs after the merged-prefix and base-ancestry checks pass. Cases that require preserving ignored commits or recovering from a native rebase failure fall back to the established restack machinery.

# Architecture
Add a drop-merged-prefix command, planner, GitHub merge-commit lookup, base-ancestry verification, optional backup tag, fast reset/rebase rewrite path, restack fallback, metadata refresh, CLI dispatch, JSON command identity, README usage, planner tests, GitHub-query tests, and a command-boundary fast-rebase fixture.

# Observability
Human output names the merged groups being dropped and the local maintenance step being run. JSON/lifecycle output stays on the existing command-output path. Backup tags use the command-specific backup namespace when `--safe` is requested.

# Tests
Validated in the original implementation run with baseline `cargo test`, targeted drop-merged-prefix and GitHub tests, `cargo clippy --tests`, `cargo fmt`, a full `cargo test` pass of 236 tests, `cargo run -- --help` showing the new command, and the command fixture that leaves only the still-open beta group above `origin/main`.

<!-- spr-stack:start -->
**Stack**:
-   #129
-   #128
-   #127
-   #126
-   #125
- ➡ #124

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->