### PR TITLE
restack: preview replay plans before rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,14 @@ Options:
   - `top` or `last` or `all`: skip all PRs; ignored commits (pr:ignore blocks) are preserved, so the branch may remain ahead of base
   - `label` or `pr:<label>`: keep that stable group and everything below it in place even if local PR numbers renumber
 - `--safe`: create a local backup tag at current `HEAD` before rebasing
+- `--preview`: print the resolved high-level plan and stop before fetch, backup tags, temp worktrees, resume files, cherry-picks, branch resets, metadata writes, pushes, or GitHub calls
+- `--json`: with `--preview`, write exactly one preview object to stdout
 
 Behavior:
 
 - Computes PR groups from `merge-base(base, HEAD)..HEAD` using `pr:<tag>` markers (oldest → newest; ignore blocks are preserved but excluded from grouping)
+- `spr restack --after ... --preview` uses local refs only and reports that remote freshness, replay conflicts, tests, hooks, GitHub mergeability, and update/push results have not been validated
+- Normal human `spr restack --after ...` prints the same high-level plan immediately before it starts the rewrite phase
 - Drops the first N groups, then rebuilds the remaining commits onto `--base` via a temp worktree
   - Ignored commits attached to dropped groups are kept before the remaining stack
   - Ignored commits attached to kept groups move with those groups
@@ -358,6 +362,12 @@ Machine-readable `--json` mode:
 - `spr relink-prs --json` writes the expected local head/base chain plus one decision per PR head
 - `spr cleanup --json` writes remote candidates, open-PR heads, per-branch decisions, and the
   delete batch
+- `spr restack --preview --json` writes one preview object with `result: "preview"` and
+  a `data` object containing the local base ref/SHA, current branch/HEAD, selected dropped groups,
+  remaining groups, ignored-segment count, planned cherry-pick operation count, operations that a
+  real run would perform, and the checks not validated by preview
+- `spr restack --json` without `--preview` keeps the rewrite lifecycle contract:
+  it writes one completed or suspended object, not a preview object
 - JSON errors across commands use one typed error envelope with `result: "error"` plus
   `error_kind` values such as `synthetic_branch_name_collision`, `invalid_arguments`, and
   `internal`
@@ -661,6 +671,8 @@ Dry run behavior
 - `--dry-run` prints most state-changing `git`/`gh` commands instead of executing
 - For safety, some local operations may still execute in temporary worktrees to better mirror behavior
 - In dry-run, set `--assume-existing-prs` with `spr update` to show `gh pr edit` instead of `gh pr create`
+- `spr restack --preview` is not a dry-run rewrite: it only prints the resolved plan and does not
+  fetch, create rewrite state, or exercise cherry-pick conflict handling
 
 Notes
 -----
@@ -700,6 +712,12 @@ spr restack --after 2 --safe
 
 # Restack only the groups above the stable beta group
 spr restack --after beta
+
+# Preview that restack plan without fetching or rewriting
+spr restack --after beta --preview
+
+# Emit the restack preview as one JSON object
+spr restack --after beta --preview --json
 
 # Land top PR only using config default mode (flatten by default)
 spr land --until 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,6 +124,10 @@ pub enum Cmd {
         #[arg(long)]
         safe: bool,
 
+        /// Print the resolved high-level restack plan and do not fetch, rewrite, or publish
+        #[arg(long)]
+        preview: bool,
+
         #[command(flatten)]
         output: OutputArgs,
     },
@@ -416,6 +420,35 @@ mod tests {
 
         let list = Cli::try_parse_from(["spr", "list", "--json", "pr"]).unwrap();
         assert_eq!(list.cmd.output_format(), OutputFormat::Json);
+    }
+
+    #[test]
+    fn restack_preview_flag_parses_with_json_and_safe() {
+        let cli = Cli::try_parse_from([
+            "spr",
+            "restack",
+            "--after",
+            "pr:alpha",
+            "--safe",
+            "--preview",
+            "--json",
+        ])
+        .unwrap();
+
+        match cli.cmd {
+            Cmd::Restack {
+                after,
+                safe,
+                preview,
+                output,
+            } => {
+                assert_eq!(after.to_string(), "pr:alpha");
+                assert!(safe);
+                assert!(preview);
+                assert_eq!(output.format(), OutputFormat::Json);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,7 +29,7 @@ pub use prep::{prep_squash, print_prep_summary};
 pub use r#move::{move_groups_after, MoveExecutionOptions};
 pub use relink_prs::{print_relink_prs_summary, relink_prs};
 pub use resolve_stack::{looks_like_pr_url, resolve_stack, ResolveStackOutput};
-pub use restack::{restack_after, restack_after_count};
+pub use restack::{preview_restack_after, restack_after, restack_after_count};
 pub use rewrite_resume::{
     resume_rewrite, RewriteCommandKind, RewriteCommandOutcome, RewriteSuspendedState,
 };

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -22,6 +22,7 @@ use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
 use crate::git::git_rev_parse;
 use crate::git::git_rw;
 use crate::parsing::{derive_local_groups_with_ignored, Group};
+use crate::restack_output::{render_human_preview, RestackPreviewData, RestackPreviewGroup};
 use crate::selectors::{resolve_after_count, AfterSelector};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +31,21 @@ struct RestackExecutionOptions {
     dry: bool,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
+}
+
+#[derive(Debug, Clone)]
+pub struct RestackPlan {
+    pub base_ref: String,
+    pub base_sha: Option<String>,
+    pub base_ref_was_refreshed: bool,
+    pub current_branch: String,
+    pub original_head: String,
+    pub after_selector: String,
+    pub resolved_after_count: usize,
+    pub dropped_groups: Vec<Group>,
+    pub remaining_groups: Vec<Group>,
+    pub kept_ignored_segments: Vec<Vec<String>>,
+    pub operations: Vec<CherryPickOp>,
 }
 
 /// Build the ordered cherry-pick plan that reconstructs the restacked history.
@@ -86,16 +102,175 @@ fn resolve_restack_after_count(groups: &[Group], after: &AfterSelector) -> Resul
     resolve_after_count(groups, after)
 }
 
-fn restack_after_resolved(
+fn group_preview(group: &Group) -> RestackPreviewGroup {
+    RestackPreviewGroup {
+        stable_handle: format!("pr:{}", group.tag),
+        commit_count: group.commits.len(),
+        ignored_after_count: group.ignored_after.len(),
+    }
+}
+
+impl RestackPlan {
+    fn preview_data(&self, safe_requested: bool) -> RestackPreviewData {
+        let would_change_branch =
+            !self.dropped_groups.is_empty() || !self.remaining_groups.is_empty();
+        let would_create_temp_worktree =
+            !self.remaining_groups.is_empty() || !self.kept_ignored_segments.is_empty();
+        let mut not_validated = if self.base_ref_was_refreshed {
+            Vec::new()
+        } else {
+            vec!["remote freshness".to_string()]
+        };
+        not_validated.extend(
+            [
+                "cherry-pick conflicts",
+                "tests",
+                "pre-push hooks",
+                "GitHub mergeability",
+                "spr update result",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        );
+
+        RestackPreviewData {
+            base_ref: self.base_ref.clone(),
+            base_sha: self.base_sha.clone(),
+            base_ref_was_refreshed: self.base_ref_was_refreshed,
+            current_branch: self.current_branch.clone(),
+            original_head: self.original_head.clone(),
+            after_selector: self.after_selector.clone(),
+            resolved_after_count: self.resolved_after_count,
+            dropped_groups: self.dropped_groups.iter().map(group_preview).collect(),
+            remaining_groups: self.remaining_groups.iter().map(group_preview).collect(),
+            kept_ignored_segment_count: self.kept_ignored_segments.len(),
+            planned_cherry_pick_operation_count: self.operations.len(),
+            would_fetch_origin_when_executed: !self.base_ref_was_refreshed,
+            would_create_backup_tag: safe_requested && would_change_branch,
+            would_create_temp_worktree,
+            would_reset_current_branch: would_change_branch,
+            would_refresh_stack_metadata: would_change_branch,
+            not_validated,
+        }
+    }
+}
+
+fn build_restack_plan(
     metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     leading_ignored: Vec<String>,
     groups: Vec<Group>,
     after: usize,
-    options: RestackExecutionOptions,
-) -> Result<RewriteCommandOutcome> {
+    after_selector: String,
+    base_ref_was_refreshed: bool,
+) -> Result<RestackPlan> {
     let after = std::cmp::min(after, groups.len());
     let kept_ignored_segments = build_kept_ignored_segments(leading_ignored, &groups, after);
-    let remaining = groups[after..].to_vec();
+    let dropped_groups = groups[..after].to_vec();
+    let remaining_groups = groups[after..].to_vec();
+    let operations = build_cherry_pick_plan(&kept_ignored_segments, &remaining_groups);
+    let (current_branch, _) = common::get_current_branch_and_short()?;
+    let original_head = git_rev_parse("HEAD")?;
+
+    Ok(RestackPlan {
+        base_ref: metadata_context.base.clone(),
+        base_sha: git_rev_parse(&metadata_context.base).ok(),
+        base_ref_was_refreshed,
+        current_branch,
+        original_head,
+        after_selector,
+        resolved_after_count: after,
+        dropped_groups,
+        remaining_groups,
+        kept_ignored_segments,
+        operations,
+    })
+}
+
+fn collect_restack_plan(
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
+    after: &AfterSelector,
+    base_ref_was_refreshed: bool,
+) -> Result<Option<RestackPlan>> {
+    let (_merge_base, leading_ignored, groups) =
+        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
+    if groups.is_empty() {
+        Ok(None)
+    } else {
+        let resolved_after_count = resolve_restack_after_count(&groups, after)?;
+        build_restack_plan(
+            metadata_context,
+            leading_ignored,
+            groups,
+            resolved_after_count,
+            after.to_string(),
+            base_ref_was_refreshed,
+        )
+        .map(Some)
+    }
+}
+
+fn collect_restack_plan_after_count(
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
+    after: usize,
+    base_ref_was_refreshed: bool,
+) -> Result<Option<RestackPlan>> {
+    let (_merge_base, leading_ignored, groups) =
+        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
+    if groups.is_empty() {
+        Ok(None)
+    } else {
+        build_restack_plan(
+            metadata_context,
+            leading_ignored,
+            groups,
+            after,
+            after.to_string(),
+            base_ref_was_refreshed,
+        )
+        .map(Some)
+    }
+}
+
+pub fn preview_restack_after(
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
+    after: &AfterSelector,
+    safe_requested: bool,
+) -> Result<RestackPreviewData> {
+    if let Some(plan) = collect_restack_plan(metadata_context, after, false)? {
+        Ok(plan.preview_data(safe_requested))
+    } else {
+        let (current_branch, _) = common::get_current_branch_and_short()?;
+        let original_head = git_rev_parse("HEAD")?;
+        Ok(RestackPlan {
+            base_ref: metadata_context.base.clone(),
+            base_sha: git_rev_parse(&metadata_context.base).ok(),
+            base_ref_was_refreshed: false,
+            current_branch,
+            original_head,
+            after_selector: after.to_string(),
+            resolved_after_count: 0,
+            dropped_groups: Vec::new(),
+            remaining_groups: Vec::new(),
+            kept_ignored_segments: Vec::new(),
+            operations: Vec::new(),
+        }
+        .preview_data(safe_requested))
+    }
+}
+
+fn log_human_restack_plan(plan: &RestackPlan, safe_requested: bool) {
+    let data = plan.preview_data(safe_requested);
+    for line in render_human_preview("Restack plan", &data).lines() {
+        info!("{line}");
+    }
+}
+
+fn restack_after_resolved(
+    metadata_context: &crate::stack_metadata::RefreshMetadataContext,
+    plan: RestackPlan,
+    options: RestackExecutionOptions,
+) -> Result<RewriteCommandOutcome> {
+    log_human_restack_plan(&plan, options.safe);
 
     common::with_dirty_worktree_policy(
         options.dry,
@@ -106,13 +281,13 @@ fn restack_after_resolved(
             let original_head = git_rev_parse("HEAD")?;
             let original_worktree_root = rewrite_resume::current_repo_root()?;
             let metadata_refresh_context = metadata_context.clone();
-            if remaining.is_empty() && kept_ignored_segments.is_empty() {
+            if plan.remaining_groups.is_empty() && plan.kept_ignored_segments.is_empty() {
                 if options.safe {
                     let _ = common::create_backup_tag(options.dry, "restack", &cur_branch, &short)?;
                 }
                 info!(
                     "Skipping all {} PR(s); syncing current branch {} to {}",
-                    groups.len(),
+                    plan.dropped_groups.len(),
                     cur_branch,
                     metadata_context.base
                 );
@@ -150,7 +325,6 @@ fn restack_after_resolved(
                     &metadata_context.base,
                     &short,
                 )?;
-                let ops = build_cherry_pick_plan(&kept_ignored_segments, &remaining);
                 let outcome = rewrite_resume::run_rewrite_session(
                     options.dry,
                     RewriteSession {
@@ -169,7 +343,7 @@ fn restack_after_resolved(
                         temp_branch: tmp_branch,
                         temp_worktree_path: tmp_path,
                         backup_tag,
-                        operations: ops,
+                        operations: plan.operations.clone(),
                         deferred_dirty_worktree_restore,
                         post_success_hint: None,
                         metadata_refresh_context: Some(metadata_refresh_context),
@@ -178,7 +352,7 @@ fn restack_after_resolved(
                 if outcome == RewriteCommandOutcome::Completed {
                     info!(
                         "Rebased commits after first {} PR(s) of {} onto {} (including ignored commits)",
-                        after, cur_branch, metadata_context.base
+                        plan.resolved_after_count, cur_branch, metadata_context.base
                     );
                 }
                 Ok(outcome)
@@ -214,18 +388,10 @@ pub fn restack_after(
 ) -> Result<RewriteCommandOutcome> {
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
-    let (_merge_base, leading_ignored, groups) =
-        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
-    if groups.is_empty() {
-        info!("No local PR groups found; nothing to restack.");
-        Ok(RewriteCommandOutcome::Completed)
-    } else {
-        let after = resolve_restack_after_count(&groups, after)?;
+    if let Some(plan) = collect_restack_plan(metadata_context, after, true)? {
         restack_after_resolved(
             metadata_context,
-            leading_ignored,
-            groups,
-            after,
+            plan,
             RestackExecutionOptions {
                 safe,
                 dry,
@@ -233,6 +399,9 @@ pub fn restack_after(
                 dirty_worktree_policy,
             },
         )
+    } else {
+        info!("No local PR groups found; nothing to restack.");
+        Ok(RewriteCommandOutcome::Completed)
     }
 }
 
@@ -247,16 +416,10 @@ pub fn restack_after_count(
 ) -> Result<RewriteCommandOutcome> {
     git_rw(dry, ["fetch", "origin"].as_slice())?;
 
-    let (_merge_base, leading_ignored, groups) =
-        derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
-    if groups.is_empty() {
-        Ok(RewriteCommandOutcome::Completed)
-    } else {
+    if let Some(plan) = collect_restack_plan_after_count(metadata_context, after, true)? {
         restack_after_resolved(
             metadata_context,
-            leading_ignored,
-            groups,
-            after,
+            plan,
             RestackExecutionOptions {
                 safe,
                 dry,
@@ -264,12 +427,17 @@ pub fn restack_after_count(
                 dirty_worktree_policy,
             },
         )
+    } else {
+        Ok(RewriteCommandOutcome::Completed)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_cherry_pick_plan, build_kept_ignored_segments, resolve_restack_after_count};
+    use super::{
+        build_cherry_pick_plan, build_kept_ignored_segments, build_restack_plan,
+        preview_restack_after, resolve_restack_after_count,
+    };
     use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
     use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
     use crate::commands::RewriteCommandOutcome;
@@ -371,6 +539,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_restack_plan_selects_dropped_remaining_ignored_and_ops() {
+        let plan = build_restack_plan(
+            &metadata_context(),
+            vec!["lead1".to_string()],
+            groups(&["alpha", "beta", "gamma"]),
+            2,
+            "pr:beta".to_string(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(plan.after_selector, "pr:beta");
+        assert_eq!(plan.resolved_after_count, 2);
+        assert_eq!(
+            plan.dropped_groups
+                .iter()
+                .map(|group| group.tag.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+        assert_eq!(
+            plan.remaining_groups
+                .iter()
+                .map(|group| group.tag.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gamma"]
+        );
+        assert_eq!(plan.kept_ignored_segments, vec![vec!["lead1".to_string()]]);
+        assert_eq!(plan.operations.len(), 2);
+    }
+
     fn init_restack_conflict_repo() -> TempDir {
         let dir = tempfile::tempdir().expect("create temp dir");
         let repo = dir.path().join("repo");
@@ -403,6 +603,69 @@ mod tests {
         commit_file(&repo, "story.txt", "base-updated\n", "feat: base update");
         git(&repo, ["checkout", "stack"].as_slice());
         dir
+    }
+
+    fn init_restack_preview_repo() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path().join("repo");
+        fs::create_dir(&repo).expect("create repo dir");
+        git(&repo, ["init", "-b", "main"].as_slice());
+        git(
+            &repo,
+            ["config", "user.email", "spr@example.com"].as_slice(),
+        );
+        git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        commit_file(&repo, "base.txt", "base\n", "init");
+
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(&repo, "alpha.txt", "alpha\n", "feat: alpha pr:alpha");
+        commit_file(&repo, "beta.txt", "beta\n", "feat: beta pr:beta");
+        dir
+    }
+
+    fn read_preview_side_effect_snapshot(repo: &Path) -> String {
+        [
+            git(repo, ["rev-parse", "HEAD"].as_slice()),
+            git(repo, ["branch", "--format=%(refname:short)"].as_slice()),
+            git(repo, ["tag", "--list"].as_slice()),
+            git(repo, ["worktree", "list", "--porcelain"].as_slice()),
+            fs::read_dir(repo.join(".git/spr/resume"))
+                .map(|entries| entries.count().to_string())
+                .unwrap_or_else(|_| "<no-resume-dir>".to_string()),
+        ]
+        .join("\n---\n")
+    }
+
+    #[test]
+    fn restack_preview_reports_plan_and_leaves_git_state_unchanged() {
+        let _lock = lock_cwd();
+        let dir = init_restack_preview_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let before = read_preview_side_effect_snapshot(&repo);
+
+        let preview = preview_restack_after(
+            &metadata_context(),
+            &AfterSelector::Group(GroupSelector::Stable(StableHandle {
+                tag: "alpha".to_string(),
+            })),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(preview.current_branch, "stack");
+        assert_eq!(preview.after_selector, "pr:alpha");
+        assert_eq!(preview.resolved_after_count, 1);
+        assert_eq!(preview.dropped_groups[0].stable_handle, "pr:alpha");
+        assert_eq!(preview.remaining_groups[0].stable_handle, "pr:beta");
+        assert!(preview.would_fetch_origin_when_executed);
+        assert!(preview.would_create_backup_tag);
+        assert!(preview.would_create_temp_worktree);
+        assert!(preview.would_reset_current_branch);
+        assert!(preview
+            .not_validated
+            .contains(&"cherry-pick conflicts".to_string()));
+        assert_eq!(read_preview_side_effect_snapshot(&repo), before);
     }
 
     fn resolve_restack_conflict(temp_repo: &Path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod maintenance_output;
 mod parsing;
 mod pr_labels;
 mod read_only_output;
+mod restack_output;
 mod selectors;
 mod stack_metadata;
 mod summary_output;
@@ -87,6 +88,7 @@ enum CommandOutput {
     None,
     Machine(crate::machine_output::MachineOutput),
     ReadOnly(crate::read_only_output::ReadOnlyOutput),
+    RestackPreview(crate::restack_output::RestackPreviewOutput),
     ResolveStack(crate::commands::ResolveStackOutput),
     Update(crate::update_output::UpdateOutput),
     Maintenance(Box<crate::maintenance_output::MaintenanceOutput>),
@@ -382,22 +384,33 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
         crate::cli::Cmd::Restack {
             after,
             safe,
+            preview,
             output: _,
         } => {
             set_dry_run_env(cli.dry_run, false);
-            Ok(CommandOutput::Machine(ensure_rewrite_completed(
-                output_format,
-                "spr restack",
-                crate::machine_output::MachineCommand::Restack,
-                crate::commands::restack_after(
-                    &metadata_refresh_context,
-                    &after,
-                    safe,
-                    cli.dry_run,
-                    restack_conflict_policy,
-                    dirty_worktree_policy,
-                )?,
-            )?))
+            if preview {
+                Ok(CommandOutput::RestackPreview(
+                    crate::restack_output::preview(crate::commands::preview_restack_after(
+                        &metadata_refresh_context,
+                        &after,
+                        safe,
+                    )?),
+                ))
+            } else {
+                Ok(CommandOutput::Machine(ensure_rewrite_completed(
+                    output_format,
+                    "spr restack",
+                    crate::machine_output::MachineCommand::Restack,
+                    crate::commands::restack_after(
+                        &metadata_refresh_context,
+                        &after,
+                        safe,
+                        cli.dry_run,
+                        restack_conflict_policy,
+                        dirty_worktree_policy,
+                    )?,
+                )?))
+            }
         }
         crate::cli::Cmd::DropMergedPrefix { safe, output: _ } => {
             set_dry_run_env(cli.dry_run, false);
@@ -753,6 +766,14 @@ fn main() {
                 if output_format == crate::cli::OutputFormat::Json {
                     println!("{}", serde_json::to_string(&output).unwrap());
                     std::process::exit(output.exit_code());
+                }
+            }
+            CommandOutput::RestackPreview(output) => {
+                if output_format == crate::cli::OutputFormat::Json {
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                    std::process::exit(output.exit_code());
+                } else {
+                    println!("{}", output.render_human());
                 }
             }
             CommandOutput::Update(output) => {
@@ -1414,6 +1435,47 @@ mod tests {
                 }
             }
             other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_cli_restack_preview_json_returns_preview_payload() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "restack",
+            "--after",
+            "pr:alpha",
+            "--preview",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::RestackPreview(output) => {
+                assert_eq!(
+                    output.result,
+                    crate::restack_output::RestackPreviewResult::Preview
+                );
+                assert_eq!(output.data.current_branch, "stack");
+                assert_eq!(output.data.after_selector, "pr:alpha");
+                assert_eq!(output.data.dropped_groups[0].stable_handle, "pr:alpha");
+                assert_eq!(output.data.remaining_groups[0].stable_handle, "pr:beta");
+                assert!(output
+                    .data
+                    .not_validated
+                    .contains(&"remote freshness".to_string()));
+            }
+            other => panic!("unexpected output: {:?}", other),
         }
     }
 

--- a/src/restack_output.rs
+++ b/src/restack_output.rs
@@ -1,0 +1,253 @@
+//! Output contract for read-only restack previews.
+
+use serde::Serialize;
+
+use crate::json_output::{JsonCommand, JSON_OUTPUT_SCHEMA_VERSION};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RestackPreviewResult {
+    Preview,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RestackPreviewOutput {
+    pub schema_version: u32,
+    pub command: JsonCommand,
+    pub result: RestackPreviewResult,
+    pub data: RestackPreviewData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RestackPreviewGroup {
+    pub stable_handle: String,
+    pub commit_count: usize,
+    pub ignored_after_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RestackPreviewData {
+    pub base_ref: String,
+    pub base_sha: Option<String>,
+    pub base_ref_was_refreshed: bool,
+    pub current_branch: String,
+    pub original_head: String,
+    pub after_selector: String,
+    pub resolved_after_count: usize,
+    pub dropped_groups: Vec<RestackPreviewGroup>,
+    pub remaining_groups: Vec<RestackPreviewGroup>,
+    pub kept_ignored_segment_count: usize,
+    pub planned_cherry_pick_operation_count: usize,
+    pub would_fetch_origin_when_executed: bool,
+    pub would_create_backup_tag: bool,
+    pub would_create_temp_worktree: bool,
+    pub would_reset_current_branch: bool,
+    pub would_refresh_stack_metadata: bool,
+    pub not_validated: Vec<String>,
+}
+
+pub fn preview(data: RestackPreviewData) -> RestackPreviewOutput {
+    RestackPreviewOutput {
+        schema_version: JSON_OUTPUT_SCHEMA_VERSION,
+        command: JsonCommand::Restack,
+        result: RestackPreviewResult::Preview,
+        data,
+    }
+}
+
+impl RestackPreviewOutput {
+    pub fn exit_code(&self) -> i32 {
+        crate::json_output::EXIT_SUCCESS
+    }
+
+    pub fn render_human(&self) -> String {
+        render_human_preview("Restack preview", &self.data)
+    }
+}
+
+fn render_groups(groups: &[RestackPreviewGroup]) -> String {
+    if groups.is_empty() {
+        "<none>".to_string()
+    } else {
+        groups
+            .iter()
+            .map(|group| {
+                if group.ignored_after_count == 0 {
+                    format!("{} ({} commit(s))", group.stable_handle, group.commit_count)
+                } else {
+                    format!(
+                        "{} ({} commit(s), {} ignored after)",
+                        group.stable_handle, group.commit_count, group.ignored_after_count
+                    )
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
+fn render_bool_list(items: &[&str]) -> String {
+    items.join("; ")
+}
+
+pub fn render_human_preview(title: &str, data: &RestackPreviewData) -> String {
+    let is_preview = title.to_ascii_lowercase().contains("preview");
+    let base_sha = data.base_sha.as_deref().unwrap_or("<unresolved>");
+    let base_note = if data.base_ref_was_refreshed {
+        "refreshed before planning"
+    } else {
+        "local ref; preview did not fetch"
+    };
+    let execution_label = if is_preview {
+        "execution would"
+    } else {
+        "execution plan"
+    };
+    let not_validated_label = if is_preview {
+        "not validated by preview"
+    } else {
+        "not validated yet"
+    };
+    let would_do = render_bool_list(&[
+        if data.would_fetch_origin_when_executed {
+            "fetch origin"
+        } else {
+            "use refreshed base ref"
+        },
+        if data.would_create_backup_tag {
+            "create backup tag"
+        } else {
+            "skip backup tag"
+        },
+        if data.would_create_temp_worktree {
+            "create temp restack worktree"
+        } else {
+            "skip temp restack worktree"
+        },
+        if data.planned_cherry_pick_operation_count == 0 {
+            "skip cherry-pick replay"
+        } else {
+            "cherry-pick replay plan"
+        },
+        if data.would_reset_current_branch {
+            "reset current branch"
+        } else {
+            "leave current branch tip unchanged"
+        },
+        if data.would_refresh_stack_metadata {
+            "refresh stack metadata"
+        } else {
+            "leave stack metadata untouched"
+        },
+    ]);
+
+    format!(
+        "{title}:\n  current branch: {} @ {}\n  target base: {} @ {} ({})\n  selector: --after {} -> keeps first {} PR group(s)\n  drop from local stack: {}\n  replay onto target base: {}\n  preserve ignored blocks before replay: {}\n  planned cherry-pick operations: {}\n  {execution_label}: {}\n  {not_validated_label}: {}",
+        data.current_branch,
+        data.original_head,
+        data.base_ref,
+        base_sha,
+        base_note,
+        data.after_selector,
+        data.resolved_after_count,
+        render_groups(&data.dropped_groups),
+        render_groups(&data.remaining_groups),
+        data.kept_ignored_segment_count,
+        data.planned_cherry_pick_operation_count,
+        would_do,
+        data.not_validated.join("; ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        preview, render_human_preview, RestackPreviewData, RestackPreviewGroup,
+        RestackPreviewResult,
+    };
+
+    fn sample_preview_data() -> RestackPreviewData {
+        RestackPreviewData {
+            base_ref: "origin/main".to_string(),
+            base_sha: Some("base123".to_string()),
+            base_ref_was_refreshed: false,
+            current_branch: "stack".to_string(),
+            original_head: "head123".to_string(),
+            after_selector: "pr:alpha".to_string(),
+            resolved_after_count: 1,
+            dropped_groups: vec![RestackPreviewGroup {
+                stable_handle: "pr:alpha".to_string(),
+                commit_count: 2,
+                ignored_after_count: 0,
+            }],
+            remaining_groups: vec![RestackPreviewGroup {
+                stable_handle: "pr:beta".to_string(),
+                commit_count: 1,
+                ignored_after_count: 1,
+            }],
+            kept_ignored_segment_count: 0,
+            planned_cherry_pick_operation_count: 2,
+            would_fetch_origin_when_executed: true,
+            would_create_backup_tag: true,
+            would_create_temp_worktree: true,
+            would_reset_current_branch: true,
+            would_refresh_stack_metadata: true,
+            not_validated: vec![
+                "remote freshness".to_string(),
+                "cherry-pick conflicts".to_string(),
+            ],
+        }
+    }
+
+    #[test]
+    fn restack_preview_json_uses_preview_envelope() {
+        let output = preview(sample_preview_data());
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(output.result, RestackPreviewResult::Preview);
+        assert_eq!(json["command"], "restack");
+        assert_eq!(json["result"], "preview");
+        assert_eq!(
+            json["data"]["dropped_groups"][0]["stable_handle"],
+            "pr:alpha"
+        );
+        assert_eq!(
+            json["data"]["remaining_groups"][0]["stable_handle"],
+            "pr:beta"
+        );
+        assert_eq!(json["data"]["would_create_backup_tag"], true);
+    }
+
+    #[test]
+    fn restack_preview_human_renderer_names_plan_and_warnings() {
+        let rendered = render_human_preview("Restack preview", &sample_preview_data());
+
+        assert!(rendered.contains("Restack preview:"));
+        assert!(rendered.contains("target base: origin/main @ base123"));
+        assert!(rendered.contains("drop from local stack: pr:alpha (2 commit(s))"));
+        assert!(
+            rendered.contains("replay onto target base: pr:beta (1 commit(s), 1 ignored after)")
+        );
+        assert!(rendered.contains("planned cherry-pick operations: 2"));
+        assert!(
+            rendered.contains("not validated by preview: remote freshness; cherry-pick conflicts")
+        );
+    }
+
+    #[test]
+    fn restack_execution_human_renderer_uses_already_refreshed_language() {
+        let data = RestackPreviewData {
+            base_ref_was_refreshed: true,
+            would_fetch_origin_when_executed: false,
+            not_validated: vec!["cherry-pick conflicts".to_string(), "tests".to_string()],
+            ..sample_preview_data()
+        };
+
+        let rendered = render_human_preview("Restack plan", &data);
+
+        assert!(rendered.contains("target base: origin/main @ base123 (refreshed before planning)"));
+        assert!(rendered.contains("execution plan: use refreshed base ref"));
+        assert!(rendered.contains("not validated yet: cherry-pick conflicts; tests"));
+        assert!(!rendered.contains("not validated by preview"));
+    }
+}

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -57,6 +57,16 @@ pub enum AfterSelector {
     Group(GroupSelector),
 }
 
+impl Display for AfterSelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bottom => write!(f, "bottom"),
+            Self::Top => write!(f, "top"),
+            Self::Group(selector) => write!(f, "{selector}"),
+        }
+    }
+}
+
 /// A selector for moving either one group or an inclusive range of groups.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupRangeSelector {


### PR DESCRIPTION
# Problem Solved
`spr restack --dry-run` still follows the rewrite-oriented path. Operators had no cheap way to see which groups would be dropped, which groups or ignored blocks would replay, and which local base object would be used before SPR starts temp-worktree/rewrite machinery.

# Mental model
Preview answers "what does SPR intend to do?" Real restack answers "perform that rewrite safely." Preview is read-only and locally scoped; normal human restack now prints the resolved high-level plan after its existing fetch/selection step and before creating rewrite state.

# Non-goals
- Do not rename or weaken the existing global `--dry-run`; it remains a rewrite-path dry run.
- Do not print an extra preview object during normal `spr restack --json`; JSON rewrite commands still emit one lifecycle result.
- Do not fetch in preview mode or claim the preview proves future cherry-picks, tests, pushes, GitHub state, or remote freshness.

# Tradeoffs
Preview intentionally inspects the current local base ref without fetching. That keeps the query fast and read-only. A real restack still performs its existing fetch and may see a fresher base; its human prelude is printed from the plan resolved for that real run.

# Architecture
Extract typed restack planning from execution, add a read-only `--preview` dispatch path, add human and JSON preview renderers, print the human plan before normal restack rewrite work starts, preserve the existing rewrite executor, and keep preview output separate from machine rewrite lifecycle output.

# Observability
`spr restack --preview` prints the resolved after selector, current branch and HEAD, inspected base ref/object, dropped groups, remaining groups, preserved ignored segments, and the planned replay operations. `--preview --json` emits the same plan as one preview object.

# Tests
Validated in the original implementation run with restack-focused tests, parser/planner/output coverage, fixture coverage that preview leaves HEAD/backup/temp/resume state unchanged, `cargo clippy --tests`, `cargo fmt`, focused final-tip restack tests, full `cargo test` with 243 passed, and `git diff --check` on the final change.

<!-- spr-stack:start -->
**Stack**:
-   #129
-   #128
-   #127
-   #126
- ➡ #125

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->