### PR TITLE
cli: make dry-run command-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Global flags
 - `--cd <PATH>`: change to `PATH` before loading repo config or running git/gh commands
 - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
-- `--dry-run` (alias: `--dr`): print state-changing commands instead of executing
 - `--until <N|0|label|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
 - `--exact <I|label|pr:<label>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
@@ -672,6 +671,8 @@ Behavior:
 Dry run behavior
 ----------------
 
+- `--dry-run` (alias: `--dr`) is a command-local option accepted only by commands that can change
+  local or remote state. Read-only commands such as `status`, `list`, and `resolve-stack` reject it.
 - `--dry-run` prints most state-changing `git`/`gh` commands instead of executing
 - For safety, some local operations may still execute in temporary worktrees to better mirror behavior
 - In dry-run, set `--assume-existing-prs` with `spr update` to show `gh pr edit` instead of `gh pr create`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
+use crate::execution::ExecutionMode;
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum Extent {
     /// Update the first N PRs (bottom-up)
@@ -62,6 +64,23 @@ impl OutputArgs {
     }
 }
 
+#[derive(Args, Debug, Clone, Copy, Default)]
+pub struct DryRunArgs {
+    /// Print state-changing commands instead of executing
+    #[arg(long = "dry-run", visible_alias = "dr")]
+    dry_run: bool,
+}
+
+impl From<DryRunArgs> for ExecutionMode {
+    fn from(args: DryRunArgs) -> Self {
+        if args.dry_run {
+            Self::DryRun
+        } else {
+            Self::Apply
+        }
+    }
+}
+
 #[derive(Subcommand, Debug, Clone, Copy)]
 pub enum ListWhat {
     /// List PRs in the stack (halts early if live groups derive case-colliding synthetic branch names)
@@ -104,6 +123,9 @@ pub enum Cmd {
         allow_branch_reuse: bool,
 
         #[command(flatten)]
+        dry_run: DryRunArgs,
+
+        #[command(flatten)]
         output: OutputArgs,
 
         /// Limit how much to update (optional sub-mode)
@@ -129,6 +151,9 @@ pub enum Cmd {
         preview: bool,
 
         #[command(flatten)]
+        dry_run: DryRunArgs,
+
+        #[command(flatten)]
         output: OutputArgs,
     },
 
@@ -140,6 +165,9 @@ pub enum Cmd {
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
+
+        #[command(flatten)]
+        dry_run: DryRunArgs,
 
         #[command(flatten)]
         output: OutputArgs,
@@ -155,12 +183,18 @@ pub enum Cmd {
         allow_replayed_duplicates: bool,
 
         #[command(flatten)]
+        dry_run: DryRunArgs,
+
+        #[command(flatten)]
         output: OutputArgs,
     },
 
     /// Prepare PRs for landing (e.g., squash) and halt early on case-colliding synthetic branch names
     Prep {
         // selection is provided via global --until/--exact flags
+        #[command(flatten)]
+        dry_run: DryRunArgs,
+
         #[command(flatten)]
         output: OutputArgs,
     },
@@ -217,12 +251,16 @@ pub enum Cmd {
         #[arg(long = "no-restack")]
         no_restack: bool,
         #[command(flatten)]
+        dry_run: DryRunArgs,
+        #[command(flatten)]
         output: OutputArgs,
     },
 
     /// Relink PR stack to match local commit stack and halt early on case-colliding synthetic branch names
     RelinkPrs {
-        // dry-run is provided via global --dry-run
+        #[command(flatten)]
+        dry_run: DryRunArgs,
+
         #[command(flatten)]
         output: OutputArgs,
     },
@@ -230,7 +268,9 @@ pub enum Cmd {
     /// Delete remote branches with the configured prefix whose PRs are all closed
     #[command(alias = "clean")]
     Cleanup {
-        // dry-run is provided via global --dry-run
+        #[command(flatten)]
+        dry_run: DryRunArgs,
+
         #[command(flatten)]
         output: OutputArgs,
     },
@@ -247,6 +287,8 @@ pub enum Cmd {
         #[arg(long)]
         safe: bool,
         #[command(flatten)]
+        dry_run: DryRunArgs,
+        #[command(flatten)]
         output: OutputArgs,
     },
 
@@ -261,6 +303,8 @@ pub enum Cmd {
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
         safe: bool,
+        #[command(flatten)]
+        dry_run: DryRunArgs,
         #[command(flatten)]
         output: OutputArgs,
     },
@@ -277,9 +321,9 @@ impl Cmd {
             | Self::Land { output, .. }
             | Self::FixPr { output, .. }
             | Self::Status { output, .. }
-            | Self::Prep { output }
-            | Self::RelinkPrs { output }
-            | Self::Cleanup { output }
+            | Self::Prep { output, .. }
+            | Self::RelinkPrs { output, .. }
+            | Self::Cleanup { output, .. }
             | Self::Move { output, .. } => output.format(),
             Self::List { output, .. } => output.format(),
             Self::Update { output, .. } => output.format(),
@@ -314,9 +358,6 @@ pub struct Cli {
     /// Global branch prefix for per-PR branches
     #[arg(long, global = true)]
     pub prefix: Option<String>,
-    /// Global dry-run flag (applies to all subcommands)
-    #[arg(long, global = true, visible_alias = "dr")]
-    pub dry_run: bool,
     /// Global until (used by prep/land). Accepts 0, a local PR number, or a stable handle
     #[arg(long, global = true, value_name = "N|0|label|pr:<label>")]
     pub until: Option<crate::selectors::InclusiveSelector>,
@@ -330,6 +371,7 @@ pub struct Cli {
 #[cfg(test)]
 mod tests {
     use super::{Cli, Cmd, OutputFormat};
+    use crate::execution::ExecutionMode;
     use clap::{CommandFactory, Parser};
     use std::path::PathBuf;
 
@@ -340,7 +382,7 @@ mod tests {
         match cli.cmd {
             Cmd::Absorb {
                 allow_replayed_duplicates,
-                output: _,
+                ..
             } => assert!(allow_replayed_duplicates),
             other => panic!("unexpected command: {:?}", other),
         }
@@ -440,15 +482,55 @@ mod tests {
                 after,
                 safe,
                 preview,
+                dry_run,
                 output,
             } => {
                 assert_eq!(after.to_string(), "pr:alpha");
                 assert!(safe);
                 assert!(preview);
+                assert_eq!(ExecutionMode::from(dry_run), ExecutionMode::Apply);
                 assert_eq!(output.format(), OutputFormat::Json);
             }
             other => panic!("unexpected command: {:?}", other),
         }
+    }
+
+    #[test]
+    fn update_dry_run_flag_parses_after_command() {
+        let cli = Cli::try_parse_from(["spr", "update", "--dry-run"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Update { dry_run, .. } => {
+                assert_eq!(ExecutionMode::from(dry_run), ExecutionMode::DryRun);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_dry_run_alias_parses_after_command() {
+        let cli = Cli::try_parse_from(["spr", "update", "--dr"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Update { dry_run, .. } => {
+                assert_eq!(ExecutionMode::from(dry_run), ExecutionMode::DryRun);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn status_dry_run_flag_is_rejected() {
+        let err = Cli::try_parse_from(["spr", "status", "--dry-run"]).unwrap_err();
+
+        assert!(err.to_string().contains("--dry-run"));
+    }
+
+    #[test]
+    fn global_dry_run_flag_before_command_is_rejected() {
+        let err = Cli::try_parse_from(["spr", "--dry-run", "update"]).unwrap_err();
+
+        assert!(err.to_string().contains("--dry-run"));
     }
 
     #[test]
@@ -532,6 +614,26 @@ mod tests {
         assert!(update
             .get_arguments()
             .any(|argument| argument.get_long() == Some("json")));
+    }
+
+    #[test]
+    fn update_help_includes_dry_run_flag() {
+        let mut cli = Cli::command();
+        let update = cli.find_subcommand_mut("update").unwrap();
+
+        assert!(update
+            .get_arguments()
+            .any(|argument| argument.get_long() == Some("dry-run")));
+    }
+
+    #[test]
+    fn status_help_does_not_include_dry_run_flag() {
+        let mut cli = Cli::command();
+        let status = cli.find_subcommand_mut("status").unwrap();
+
+        assert!(!status
+            .get_arguments()
+            .any(|argument| argument.get_long() == Some("dry-run")));
     }
 
     #[test]

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -20,6 +20,7 @@ use crate::commands::rewrite_resume::{
     self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
 };
 use crate::config::DirtyWorktreePolicy;
+use crate::execution::ExecutionMode;
 use crate::git::{
     git_commit_message, git_commit_parent_count, git_commit_tree, git_is_ancestor,
     git_local_branch_tip, git_merge_base, git_patch_ids_for_commits, git_rev_list_range,
@@ -46,7 +47,7 @@ pub fn absorb_branch_tails(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-    dry: bool,
+    execution_mode: ExecutionMode,
     dirty_worktree_policy: DirtyWorktreePolicy,
     options: AbsorbOptions,
 ) -> Result<RewriteCommandOutcome> {
@@ -68,9 +69,14 @@ pub fn absorb_branch_tails(
             info!("No absorbable branch tails found; nothing to rewrite.");
             Ok(RewriteCommandOutcome::Completed)
         }
-        AbsorbPlanValidation::ReadyToRewrite => {
-            execute_absorb_plan(base, prefix, ignore_tag, &plan, dry, dirty_worktree_policy)
-        }
+        AbsorbPlanValidation::ReadyToRewrite => execute_absorb_plan(
+            base,
+            prefix,
+            ignore_tag,
+            &plan,
+            execution_mode,
+            dirty_worktree_policy,
+        ),
     }
 }
 
@@ -941,16 +947,16 @@ fn execute_absorb_plan(
     prefix: &str,
     ignore_tag: &str,
     plan: &RewritePlan,
-    dry: bool,
+    execution_mode: ExecutionMode,
     dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<RewriteCommandOutcome> {
     emit_rewrite_plan(plan);
     common::with_dirty_worktree_policy(
-        dry,
+        execution_mode,
         "spr absorb",
         dirty_worktree_policy,
         |deferred_dirty_worktree_restore| {
-            if dry {
+            if execution_mode == ExecutionMode::DryRun {
                 info!("Dry run complete. No local git state or GitHub state was changed.");
                 info!("Run `spr absorb` without `--dry-run` to apply the rewrite.");
                 info!("After inspecting the rewritten stack, run `spr update`.");
@@ -960,41 +966,44 @@ fn execute_absorb_plan(
                 let original_head = git_rev_parse("HEAD")?;
                 let original_worktree_root = rewrite_resume::current_repo_root()?;
                 let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
-                    dry,
+                    execution_mode,
                     RewriteCommandKind::Absorb,
                     &cur_branch,
                     &original_head,
                 )?;
-                let backup_tag = common::create_backup_tag(dry, "absorb", &cur_branch, &short)?;
-                let (tmp_path, tmp_branch) =
-                    common::create_temp_worktree(dry, "absorb", &plan.merge_base, &short)?;
+                let backup_tag =
+                    common::create_backup_tag(execution_mode, "absorb", &cur_branch, &short)?;
+                let (tmp_path, tmp_branch) = common::create_temp_worktree(
+                    execution_mode,
+                    "absorb",
+                    &plan.merge_base,
+                    &short,
+                )?;
                 rewrite_resume::run_rewrite_session(
-                dry,
-                RewriteSession {
-                    command_kind: RewriteCommandKind::Absorb,
-                    conflict_policy: RewriteConflictPolicy::Suspend,
-                    original_worktree_root,
-                    original_branch: cur_branch,
-                    original_head,
-                    resume_path,
-                    temp_branch: tmp_branch,
-                    temp_worktree_path: tmp_path,
-                    backup_tag: Some(backup_tag),
-                    operations: plan.operations.clone(),
-                    deferred_dirty_worktree_restore,
-                    post_success_hint: Some(
-                        "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
-                            .to_string(),
-                    ),
-                    metadata_refresh_context: Some(
-                        crate::stack_metadata::RefreshMetadataContext {
+                    execution_mode,
+                    RewriteSession {
+                        command_kind: RewriteCommandKind::Absorb,
+                        conflict_policy: RewriteConflictPolicy::Suspend,
+                        original_worktree_root,
+                        original_branch: cur_branch,
+                        original_head,
+                        resume_path,
+                        temp_branch: tmp_branch,
+                        temp_worktree_path: tmp_path,
+                        backup_tag: Some(backup_tag),
+                        operations: plan.operations.clone(),
+                        deferred_dirty_worktree_restore,
+                        post_success_hint: Some(
+                            "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+                                .to_string(),
+                        ),
+                        metadata_refresh_context: Some(crate::stack_metadata::RefreshMetadataContext {
                             base: base.to_string(),
                             prefix: prefix.to_string(),
                             ignore_tag: ignore_tag.to_string(),
-                        },
-                    ),
-                },
-            )
+                        }),
+                    },
+                )
             }
         },
     )
@@ -1079,6 +1088,7 @@ mod tests {
     use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
     use crate::commands::RewriteCommandOutcome;
     use crate::config::DirtyWorktreePolicy;
+    use crate::execution::ExecutionMode;
     use crate::parsing::{derive_local_groups_with_ignored, Group};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
     use std::env;
@@ -1185,7 +1195,7 @@ mod tests {
             "main",
             "dank-spr/",
             "ignore",
-            true,
+            ExecutionMode::DryRun,
             DirtyWorktreePolicy::Halt,
             AbsorbOptions::default(),
         )
@@ -1964,7 +1974,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -1996,7 +2006,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -2034,7 +2044,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -2074,7 +2084,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 absorb_override_options(),
             )
@@ -2170,7 +2180,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -2272,7 +2282,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -2309,7 +2319,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -2344,7 +2354,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                true,
+                ExecutionMode::DryRun,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
             )
@@ -2386,7 +2396,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
-                false,
+                ExecutionMode::Apply,
                 DirtyWorktreePolicy::Halt,
                 default_absorb_options(),
             )
@@ -2411,7 +2421,7 @@ mod tests {
 
         {
             let _guard = DirGuard::change_to(&repo.repo);
-            let resumed = resume_rewrite(false, &resume_path).expect("resume absorb");
+            let resumed = resume_rewrite(&resume_path).expect("resume absorb");
             assert_eq!(resumed, RewriteCommandOutcome::Completed);
         }
 

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use tracing::info;
 
+use crate::execution::ExecutionMode;
 use crate::git::{git_rw, list_remote_branches_with_prefix};
 use crate::github::list_open_pr_heads;
 use crate::maintenance_output::{
@@ -33,7 +34,11 @@ pub fn print_cleanup_summary(summary: &CleanupSummaryData) {
 }
 
 /// Delete remote branches that start with the configured prefix and have only closed PRs (or no PRs)
-pub fn cleanup_remote_branches(prefix: &str, dry: bool) -> Result<CleanupSummaryData> {
+pub fn cleanup_remote_branches(
+    prefix: &str,
+    execution_mode: ExecutionMode,
+) -> Result<CleanupSummaryData> {
+    let dry_run = execution_mode == ExecutionMode::DryRun;
     let mut branches = list_remote_branches_with_prefix(prefix)?;
     branches.sort();
     if branches.is_empty() {
@@ -41,7 +46,7 @@ pub fn cleanup_remote_branches(prefix: &str, dry: bool) -> Result<CleanupSummary
             repo: CleanupRepoContext {
                 prefix: prefix.to_string(),
             },
-            options: MaintenanceOptions { dry_run: dry },
+            options: MaintenanceOptions { dry_run },
             remote_candidates: branches,
             open_pr_heads: Vec::new(),
             decisions: Vec::new(),
@@ -57,7 +62,7 @@ pub fn cleanup_remote_branches(prefix: &str, dry: bool) -> Result<CleanupSummary
             branch: branch.clone(),
             action: if open_heads.contains(branch) {
                 CleanupAction::SkipOpenPr
-            } else if dry {
+            } else if dry_run {
                 CleanupAction::DryRunDelete
             } else {
                 CleanupAction::Delete
@@ -79,14 +84,14 @@ pub fn cleanup_remote_branches(prefix: &str, dry: bool) -> Result<CleanupSummary
         let mut owned_args: Vec<String> = vec!["push".into(), "origin".into(), "--delete".into()];
         owned_args.extend(delete_batch.iter().cloned());
         let args: Vec<&str> = owned_args.iter().map(String::as_str).collect();
-        let _ = git_rw(dry, &args)?;
+        let _ = git_rw(execution_mode, &args)?;
     }
 
     Ok(CleanupSummaryData {
         repo: CleanupRepoContext {
             prefix: prefix.to_string(),
         },
-        options: MaintenanceOptions { dry_run: dry },
+        options: MaintenanceOptions { dry_run },
         remote_candidates: branches,
         open_pr_heads: open_heads,
         decisions,
@@ -97,6 +102,7 @@ pub fn cleanup_remote_branches(prefix: &str, dry: bool) -> Result<CleanupSummary
 #[cfg(test)]
 mod tests {
     use super::cleanup_remote_branches;
+    use crate::execution::ExecutionMode;
     use crate::maintenance_output::CleanupAction;
     use crate::test_support::{commit_file, git, lock_cwd, write_file, DirGuard};
     use std::env;
@@ -201,7 +207,7 @@ mod tests {
         );
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
 
-        let summary = cleanup_remote_branches("skilltest/", true).unwrap();
+        let summary = cleanup_remote_branches("skilltest/", ExecutionMode::DryRun).unwrap();
 
         assert_eq!(
             summary.remote_candidates,
@@ -229,7 +235,7 @@ mod tests {
         );
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
 
-        let summary = cleanup_remote_branches("missing/", true).unwrap();
+        let summary = cleanup_remote_branches("missing/", ExecutionMode::DryRun).unwrap();
 
         assert!(summary.remote_candidates.is_empty());
         assert!(summary.open_pr_heads.is_empty());

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -34,6 +34,7 @@ use std::path::Path;
 use tracing::{info, warn};
 
 use crate::config::DirtyWorktreePolicy;
+use crate::execution::ExecutionMode;
 use crate::git::{git_ro, git_rw, normalize_branch_name, repo_root};
 use crate::parsing::Group;
 
@@ -63,7 +64,12 @@ pub fn get_current_branch_and_short() -> Result<(String, String)> {
 ///
 /// The existence check is only used to drive the log message; the tag is
 /// always updated to point at `HEAD`.
-pub fn create_backup_tag(dry: bool, kind: &str, cur_branch: &str, short: &str) -> Result<String> {
+pub fn create_backup_tag(
+    execution_mode: ExecutionMode,
+    kind: &str,
+    cur_branch: &str,
+    short: &str,
+) -> Result<String> {
     let backup = format!("backup/{}/{}-{}", kind, cur_branch, short);
     let exists = git_ro(["tag", "--list", &backup].as_slice())?;
     if exists.trim().is_empty() {
@@ -73,7 +79,7 @@ pub fn create_backup_tag(dry: bool, kind: &str, cur_branch: &str, short: &str) -
     }
     // Use `-f` to make backup creation idempotent. When the name already
     // exists, we explicitly move it to the current HEAD.
-    let _ = git_rw(dry, ["tag", "-f", &backup, "HEAD"].as_slice())?;
+    let _ = git_rw(execution_mode, ["tag", "-f", &backup, "HEAD"].as_slice())?;
     Ok(backup)
 }
 
@@ -86,20 +92,20 @@ pub fn create_backup_tag(dry: bool, kind: &str, cur_branch: &str, short: &str) -
 /// create) rather than `-b` to avoid "branch already exists" failures when a
 /// dry-run skipped the cleanup steps.
 pub fn create_temp_worktree(
-    dry: bool,
+    execution_mode: ExecutionMode,
     kind: &str,
     merge_base: &str,
     short: &str,
 ) -> Result<(String, String)> {
     let tmp_branch = format!("spr/tmp-{}-{}", kind, short);
     let tmp_path = format!("/tmp/spr-{}-{}", kind, short);
-    cleanup_existing_temp_state(dry, &tmp_path, &tmp_branch)?;
+    cleanup_existing_temp_state(execution_mode, &tmp_path, &tmp_branch)?;
     info!(
         "Creating temp worktree {} on branch {}…",
         tmp_path, tmp_branch
     );
     let _ = git_rw(
-        dry,
+        execution_mode,
         [
             "worktree",
             "add",
@@ -133,27 +139,34 @@ pub enum NativeRebaseOutcome {
 /// rebase error is returned with context that tells the user where to repair the
 /// repository.
 pub fn run_native_rebase_with_abort(
-    dry: bool,
+    execution_mode: ExecutionMode,
     args: &[&str],
     command_label: &str,
 ) -> Result<NativeRebaseOutcome> {
-    if dry {
-        let _ = git_rw(true, args)?;
-        Ok(NativeRebaseOutcome::Completed)
-    } else if let Err(rebase_err) = git_rw(false, args) {
-        if let Err(abort_err) = git_rw(false, ["rebase", "--abort"].as_slice()) {
-            let repo = repo_root()?.unwrap_or_else(|| ".".to_string());
-            Err(rebase_err).with_context(|| {
-                format!(
-                    "{command_label} rebase failed, and `git rebase --abort` also failed: {abort_err:#}. Inspect {} and run `git rebase --abort` there before retrying.",
-                    repo
-                )
-            })
-        } else {
-            Ok(NativeRebaseOutcome::Aborted)
+    match execution_mode {
+        ExecutionMode::DryRun => {
+            let _ = git_rw(ExecutionMode::DryRun, args)?;
+            Ok(NativeRebaseOutcome::Completed)
         }
-    } else {
-        Ok(NativeRebaseOutcome::Completed)
+        ExecutionMode::Apply => {
+            if let Err(rebase_err) = git_rw(ExecutionMode::Apply, args) {
+                if let Err(abort_err) =
+                    git_rw(ExecutionMode::Apply, ["rebase", "--abort"].as_slice())
+                {
+                    let repo = repo_root()?.unwrap_or_else(|| ".".to_string());
+                    Err(rebase_err).with_context(|| {
+                        format!(
+                            "{command_label} rebase failed, and `git rebase --abort` also failed: {abort_err:#}. Inspect {} and run `git rebase --abort` there before retrying.",
+                            repo
+                        )
+                    })
+                } else {
+                    Ok(NativeRebaseOutcome::Aborted)
+                }
+            } else {
+                Ok(NativeRebaseOutcome::Completed)
+            }
+        }
     }
 }
 
@@ -218,7 +231,11 @@ fn branch_exists(branch: &str) -> Result<bool> {
 /// temp branch checked out must be removed before the branch can be deleted.
 /// We also remove a matching temp path that is not registered as a worktree,
 /// which can happen after interrupted runs.
-fn cleanup_existing_temp_state(dry: bool, tmp_path: &str, tmp_branch: &str) -> Result<()> {
+fn cleanup_existing_temp_state(
+    execution_mode: ExecutionMode,
+    tmp_path: &str,
+    tmp_branch: &str,
+) -> Result<()> {
     let entries = list_worktrees()?;
     let mut removed_paths: HashSet<String> = HashSet::new();
 
@@ -233,7 +250,7 @@ fn cleanup_existing_temp_state(dry: bool, tmp_path: &str, tmp_branch: &str) -> R
             entry.path, tmp_branch
         );
         let _ = git_rw(
-            dry,
+            execution_mode,
             ["worktree", "remove", "-f", entry.path.as_str()].as_slice(),
         )?;
         removed_paths.insert(entry.path.clone());
@@ -243,13 +260,16 @@ fn cleanup_existing_temp_state(dry: bool, tmp_path: &str, tmp_branch: &str) -> R
     // branch name is missing (e.g., detached HEAD).
     if entries.iter().any(|e| e.path == tmp_path) && !removed_paths.contains(tmp_path) {
         info!("Removing existing temp worktree at {}…", tmp_path);
-        let _ = git_rw(dry, ["worktree", "remove", "-f", tmp_path].as_slice())?;
+        let _ = git_rw(
+            execution_mode,
+            ["worktree", "remove", "-f", tmp_path].as_slice(),
+        )?;
     } else if Path::new(tmp_path).exists() {
         info!(
             "Temp path {} exists but is not registered as a worktree; removing it…",
             tmp_path
         );
-        if !dry {
+        if execution_mode == ExecutionMode::Apply {
             fs::remove_dir_all(tmp_path)
                 .with_context(|| format!("failed to remove existing temp path {}", tmp_path))?;
         }
@@ -257,7 +277,7 @@ fn cleanup_existing_temp_state(dry: bool, tmp_path: &str, tmp_branch: &str) -> R
 
     if branch_exists(tmp_branch)? {
         info!("Deleting existing temp branch {}…", tmp_branch);
-        let _ = git_rw(dry, ["branch", "-D", tmp_branch].as_slice())?;
+        let _ = git_rw(execution_mode, ["branch", "-D", tmp_branch].as_slice())?;
     }
 
     Ok(())
@@ -277,18 +297,18 @@ fn cherry_pick_args<'a>(
 }
 
 pub fn cherry_pick_commit(
-    dry: bool,
+    execution_mode: ExecutionMode,
     tmp_path: &str,
     sha: &str,
     empty_policy: CherryPickEmptyPolicy,
 ) -> Result<()> {
     let args = cherry_pick_args(tmp_path, empty_policy, &[sha]);
-    let _ = git_rw(dry, args.as_slice())?;
+    let _ = git_rw(execution_mode, args.as_slice())?;
     Ok(())
 }
 
 pub fn cherry_pick_range(
-    dry: bool,
+    execution_mode: ExecutionMode,
     tmp_path: &str,
     first: &str,
     last: &str,
@@ -296,7 +316,7 @@ pub fn cherry_pick_range(
 ) -> Result<()> {
     let range = format!("{first}^..{last}");
     let args = cherry_pick_args(tmp_path, empty_policy, &[range.as_str()]);
-    let _ = git_rw(dry, args.as_slice())?;
+    let _ = git_rw(execution_mode, args.as_slice())?;
     Ok(())
 }
 
@@ -306,14 +326,21 @@ pub fn tip_of_tmp(tmp_path: &str) -> Result<String> {
         .to_string())
 }
 
-pub fn reset_current_branch_to(dry: bool, new_tip: &str) -> Result<()> {
-    let _ = git_rw(dry, ["reset", "--hard", new_tip].as_slice())?;
+pub fn reset_current_branch_to(execution_mode: ExecutionMode, new_tip: &str) -> Result<()> {
+    let _ = git_rw(execution_mode, ["reset", "--hard", new_tip].as_slice())?;
     Ok(())
 }
 
-pub fn cleanup_temp_worktree(dry: bool, tmp_path: &str, tmp_branch: &str) -> Result<()> {
-    let _ = git_rw(dry, ["worktree", "remove", "-f", tmp_path].as_slice())?;
-    let _ = git_rw(dry, ["branch", "-D", tmp_branch].as_slice())?;
+pub fn cleanup_temp_worktree(
+    execution_mode: ExecutionMode,
+    tmp_path: &str,
+    tmp_branch: &str,
+) -> Result<()> {
+    let _ = git_rw(
+        execution_mode,
+        ["worktree", "remove", "-f", tmp_path].as_slice(),
+    )?;
+    let _ = git_rw(execution_mode, ["branch", "-D", tmp_branch].as_slice())?;
     Ok(())
 }
 
@@ -330,14 +357,14 @@ pub enum DeferredDirtyWorktreeRestore {
 impl DeferredDirtyWorktreeRestore {
     pub fn restore_after_success(
         self,
-        dry: bool,
+        execution_mode: ExecutionMode,
         command_name: &str,
         worktree_root: &str,
     ) -> Result<()> {
         match self {
             Self::Noop => Ok(()),
             Self::Stash { stash_commit } => restore_stash_in_worktree(
-                dry,
+                execution_mode,
                 command_name,
                 worktree_root,
                 &stash_commit,
@@ -407,7 +434,7 @@ fn status_line_has_conflict(line: &str) -> bool {
 }
 
 fn prepare_dirty_worktree(
-    dry: bool,
+    execution_mode: ExecutionMode,
     command_name: &str,
     policy: DirtyWorktreePolicy,
 ) -> Result<DirtyWorktreeRestore> {
@@ -435,7 +462,7 @@ fn prepare_dirty_worktree(
             command_name,
             status_lines.join("\n")
         );
-    } else if dry {
+    } else if execution_mode == ExecutionMode::DryRun {
         info!(
             "DRY-RUN: would stash local changes before {} because dirty_worktree=stash",
             command_name
@@ -444,7 +471,7 @@ fn prepare_dirty_worktree(
     } else {
         let message = format!("spr auto-stash before {}", command_name);
         let _ = git_rw(
-            false,
+            ExecutionMode::Apply,
             [
                 "stash",
                 "push",
@@ -484,11 +511,16 @@ impl DirtyWorktreeRestore {
         }
     }
 
-    fn restore(self, dry: bool, command_name: &str, outcome: RewriteOutcome) -> Result<()> {
+    fn restore(
+        self,
+        execution_mode: ExecutionMode,
+        command_name: &str,
+        outcome: RewriteOutcome,
+    ) -> Result<()> {
         match self {
             Self::Noop => Ok(()),
             Self::PlannedStash => {
-                if dry {
+                if execution_mode == ExecutionMode::DryRun {
                     info!(
                         "DRY-RUN: would restore stashed local changes after {}",
                         command_name
@@ -497,21 +529,21 @@ impl DirtyWorktreeRestore {
                 Ok(())
             }
             Self::Stashed { stash_commit } => {
-                restore_stash_in_worktree(dry, command_name, ".", &stash_commit, outcome)
+                restore_stash_in_worktree(execution_mode, command_name, ".", &stash_commit, outcome)
             }
         }
     }
 }
 
 fn restore_stash_in_worktree(
-    dry: bool,
+    execution_mode: ExecutionMode,
     command_name: &str,
     worktree_root: &str,
     stash_commit: &str,
     outcome: RewriteOutcome,
 ) -> Result<()> {
     let _ = git_rw(
-        false,
+        ExecutionMode::Apply,
         [
             "-C",
             worktree_root,
@@ -533,7 +565,7 @@ fn restore_stash_in_worktree(
     match stash_ref_for_commit_in_worktree(worktree_root, stash_commit)? {
         Some(stash_ref) => {
             if let Err(err) = git_rw(
-                false,
+                ExecutionMode::Apply,
                 ["-C", worktree_root, "stash", "drop", &stash_ref].as_slice(),
             ) {
                 warn!(
@@ -549,7 +581,7 @@ fn restore_stash_in_worktree(
             );
         }
     }
-    if dry {
+    if execution_mode == ExecutionMode::DryRun {
         info!(
             "DRY-RUN: restored stashed local changes after {}",
             command_name
@@ -580,7 +612,7 @@ fn stash_ref_for_commit_in_worktree(
 /// This is the single source of truth for commands that rebuild the
 /// checked-out branch and then replace it with a rewritten tip.
 pub fn with_dirty_worktree_policy<T, F>(
-    dry: bool,
+    execution_mode: ExecutionMode,
     command_name: &str,
     policy: DirtyWorktreePolicy,
     rewrite: F,
@@ -589,7 +621,7 @@ where
     T: DirtyWorktreeOutcome,
     F: FnOnce(DeferredDirtyWorktreeRestore) -> Result<T>,
 {
-    let restore = prepare_dirty_worktree(dry, command_name, policy)?;
+    let restore = prepare_dirty_worktree(execution_mode, command_name, policy)?;
     let deferred_restore = restore.deferred_restore();
     let rewrite_result = rewrite(deferred_restore);
     let restore_result = if rewrite_result
@@ -603,7 +635,7 @@ where
         } else {
             RewriteOutcome::Failed
         };
-        restore.restore(dry, command_name, outcome)
+        restore.restore(execution_mode, command_name, outcome)
     };
 
     match (rewrite_result, restore_result) {
@@ -708,6 +740,7 @@ mod tests {
         cleanup_temp_worktree, create_backup_tag, create_temp_worktree,
         get_current_branch_and_short,
     };
+    use crate::execution::ExecutionMode;
     use crate::test_support::{lock_cwd, DirGuard};
     use std::fs;
     use std::path::Path;
@@ -752,10 +785,10 @@ mod tests {
         let (cur_branch, short) =
             get_current_branch_and_short().expect("get current branch and short sha");
 
-        let backup =
-            create_backup_tag(false, "restack", &cur_branch, &short).expect("create backup");
-        let backup_again =
-            create_backup_tag(false, "restack", &cur_branch, &short).expect("overwrite backup");
+        let backup = create_backup_tag(ExecutionMode::Apply, "restack", &cur_branch, &short)
+            .expect("create backup");
+        let backup_again = create_backup_tag(ExecutionMode::Apply, "restack", &cur_branch, &short)
+            .expect("overwrite backup");
 
         assert_eq!(backup, backup_again, "backup name should be stable");
 
@@ -782,8 +815,9 @@ mod tests {
         let merge_base = git(&repo, ["rev-parse", "HEAD"].as_slice());
         let merge_base = merge_base.trim().to_string();
 
-        let (tmp_path, tmp_branch) = create_temp_worktree(false, "restack", &merge_base, &short)
-            .expect("create initial temp worktree");
+        let (tmp_path, tmp_branch) =
+            create_temp_worktree(ExecutionMode::Apply, "restack", &merge_base, &short)
+                .expect("create initial temp worktree");
 
         // Simulate a failed prior run that removed the worktree but left the
         // temp branch behind.
@@ -799,7 +833,7 @@ mod tests {
         );
 
         let (tmp_path_2, tmp_branch_2) =
-            create_temp_worktree(false, "restack", &merge_base, &short)
+            create_temp_worktree(ExecutionMode::Apply, "restack", &merge_base, &short)
                 .expect("recreate temp worktree after cleanup");
         assert_eq!(tmp_path, tmp_path_2, "temp path should be stable");
         assert_eq!(tmp_branch, tmp_branch_2, "temp branch should be stable");
@@ -808,7 +842,7 @@ mod tests {
             "temp worktree path should exist"
         );
 
-        cleanup_temp_worktree(false, &tmp_path_2, &tmp_branch_2)
+        cleanup_temp_worktree(ExecutionMode::Apply, &tmp_path_2, &tmp_branch_2)
             .expect("cleanup recreated temp worktree");
     }
 }

--- a/src/commands/drop_merged_prefix.rs
+++ b/src/commands/drop_merged_prefix.rs
@@ -14,6 +14,7 @@ use crate::commands::common::{self, DirtyWorktreeOutcome, NativeRebaseOutcome};
 use crate::commands::restack_after_count;
 use crate::commands::rewrite_resume::RewriteCommandOutcome;
 use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+use crate::execution::ExecutionMode;
 use crate::git::{git_is_ancestor, git_rw};
 use crate::github::{
     fetch_merged_pr_merge_commit_oids, list_open_or_merged_prs_for_heads, PrInfoWithState, PrState,
@@ -157,14 +158,14 @@ fn verify_merge_commits_are_in_base(plan: &DropMergedPrefixPlan, base: &str) -> 
     Ok(())
 }
 
-fn log_drop_plan(plan: &DropMergedPrefixPlan, dry: bool, base: &str) {
+fn log_drop_plan(plan: &DropMergedPrefixPlan, execution_mode: ExecutionMode, base: &str) {
     let handles = plan
         .dropped
         .iter()
         .map(|candidate| format!("pr:{} (#{})", candidate.tag, candidate.pr_number))
         .collect::<Vec<_>>()
         .join(", ");
-    let mode = if dry {
+    let mode = if execution_mode == ExecutionMode::DryRun {
         "DRY-RUN: would drop"
     } else {
         "Dropping"
@@ -176,13 +177,17 @@ fn log_drop_plan(plan: &DropMergedPrefixPlan, dry: bool, base: &str) {
 }
 
 fn run_native_rebase(
-    dry: bool,
+    execution_mode: ExecutionMode,
     base: &str,
     boundary_commit: &str,
     cur_branch: &str,
 ) -> Result<FastLocalRewriteOutcome> {
     let args = ["rebase", "--onto", base, boundary_commit, cur_branch];
-    match common::run_native_rebase_with_abort(dry, args.as_slice(), "native drop-merged-prefix")? {
+    match common::run_native_rebase_with_abort(
+        execution_mode,
+        args.as_slice(),
+        "native drop-merged-prefix",
+    )? {
         NativeRebaseOutcome::Completed => Ok(FastLocalRewriteOutcome::Completed),
         NativeRebaseOutcome::Aborted => {
             warn!(
@@ -197,25 +202,30 @@ fn execute_fast_local_rewrite(
     metadata_context: &RefreshMetadataContext,
     plan: &DropMergedPrefixPlan,
     safe: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<FastLocalRewriteOutcome> {
     common::with_dirty_worktree_policy(
-        dry,
+        execution_mode,
         "spr drop-merged-prefix",
         dirty_worktree_policy,
         |_deferred_dirty_worktree_restore| {
             let (cur_branch, short) = common::get_current_branch_and_short()?;
             if safe {
-                let _ = common::create_backup_tag(dry, "drop-merged-prefix", &cur_branch, &short)?;
+                let _ = common::create_backup_tag(
+                    execution_mode,
+                    "drop-merged-prefix",
+                    &cur_branch,
+                    &short,
+                )?;
             }
             let outcome = match plan.strategy {
                 DropMergedRewriteStrategy::FastResetAll => {
-                    common::reset_current_branch_to(dry, &metadata_context.base)?;
+                    common::reset_current_branch_to(execution_mode, &metadata_context.base)?;
                     FastLocalRewriteOutcome::Completed
                 }
                 DropMergedRewriteStrategy::FastRebase => run_native_rebase(
-                    dry,
+                    execution_mode,
                     &metadata_context.base,
                     &plan.boundary_commit,
                     &cur_branch,
@@ -224,7 +234,9 @@ fn execute_fast_local_rewrite(
                     unreachable!("restack fallback is executed outside the fast-rewrite path")
                 }
             };
-            if outcome == FastLocalRewriteOutcome::Completed && !dry {
+            if outcome == FastLocalRewriteOutcome::Completed
+                && execution_mode == ExecutionMode::Apply
+            {
                 crate::stack_metadata::refresh_metadata_for_current_checkout(
                     &metadata_context.base,
                     &metadata_context.prefix,
@@ -239,11 +251,11 @@ fn execute_fast_local_rewrite(
 pub fn drop_merged_prefix(
     metadata_context: &RefreshMetadataContext,
     safe: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     restack_conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<RewriteCommandOutcome> {
-    git_rw(dry, ["fetch", "origin"].as_slice())?;
+    git_rw(execution_mode, ["fetch", "origin"].as_slice())?;
 
     let (_merge_base, leading_ignored, groups) =
         derive_local_groups_with_ignored(&metadata_context.base, &metadata_context.ignore_tag)?;
@@ -271,19 +283,25 @@ pub fn drop_merged_prefix(
         &merge_commit_oids_by_pr_number,
     )?;
     verify_merge_commits_are_in_base(&plan, &metadata_context.base)?;
-    log_drop_plan(&plan, dry, &metadata_context.base);
+    log_drop_plan(&plan, execution_mode, &metadata_context.base);
 
     let fast_outcome = if plan.strategy == DropMergedRewriteStrategy::RestackFallback {
         FastLocalRewriteOutcome::FallbackRequired
     } else {
-        execute_fast_local_rewrite(metadata_context, &plan, safe, dry, dirty_worktree_policy)?
+        execute_fast_local_rewrite(
+            metadata_context,
+            &plan,
+            safe,
+            execution_mode,
+            dirty_worktree_policy,
+        )?
     };
     if fast_outcome == FastLocalRewriteOutcome::FallbackRequired {
         restack_after_count(
             metadata_context,
             plan.dropped.len(),
             safe,
-            dry,
+            execution_mode,
             restack_conflict_policy,
             dirty_worktree_policy,
         )
@@ -304,6 +322,7 @@ mod tests {
     };
     use crate::commands::RewriteCommandOutcome;
     use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+    use crate::execution::ExecutionMode;
     use crate::github::{PrInfoWithState, PrState};
     use crate::parsing::Group;
     use crate::stack_metadata::RefreshMetadataContext;
@@ -601,7 +620,7 @@ mod tests {
                 ignore_tag: "ignore".to_string(),
             },
             true,
-            false,
+            ExecutionMode::Apply,
             RestackConflictPolicy::Halt,
             DirtyWorktreePolicy::Halt,
         )

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -10,6 +10,7 @@ use crate::commands::rewrite_resume::{
     self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
 };
 use crate::config::DirtyWorktreePolicy;
+use crate::execution::ExecutionMode;
 use crate::git::git_rev_parse;
 use crate::git::git_ro;
 use crate::parsing::derive_local_groups_with_ignored;
@@ -51,7 +52,7 @@ pub fn fix_pr_tail(
     target: &GroupSelector,
     tail_count: usize,
     safe: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<RewriteCommandOutcome> {
     if tail_count == 0 {
@@ -146,7 +147,7 @@ pub fn fix_pr_tail(
         .ok_or_else(|| anyhow!("Could not locate last commit of PR {} in stream", target_n))?;
 
     common::with_dirty_worktree_policy(
-        dry,
+        execution_mode,
         "spr fix-pr",
         dirty_worktree_policy,
         |deferred_dirty_worktree_restore| {
@@ -154,14 +155,14 @@ pub fn fix_pr_tail(
             let original_head = git_rev_parse("HEAD")?;
             let original_worktree_root = rewrite_resume::current_repo_root()?;
             let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
-                dry,
+                execution_mode,
                 RewriteCommandKind::FixPr,
                 &cur_branch,
                 &original_head,
             )?;
             let backup_tag = if safe {
                 Some(common::create_backup_tag(
-                    dry,
+                    execution_mode,
                     "fix-pr",
                     &cur_branch,
                     &short,
@@ -171,29 +172,29 @@ pub fn fix_pr_tail(
             };
 
             let (tmp_path, tmp_branch) =
-                common::create_temp_worktree(dry, "fix", &merge_base, &short)?;
+                common::create_temp_worktree(execution_mode, "fix", &merge_base, &short)?;
             let operations = build_fix_pr_operations(&all_commits, &top_commits, insert_pos);
             rewrite_resume::run_rewrite_session(
-            dry,
-            RewriteSession {
-                command_kind: RewriteCommandKind::FixPr,
-                conflict_policy: RewriteConflictPolicy::Suspend,
-                original_worktree_root,
-                original_branch: cur_branch,
-                original_head,
-                resume_path,
-                temp_branch: tmp_branch,
-                temp_worktree_path: tmp_path,
-                backup_tag,
-                operations,
-                deferred_dirty_worktree_restore,
-                post_success_hint: Some(
-                    "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
-                        .to_string(),
-                ),
-                metadata_refresh_context: Some(metadata_context.clone()),
-            },
-        )
+                execution_mode,
+                RewriteSession {
+                    command_kind: RewriteCommandKind::FixPr,
+                    conflict_policy: RewriteConflictPolicy::Suspend,
+                    original_worktree_root,
+                    original_branch: cur_branch,
+                    original_head,
+                    resume_path,
+                    temp_branch: tmp_branch,
+                    temp_worktree_path: tmp_path,
+                    backup_tag,
+                    operations,
+                    deferred_dirty_worktree_restore,
+                    post_success_hint: Some(
+                        "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+                            .to_string(),
+                    ),
+                    metadata_refresh_context: Some(metadata_context.clone()),
+                },
+            )
         },
     )
 }
@@ -204,6 +205,7 @@ mod tests {
     use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
     use crate::commands::RewriteCommandOutcome;
     use crate::config::DirtyWorktreePolicy;
+    use crate::execution::ExecutionMode;
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, StableHandle};
     use crate::test_support::{lock_cwd, DirGuard};
@@ -352,7 +354,7 @@ mod tests {
             &GroupSelector::LocalPr(1),
             1,
             false,
-            false,
+            ExecutionMode::Apply,
             DirtyWorktreePolicy::Discard,
         )
         .expect("fix-pr should rewrite under discard policy");
@@ -391,7 +393,7 @@ mod tests {
             &GroupSelector::LocalPr(1),
             1,
             false,
-            false,
+            ExecutionMode::Apply,
             DirtyWorktreePolicy::Stash,
         )
         .expect("fix-pr should rewrite and restore stashed changes");
@@ -433,7 +435,7 @@ mod tests {
             &GroupSelector::LocalPr(1),
             1,
             false,
-            false,
+            ExecutionMode::Apply,
             DirtyWorktreePolicy::Stash,
         )
         .expect("fix-pr should suspend under stash policy");
@@ -482,7 +484,7 @@ mod tests {
                 Path::new(&resume_state.temp_worktree_path),
                 ["add", "story.txt"].as_slice(),
             );
-            current = resume_rewrite(false, &resume_path).expect("resume fix-pr");
+            current = resume_rewrite(&resume_path).expect("resume fix-pr");
         }
 
         assert_eq!(current, RewriteCommandOutcome::Completed);
@@ -517,7 +519,7 @@ mod tests {
             &GroupSelector::LocalPr(1),
             1,
             false,
-            false,
+            ExecutionMode::Apply,
             DirtyWorktreePolicy::Halt,
         )
         .expect_err("halt policy should refuse a dirty worktree");
@@ -557,7 +559,7 @@ mod tests {
             &GroupSelector::LocalPr(1),
             1,
             false,
-            false,
+            ExecutionMode::Apply,
             DirtyWorktreePolicy::Halt,
         )
         .expect("fix-pr should suspend");
@@ -594,7 +596,7 @@ mod tests {
                 ["add", "story.txt"].as_slice(),
             );
             last_resume_path = Some(resume_path.clone());
-            current = resume_rewrite(false, &resume_path).expect("resume fix-pr");
+            current = resume_rewrite(&resume_path).expect("resume fix-pr");
         }
 
         assert_eq!(current, RewriteCommandOutcome::Completed);

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -4,6 +4,7 @@ use tracing::warn;
 
 use crate::branch_names::{canonical_branch_conflict_key, group_branch_identities};
 use crate::cli::LandCmd;
+use crate::execution::ExecutionMode;
 use crate::git::{gh_rw, git_ro, git_rw, sanitize_gh_base_ref, to_remote_ref};
 use crate::github::{
     fetch_pr_bodies_graphql, fetch_pr_ci_review_status, graphql_escape, list_open_prs_for_heads,
@@ -50,7 +51,7 @@ pub fn land_until(
     prefix: &str,
     ignore_tag: &str,
     until: &InclusiveSelector,
-    dry: bool,
+    execution_mode: ExecutionMode,
     mode: LandCmd,
     bypass_safety: bool,
 ) -> Result<usize> {
@@ -132,7 +133,7 @@ pub fn land_until(
 
     if let LandCmd::PerPr = mode {
         // Verify each has exactly one unique commit over its parent
-        git_rw(dry, ["fetch", "origin"].as_slice())?; // ensure remotes up to date
+        git_rw(execution_mode, ["fetch", "origin"].as_slice())?; // ensure remotes up to date
         let mut offenders: Vec<u64> = vec![];
         for (i, pr) in segment.iter().enumerate() {
             let parent = if i == 0 {
@@ -232,7 +233,7 @@ pub fn land_until(
         take_n - 1
     );
     gh_rw(
-        dry,
+        execution_mode,
         ["api", "graphql", "-f", &format!("query={}", m)].as_slice(),
     )?;
 
@@ -246,7 +247,7 @@ pub fn land_per_pr_until(
     prefix: &str,
     ignore_tag: &str,
     until: &InclusiveSelector,
-    dry: bool,
+    execution_mode: ExecutionMode,
     bypass_safety: bool,
 ) -> Result<usize> {
     land_until(
@@ -254,7 +255,7 @@ pub fn land_per_pr_until(
         prefix,
         ignore_tag,
         until,
-        dry,
+        execution_mode,
         LandCmd::PerPr,
         bypass_safety,
     )
@@ -266,7 +267,7 @@ pub fn land_flatten_until(
     prefix: &str,
     ignore_tag: &str,
     until: &InclusiveSelector,
-    dry: bool,
+    execution_mode: ExecutionMode,
     bypass_safety: bool,
 ) -> Result<usize> {
     land_until(
@@ -274,7 +275,7 @@ pub fn land_flatten_until(
         prefix,
         ignore_tag,
         until,
-        dry,
+        execution_mode,
         LandCmd::Flatten,
         bypass_safety,
     )
@@ -284,6 +285,7 @@ pub fn land_flatten_until(
 mod tests {
     use super::{land_until, resolve_land_take_count, resolve_landed_pr_segment};
     use crate::cli::LandCmd;
+    use crate::execution::ExecutionMode;
     use crate::github::PrInfo;
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, InclusiveSelector, StableHandle};
@@ -384,7 +386,7 @@ mod tests {
             "dank-spr/",
             "ignore",
             &InclusiveSelector::All,
-            true,
+            ExecutionMode::DryRun,
             LandCmd::Flatten,
             false,
         )

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -10,6 +10,7 @@ use crate::commands::rewrite_resume::{
     self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
 };
 use crate::config::DirtyWorktreePolicy;
+use crate::execution::ExecutionMode;
 use crate::git::git_rev_parse;
 use crate::github::get_open_pr_automerge_for_head;
 use crate::parsing::derive_local_groups_with_ignored;
@@ -21,7 +22,7 @@ use crate::selectors::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveExecutionOptions {
     pub safe: bool,
-    pub dry: bool,
+    pub execution_mode: ExecutionMode,
     pub dirty_worktree_policy: DirtyWorktreePolicy,
 }
 
@@ -210,7 +211,7 @@ pub fn move_groups_after(
     }
 
     common::with_dirty_worktree_policy(
-        options.dry,
+        options.execution_mode,
         "spr move",
         options.dirty_worktree_policy,
         |deferred_dirty_worktree_restore| {
@@ -218,14 +219,14 @@ pub fn move_groups_after(
             let original_head = git_rev_parse("HEAD")?;
             let original_worktree_root = rewrite_resume::current_repo_root()?;
             let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
-                options.dry,
+                options.execution_mode,
                 RewriteCommandKind::Move,
                 &cur_branch,
                 &original_head,
             )?;
             let backup_tag = if options.safe {
                 Some(common::create_backup_tag(
-                    options.dry,
+                    options.execution_mode,
                     "move",
                     &cur_branch,
                     &short,
@@ -235,10 +236,10 @@ pub fn move_groups_after(
             };
 
             let (tmp_path, tmp_branch) =
-                common::create_temp_worktree(options.dry, "move", &merge_base, &short)?;
+                common::create_temp_worktree(options.execution_mode, "move", &merge_base, &short)?;
             let operations = build_move_operations(&leading_ignored, &groups, &new_order);
             rewrite_resume::run_rewrite_session(
-                options.dry,
+                options.execution_mode,
                 RewriteSession {
                     command_kind: RewriteCommandKind::Move,
                     conflict_policy: RewriteConflictPolicy::Suspend,
@@ -277,6 +278,7 @@ mod tests {
     use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
     use crate::commands::{move_groups_after, MoveExecutionOptions, RewriteCommandOutcome};
     use crate::config::DirtyWorktreePolicy;
+    use crate::execution::ExecutionMode;
     use crate::parsing::Group;
     use crate::selectors::{AfterSelector, GroupRangeSelector, GroupSelector, StableHandle};
     use crate::test_support::{commit_file, git, lock_cwd, log_subjects, write_file, DirGuard};
@@ -426,7 +428,7 @@ mod tests {
             &AfterSelector::Group(GroupSelector::LocalPr(1)),
             MoveExecutionOptions {
                 safe: false,
-                dry: false,
+                execution_mode: ExecutionMode::Apply,
                 dirty_worktree_policy: DirtyWorktreePolicy::Halt,
             },
         )
@@ -464,7 +466,7 @@ mod tests {
                 ["add", "story.txt"].as_slice(),
             );
             last_resume_path = Some(resume_path.clone());
-            current = resume_rewrite(false, &resume_path).expect("resume move");
+            current = resume_rewrite(&resume_path).expect("resume move");
         }
 
         assert_eq!(current, RewriteCommandOutcome::Completed);

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use tracing::info;
 
 use crate::branch_names::{canonical_branch_conflict_key, group_branch_identities};
+use crate::execution::ExecutionMode;
 use crate::git::{git_ro, git_rw};
 use crate::github::{append_warning_to_pr, list_open_prs_for_heads};
 use crate::limit::Limit;
@@ -179,8 +180,9 @@ pub fn prep_squash(
     pr_description_mode: crate::config::PrDescriptionMode,
     list_order: crate::config::ListOrder,
     selection: crate::cli::PrepSelection,
-    dry: bool,
+    execution_mode: ExecutionMode,
 ) -> Result<PrepSummaryData> {
+    let dry_run = execution_mode == ExecutionMode::DryRun;
     let (merge_base, groups) = derive_local_groups(base, ignore_tag)?;
     if groups.is_empty() {
         return Ok(PrepSummaryData {
@@ -190,7 +192,7 @@ pub fn prep_squash(
                 ignore_tag: ignore_tag.to_string(),
             },
             options: PrepOptions {
-                dry_run: dry,
+                dry_run,
                 pr_description_mode,
             },
             selection: ResolvedPrepSelection::All,
@@ -274,7 +276,7 @@ pub fn prep_squash(
                     .to_string();
             if tree != parent_tree {
                 let new_commit = git_rw(
-                    dry,
+                    execution_mode,
                     ["commit-tree", tree, "-p", &parent_sha, "-m", &message].as_slice(),
                 )?
                 .trim()
@@ -340,7 +342,7 @@ pub fn prep_squash(
                 skipped_replay_commit_count += 1;
             } else {
                 let new_commit = git_rw(
-                    dry,
+                    execution_mode,
                     ["commit-tree", tree, "-p", &parent_sha, "-m", message].as_slice(),
                 )?
                 .trim()
@@ -355,7 +357,7 @@ pub fn prep_squash(
         .trim()
         .to_string();
     git_rw(
-        dry,
+        execution_mode,
         [
             "update-ref",
             &format!("refs/heads/{}", current_branch),
@@ -374,7 +376,7 @@ pub fn prep_squash(
         prefix,
         &skipped_handles,
         false,
-        dry,
+        execution_mode,
         pr_description_mode,
         limit,
         updated_groups,
@@ -390,7 +392,7 @@ pub fn prep_squash(
             ignore_tag: ignore_tag.to_string(),
         },
         UpdateOptions {
-            dry_run: dry,
+            dry_run,
             no_pr: false,
             pr_description_mode,
         },
@@ -413,9 +415,9 @@ pub fn prep_squash(
                             append_warning_to_pr(
                                 pr.number,
                                 "🚨🚨 parent PRs have changed, this PR may show extra diffs from parent PR 🚨🚨",
-                                dry,
+                                execution_mode,
                             )?;
-                            if dry {
+                            if dry_run {
                                 PrepNextChildAction::WouldAppendWarning
                             } else {
                                 PrepNextChildAction::WarningAppended
@@ -459,7 +461,7 @@ pub fn prep_squash(
             ignore_tag: ignore_tag.to_string(),
         },
         options: PrepOptions {
-            dry_run: dry,
+            dry_run,
             pr_description_mode,
         },
         selection: resolved_selection,
@@ -483,6 +485,7 @@ mod tests {
     use super::{prep_squash, render_prep_summary, resolve_prep_window};
     use crate::cli::PrepSelection;
     use crate::config::{ListOrder, PrDescriptionMode};
+    use crate::execution::ExecutionMode;
     use crate::maintenance_output::{PreparedGroupAction, ResolvedPrepSelection};
     use crate::parsing::Group;
     use crate::selectors::{GroupSelector, InclusiveSelector, StableHandle};
@@ -570,7 +573,7 @@ mod tests {
             PrDescriptionMode::Overwrite,
             ListOrder::RecentOnBottom,
             PrepSelection::All,
-            true,
+            ExecutionMode::DryRun,
         )
         .unwrap_err();
 

--- a/src/commands/relink_prs.rs
+++ b/src/commands/relink_prs.rs
@@ -4,6 +4,7 @@ use tracing::info;
 
 use crate::branch_names::{canonical_branch_conflict_key, group_branch_identities};
 use crate::commands::common;
+use crate::execution::ExecutionMode;
 use crate::git::{gh_rw, normalize_branch_name, sanitize_gh_base_ref};
 use crate::github::list_open_prs_for_heads;
 use crate::maintenance_output::{
@@ -40,8 +41,9 @@ pub fn relink_prs(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-    dry: bool,
+    execution_mode: ExecutionMode,
 ) -> Result<RelinkPrsSummaryData> {
+    let dry_run = execution_mode == ExecutionMode::DryRun;
     let normalized_base = normalize_branch_name(base);
     let (_merge_base, groups) = derive_local_groups(base, ignore_tag)?;
     if groups.is_empty() {
@@ -50,7 +52,7 @@ pub fn relink_prs(
                 base: normalized_base,
                 prefix: prefix.to_string(),
             },
-            options: MaintenanceOptions { dry_run: dry },
+            options: MaintenanceOptions { dry_run },
             expected_chain: Vec::new(),
             decisions: Vec::new(),
         });
@@ -90,7 +92,7 @@ pub fn relink_prs(
                 RelinkPrAction::AlreadyCorrect
             } else {
                 gh_rw(
-                    dry,
+                    execution_mode,
                     [
                         "pr",
                         "edit",
@@ -100,7 +102,7 @@ pub fn relink_prs(
                     ]
                     .as_slice(),
                 )?;
-                if dry {
+                if dry_run {
                     RelinkPrAction::DryRunEdit
                 } else {
                     RelinkPrAction::Edited
@@ -133,7 +135,7 @@ pub fn relink_prs(
             base: normalized_base,
             prefix: prefix.to_string(),
         },
-        options: MaintenanceOptions { dry_run: dry },
+        options: MaintenanceOptions { dry_run },
         expected_chain,
         decisions,
     })
@@ -142,6 +144,7 @@ pub fn relink_prs(
 #[cfg(test)]
 mod tests {
     use super::relink_prs;
+    use crate::execution::ExecutionMode;
     use crate::maintenance_output::RelinkPrAction;
     use crate::test_support::{commit_file, git, lock_cwd, write_file, DirGuard};
     use std::env;
@@ -240,7 +243,7 @@ mod tests {
         );
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
 
-        let summary = relink_prs("main", "skilltest/", "ignore", false).unwrap();
+        let summary = relink_prs("main", "skilltest/", "ignore", ExecutionMode::Apply).unwrap();
 
         assert_eq!(summary.decisions[0].action, RelinkPrAction::AlreadyCorrect);
         assert_eq!(summary.decisions[1].action, RelinkPrAction::Edited);
@@ -262,7 +265,7 @@ mod tests {
         );
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
 
-        let err = relink_prs("main", "skilltest/", "ignore", false).unwrap_err();
+        let err = relink_prs("main", "skilltest/", "ignore", ExecutionMode::Apply).unwrap_err();
 
         assert!(err
             .to_string()
@@ -285,7 +288,7 @@ mod tests {
         );
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
 
-        let summary = relink_prs("main", "skilltest/", "ignore", false).unwrap();
+        let summary = relink_prs("main", "skilltest/", "ignore", ExecutionMode::Apply).unwrap();
 
         assert_eq!(summary.expected_chain.len(), 2);
         assert_eq!(summary.decisions.len(), 2);

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -20,6 +20,7 @@ use crate::commands::rewrite_resume::{
     self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
 };
 use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+use crate::execution::ExecutionMode;
 use crate::git::git_rev_list_range;
 use crate::git::git_rev_parse;
 use crate::git::git_ro;
@@ -33,7 +34,7 @@ use crate::selectors::{resolve_after_count, AfterSelector};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RestackExecutionOptions {
     safe: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
 }
@@ -461,7 +462,11 @@ fn try_fast_suffix_rebase(
         fast_plan.upstream_exclusive.as_str(),
         cur_branch,
     ];
-    match common::run_native_rebase_with_abort(false, rebase_args.as_slice(), "fast restack")? {
+    match common::run_native_rebase_with_abort(
+        ExecutionMode::Apply,
+        rebase_args.as_slice(),
+        "fast restack",
+    )? {
         NativeRebaseOutcome::Aborted => {
             verify_fast_rebase_abort_cleanup(&fast_plan.original_head).with_context(|| {
                 format!(
@@ -498,11 +503,11 @@ fn restack_after_resolved(
     plan: RestackPlan,
     options: RestackExecutionOptions,
 ) -> Result<RewriteCommandOutcome> {
-    let planned_executor = plan.planned_executor(!options.dry)?;
+    let planned_executor = plan.planned_executor(options.execution_mode == ExecutionMode::Apply)?;
     log_human_restack_plan(&plan, options.safe, planned_executor.clone());
 
     common::with_dirty_worktree_policy(
-        options.dry,
+        options.execution_mode,
         "spr restack",
         options.dirty_worktree_policy,
         |deferred_dirty_worktree_restore| {
@@ -512,7 +517,12 @@ fn restack_after_resolved(
             let metadata_refresh_context = metadata_context.clone();
             if plan.remaining_groups.is_empty() && plan.kept_ignored_segments.is_empty() {
                 if options.safe {
-                    let _ = common::create_backup_tag(options.dry, "restack", &cur_branch, &short)?;
+                    let _ = common::create_backup_tag(
+                        options.execution_mode,
+                        "restack",
+                        &cur_branch,
+                        &short,
+                    )?;
                 }
                 info!(
                     "Skipping all {} PR(s); syncing current branch {} to {}",
@@ -520,8 +530,8 @@ fn restack_after_resolved(
                     cur_branch,
                     metadata_context.base
                 );
-                common::reset_current_branch_to(options.dry, &metadata_context.base)?;
-                if !options.dry {
+                common::reset_current_branch_to(options.execution_mode, &metadata_context.base)?;
+                if options.execution_mode == ExecutionMode::Apply {
                     crate::stack_metadata::refresh_metadata_for_branch(
                         &original_worktree_root,
                         &cur_branch,
@@ -538,7 +548,7 @@ fn restack_after_resolved(
                     } => {
                         let backup_tag = if options.safe {
                             Some(common::create_backup_tag(
-                                false,
+                                ExecutionMode::Apply,
                                 "restack",
                                 &cur_branch,
                                 &short,
@@ -570,7 +580,7 @@ fn restack_after_resolved(
                     Ok(RewriteCommandOutcome::Completed)
                 } else {
                     let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
-                        options.dry,
+                        options.execution_mode,
                         RewriteCommandKind::Restack,
                         &cur_branch,
                         &original_head,
@@ -579,7 +589,7 @@ fn restack_after_resolved(
                         existing_backup_tag
                     } else if options.safe {
                         Some(common::create_backup_tag(
-                            options.dry,
+                            options.execution_mode,
                             "restack",
                             &cur_branch,
                             &short,
@@ -589,13 +599,13 @@ fn restack_after_resolved(
                     };
 
                     let (tmp_path, tmp_branch) = common::create_temp_worktree(
-                        options.dry,
+                        options.execution_mode,
                         "restack",
                         &metadata_context.base,
                         &short,
                     )?;
                     let outcome = rewrite_resume::run_rewrite_session(
-                        options.dry,
+                        options.execution_mode,
                         RewriteSession {
                             command_kind: RewriteCommandKind::Restack,
                             conflict_policy: if options.conflict_policy
@@ -652,11 +662,11 @@ pub fn restack_after(
     metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     after: &AfterSelector,
     safe: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<RewriteCommandOutcome> {
-    git_rw(dry, ["fetch", "origin"].as_slice())?;
+    git_rw(execution_mode, ["fetch", "origin"].as_slice())?;
 
     if let Some(plan) = collect_restack_plan(metadata_context, after, true)? {
         restack_after_resolved(
@@ -664,7 +674,7 @@ pub fn restack_after(
             plan,
             RestackExecutionOptions {
                 safe,
-                dry,
+                execution_mode,
                 conflict_policy,
                 dirty_worktree_policy,
             },
@@ -680,11 +690,11 @@ pub fn restack_after_count(
     metadata_context: &crate::stack_metadata::RefreshMetadataContext,
     after: usize,
     safe: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     conflict_policy: RestackConflictPolicy,
     dirty_worktree_policy: DirtyWorktreePolicy,
 ) -> Result<RewriteCommandOutcome> {
-    git_rw(dry, ["fetch", "origin"].as_slice())?;
+    git_rw(execution_mode, ["fetch", "origin"].as_slice())?;
 
     if let Some(plan) = collect_restack_plan_after_count(metadata_context, after, true)? {
         restack_after_resolved(
@@ -692,7 +702,7 @@ pub fn restack_after_count(
             plan,
             RestackExecutionOptions {
                 safe,
-                dry,
+                execution_mode,
                 conflict_policy,
                 dirty_worktree_policy,
             },
@@ -712,6 +722,7 @@ mod tests {
     use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
     use crate::commands::RewriteCommandOutcome;
     use crate::config::{DirtyWorktreePolicy, RestackConflictPolicy};
+    use crate::execution::ExecutionMode;
     use crate::parsing::Group;
     use crate::restack_output::RestackExecutorPlan;
     use crate::selectors::{AfterSelector, GroupSelector, StableHandle};
@@ -1176,7 +1187,7 @@ mod tests {
             &metadata_context(),
             &AfterSelector::Group(GroupSelector::LocalPr(1)),
             true,
-            false,
+            ExecutionMode::Apply,
             RestackConflictPolicy::Halt,
             DirtyWorktreePolicy::Halt,
         )
@@ -1242,7 +1253,7 @@ mod tests {
             &metadata_context(),
             &AfterSelector::Group(GroupSelector::LocalPr(1)),
             false,
-            false,
+            ExecutionMode::Apply,
             RestackConflictPolicy::Halt,
             DirtyWorktreePolicy::Halt,
         )
@@ -1264,7 +1275,7 @@ mod tests {
         );
         resolve_restack_conflict(Path::new(&resume_state.temp_worktree_path));
 
-        let resumed = resume_rewrite(false, &resume_path).expect("resume restack");
+        let resumed = resume_rewrite(&resume_path).expect("resume restack");
         assert_eq!(resumed, RewriteCommandOutcome::Completed);
         assert!(
             !resume_path.exists(),

--- a/src/commands/rewrite_resume.rs
+++ b/src/commands/rewrite_resume.rs
@@ -19,6 +19,7 @@ use tracing::{info, warn};
 use crate::commands::common::{
     self, CherryPickEmptyPolicy, CherryPickOp, DeferredDirtyWorktreeRestore, DirtyWorktreeOutcome,
 };
+use crate::execution::ExecutionMode;
 use crate::git::{git_common_dir, git_rev_list_range, git_ro, git_rw, repo_root};
 
 const REWRITE_RESUME_SCHEMA_VERSION: u32 = 1;
@@ -131,7 +132,7 @@ pub fn current_repo_root() -> Result<String> {
 }
 
 pub fn prepare_resume_path_for_new_session(
-    dry: bool,
+    execution_mode: ExecutionMode,
     command_kind: RewriteCommandKind,
     original_branch: &str,
     original_head: &str,
@@ -163,7 +164,7 @@ pub fn prepare_resume_path_for_new_session(
         );
     }
 
-    if dry {
+    if execution_mode == ExecutionMode::DryRun {
         bail!(
             "stale resume file {} exists for {}, but `--dry-run` will not remove it; delete the file or rerun without `--dry-run`",
             resume_path.display(),
@@ -176,11 +177,14 @@ pub fn prepare_resume_path_for_new_session(
         resume_path.display(),
         existing_state.temp_worktree_path
     );
-    remove_resume_file_if_exists(false, &resume_path)?;
+    remove_resume_file_if_exists(ExecutionMode::Apply, &resume_path)?;
     Ok(resume_path)
 }
 
-pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<RewriteCommandOutcome> {
+pub fn run_rewrite_session(
+    execution_mode: ExecutionMode,
+    session: RewriteSession,
+) -> Result<RewriteCommandOutcome> {
     let git_common_dir = git_common_dir()?;
     let state = RewriteResumeState {
         schema_version: REWRITE_RESUME_SCHEMA_VERSION,
@@ -203,7 +207,7 @@ pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<Rewrite
         metadata_refresh_context: session.metadata_refresh_context,
     };
     continue_rewrite_operations(
-        dry,
+        execution_mode,
         state,
         session.conflict_policy,
         &session.resume_path,
@@ -212,11 +216,7 @@ pub fn run_rewrite_session(dry: bool, session: RewriteSession) -> Result<Rewrite
     )
 }
 
-pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
-    if dry {
-        bail!("`spr resume` does not support `--dry-run`");
-    }
-
+pub fn resume_rewrite(path: &Path) -> Result<RewriteCommandOutcome> {
     let resume_path = absolute_path(path)?;
     let state = read_resume_state(&resume_path)?;
     validate_resume_state_against_current_repo(&resume_path, &state)?;
@@ -232,7 +232,7 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
         }
         ensure_no_unmerged_paths(&state.temp_worktree_path)?;
         let continue_result = git_rw(
-            false,
+            ExecutionMode::Apply,
             [
                 "-C",
                 state.temp_worktree_path.as_str(),
@@ -257,7 +257,7 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
                     state.temp_worktree_path
                 );
                 let skip_result = git_rw(
-                    false,
+                    ExecutionMode::Apply,
                     [
                         "-C",
                         state.temp_worktree_path.as_str(),
@@ -299,7 +299,7 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
 
     let remaining_operations = state.remaining_operations.clone();
     continue_rewrite_operations(
-        false,
+        ExecutionMode::Apply,
         state,
         RewriteConflictPolicy::Suspend,
         &resume_path,
@@ -309,7 +309,7 @@ pub fn resume_rewrite(dry: bool, path: &Path) -> Result<RewriteCommandOutcome> {
 }
 
 fn continue_rewrite_operations(
-    dry: bool,
+    execution_mode: ExecutionMode,
     mut state: RewriteResumeState,
     conflict_policy: RewriteConflictPolicy,
     resume_path: &Path,
@@ -317,7 +317,7 @@ fn continue_rewrite_operations(
     restore_dirty_worktree_on_success: bool,
 ) -> Result<RewriteCommandOutcome> {
     for (op_index, op) in operations.iter().enumerate() {
-        if let Err(err) = run_cherry_pick_op(dry, &state.temp_worktree_path, op) {
+        if let Err(err) = run_cherry_pick_op(execution_mode, &state.temp_worktree_path, op) {
             let conflict = cherry_pick_head_exists(&state.temp_worktree_path);
             if conflict && conflict_policy == RewriteConflictPolicy::Suspend {
                 state.paused_head = head_at(&state.temp_worktree_path)?;
@@ -336,9 +336,13 @@ fn continue_rewrite_operations(
             }
 
             if conflict {
-                abort_cherry_pick_best_effort(dry, &state.temp_worktree_path);
+                abort_cherry_pick_best_effort(execution_mode, &state.temp_worktree_path);
             }
-            cleanup_temp_state_best_effort(dry, &state.temp_worktree_path, &state.temp_branch);
+            cleanup_temp_state_best_effort(
+                execution_mode,
+                &state.temp_worktree_path,
+                &state.temp_branch,
+            );
             return Err(err).with_context(|| {
                 format!(
                     "{} failed; temp rewrite state was cleaned up",
@@ -348,11 +352,16 @@ fn continue_rewrite_operations(
         }
     }
 
-    finish_rewrite(dry, state, resume_path, restore_dirty_worktree_on_success)
+    finish_rewrite(
+        execution_mode,
+        state,
+        resume_path,
+        restore_dirty_worktree_on_success,
+    )
 }
 
 fn finish_rewrite(
-    dry: bool,
+    execution_mode: ExecutionMode,
     state: RewriteResumeState,
     resume_path: &Path,
     restore_dirty_worktree_on_success: bool,
@@ -364,7 +373,7 @@ fn finish_rewrite(
         state.original_branch, state.original_worktree_root, new_tip
     );
     let _ = git_rw(
-        dry,
+        execution_mode,
         [
             "-C",
             state.original_worktree_root.as_str(),
@@ -374,7 +383,7 @@ fn finish_rewrite(
         ]
         .as_slice(),
     )?;
-    let metadata_refresh_result = if dry {
+    let metadata_refresh_result = if execution_mode == ExecutionMode::DryRun {
         Ok(())
     } else if let Some(metadata_refresh_context) = &state.metadata_refresh_context {
         crate::stack_metadata::refresh_metadata_for_branch(
@@ -391,15 +400,19 @@ fn finish_rewrite(
             .deferred_dirty_worktree_restore
             .clone()
             .restore_after_success(
-                dry,
+                execution_mode,
                 state.command_kind.command_name(),
                 &state.original_worktree_root,
             )
     } else {
         Ok(())
     };
-    cleanup_temp_state_best_effort(dry, &state.temp_worktree_path, &state.temp_branch);
-    remove_resume_file_if_exists(dry, resume_path)?;
+    cleanup_temp_state_best_effort(
+        execution_mode,
+        &state.temp_worktree_path,
+        &state.temp_branch,
+    );
+    remove_resume_file_if_exists(execution_mode, resume_path)?;
     if let Some(post_success_hint) = &state.post_success_hint {
         info!("{post_success_hint}");
     }
@@ -479,16 +492,20 @@ struct CommitIdentity {
     author_date: String,
 }
 
-fn run_cherry_pick_op(dry: bool, tmp_path: &str, op: &CherryPickOp) -> Result<()> {
+fn run_cherry_pick_op(
+    execution_mode: ExecutionMode,
+    tmp_path: &str,
+    op: &CherryPickOp,
+) -> Result<()> {
     match op {
         CherryPickOp::Commit { sha, empty_policy } => {
-            common::cherry_pick_commit(dry, tmp_path, sha, *empty_policy)
+            common::cherry_pick_commit(execution_mode, tmp_path, sha, *empty_policy)
         }
         CherryPickOp::Range {
             first,
             last,
             empty_policy,
-        } => common::cherry_pick_range(dry, tmp_path, first, last, *empty_policy),
+        } => common::cherry_pick_range(execution_mode, tmp_path, first, last, *empty_policy),
     }
 }
 
@@ -712,14 +729,17 @@ fn git_dir_at(tmp_path: &str) -> Result<PathBuf> {
     }
 }
 
-fn abort_cherry_pick_best_effort(dry: bool, tmp_path: &str) {
-    if let Err(err) = git_rw(dry, ["-C", tmp_path, "cherry-pick", "--abort"].as_slice()) {
+fn abort_cherry_pick_best_effort(execution_mode: ExecutionMode, tmp_path: &str) {
+    if let Err(err) = git_rw(
+        execution_mode,
+        ["-C", tmp_path, "cherry-pick", "--abort"].as_slice(),
+    ) {
         warn!("Failed to abort cherry-pick in {}: {}", tmp_path, err);
     }
 }
 
-fn cleanup_temp_state_best_effort(dry: bool, tmp_path: &str, tmp_branch: &str) {
-    if let Err(err) = common::cleanup_temp_worktree(dry, tmp_path, tmp_branch) {
+fn cleanup_temp_state_best_effort(execution_mode: ExecutionMode, tmp_path: &str, tmp_branch: &str) {
+    if let Err(err) = common::cleanup_temp_worktree(execution_mode, tmp_path, tmp_branch) {
         warn!(
             "Failed to clean up temp rewrite state ({} / {}): {}",
             tmp_path, tmp_branch, err
@@ -872,8 +892,8 @@ fn short_head(head: &str) -> &str {
     &head[..limit]
 }
 
-fn remove_resume_file_if_exists(dry: bool, path: &Path) -> Result<()> {
-    if dry {
+fn remove_resume_file_if_exists(execution_mode: ExecutionMode, path: &Path) -> Result<()> {
+    if execution_mode == ExecutionMode::DryRun {
         Ok(())
     } else if path.exists() {
         fs::remove_file(path)
@@ -1044,6 +1064,7 @@ mod tests {
     use crate::commands::common::{
         CherryPickEmptyPolicy, CherryPickOp, DeferredDirtyWorktreeRestore,
     };
+    use crate::execution::ExecutionMode;
     use crate::test_support::{lock_cwd, DirGuard};
 
     fn git(repo: &Path, args: &[&str]) -> String {
@@ -1126,11 +1147,15 @@ mod tests {
         let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
             .trim()
             .to_string();
-        let (tmp_path, tmp_branch) =
-            crate::commands::common::create_temp_worktree(false, "restack", &base_head, &short)
-                .expect("create temp worktree");
+        let (tmp_path, tmp_branch) = crate::commands::common::create_temp_worktree(
+            ExecutionMode::Apply,
+            "restack",
+            &base_head,
+            &short,
+        )
+        .expect("create temp worktree");
         let resume_path = prepare_resume_path_for_new_session(
-            false,
+            ExecutionMode::Apply,
             RewriteCommandKind::Restack,
             "stack",
             &original_head,
@@ -1156,7 +1181,8 @@ mod tests {
             metadata_refresh_context: None,
         };
 
-        let outcome = run_rewrite_session(false, session).expect("run rewrite session");
+        let outcome =
+            run_rewrite_session(ExecutionMode::Apply, session).expect("run rewrite session");
         let resume_path = match outcome {
             RewriteCommandOutcome::Completed => panic!("expected suspended rewrite"),
             RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
@@ -1182,11 +1208,15 @@ mod tests {
         let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
             .trim()
             .to_string();
-        let (tmp_path, tmp_branch) =
-            crate::commands::common::create_temp_worktree(false, "restack", &base_head, &short)
-                .expect("create temp worktree");
+        let (tmp_path, tmp_branch) = crate::commands::common::create_temp_worktree(
+            ExecutionMode::Apply,
+            "restack",
+            &base_head,
+            &short,
+        )
+        .expect("create temp worktree");
         let resume_path = prepare_resume_path_for_new_session(
-            false,
+            ExecutionMode::Apply,
             RewriteCommandKind::Restack,
             "stack",
             &original_head,
@@ -1194,7 +1224,7 @@ mod tests {
         .expect("prepare resume path");
 
         let outcome = run_rewrite_session(
-            false,
+            ExecutionMode::Apply,
             RewriteSession {
                 command_kind: RewriteCommandKind::Restack,
                 conflict_policy: RewriteConflictPolicy::Suspend,
@@ -1259,11 +1289,15 @@ mod tests {
         let short = git(&repo, ["rev-parse", "--short", "HEAD"].as_slice())
             .trim()
             .to_string();
-        let (tmp_path, tmp_branch) =
-            crate::commands::common::create_temp_worktree(false, "restack", &base_head, &short)
-                .expect("create temp worktree");
+        let (tmp_path, tmp_branch) = crate::commands::common::create_temp_worktree(
+            ExecutionMode::Apply,
+            "restack",
+            &base_head,
+            &short,
+        )
+        .expect("create temp worktree");
         let resume_path = prepare_resume_path_for_new_session(
-            false,
+            ExecutionMode::Apply,
             RewriteCommandKind::Restack,
             "stack",
             &original_head,
@@ -1271,7 +1305,7 @@ mod tests {
         .expect("prepare resume path");
 
         let outcome = run_rewrite_session(
-            false,
+            ExecutionMode::Apply,
             RewriteSession {
                 command_kind: RewriteCommandKind::Restack,
                 conflict_policy: RewriteConflictPolicy::Suspend,
@@ -1358,7 +1392,7 @@ mod tests {
             "base-updated\nstack-change\n",
         );
 
-        let outcome = resume_rewrite(false, &resume_path).expect("resume rewrite");
+        let outcome = resume_rewrite(&resume_path).expect("resume rewrite");
         assert_eq!(outcome, RewriteCommandOutcome::Completed);
         assert!(
             !resume_path.exists(),
@@ -1388,7 +1422,7 @@ mod tests {
             "manual continue should finish only the paused commit before spr resume relaunches the suffix"
         );
 
-        let outcome = resume_rewrite(false, &resume_path).expect("resume after manual continue");
+        let outcome = resume_rewrite(&resume_path).expect("resume after manual continue");
         assert_eq!(outcome, RewriteCommandOutcome::Completed);
         assert!(
             !resume_path.exists(),
@@ -1427,7 +1461,7 @@ mod tests {
             "manual unrelated commit",
         );
 
-        let err = resume_rewrite(false, &resume_path)
+        let err = resume_rewrite(&resume_path)
             .expect_err("unrelated one-commit manual history should fail");
         let err_text = format!("{err:#}");
         assert!(
@@ -1444,7 +1478,7 @@ mod tests {
         let _keep_dir_alive = dir.path();
         let wrong_repo = init_conflict_repo();
         let _guard = DirGuard::change_to(wrong_repo.path());
-        let err = resume_rewrite(false, &resume_path).expect_err("wrong repo should fail");
+        let err = resume_rewrite(&resume_path).expect_err("wrong repo should fail");
         let err_text = format!("{err:#}");
         assert!(
             err_text.contains("belongs to git-common-dir"),
@@ -1460,7 +1494,7 @@ mod tests {
         let _keep_dir_alive = dir.path();
         let _guard = DirGuard::change_to(&repo);
 
-        let err = resume_rewrite(false, &resume_path).expect_err("unresolved conflict should fail");
+        let err = resume_rewrite(&resume_path).expect_err("unresolved conflict should fail");
         let err_text = format!("{err:#}");
         assert!(
             err_text.contains("still has unresolved conflicts"),
@@ -1485,7 +1519,7 @@ mod tests {
         )
         .expect("overwrite resume state");
 
-        let err = resume_rewrite(false, &resume_path).expect_err("unknown schema should fail");
+        let err = resume_rewrite(&resume_path).expect_err("unknown schema should fail");
         let err_text = format!("{err:#}");
         assert!(
             err_text.contains("schema version"),
@@ -1513,7 +1547,7 @@ mod tests {
             "feat: unsupported manual edit",
         );
 
-        let err = resume_rewrite(false, &resume_path).expect_err("extra manual commit should fail");
+        let err = resume_rewrite(&resume_path).expect_err("extra manual commit should fail");
         let err_text = format!("{err:#}");
         assert!(
             err_text.contains("only one accidental manual continue is supported"),
@@ -1537,7 +1571,7 @@ mod tests {
             "base-updated\nstack-1\n",
         );
 
-        let resumed = resume_rewrite(false, &resume_path).expect("resume into second conflict");
+        let resumed = resume_rewrite(&resume_path).expect("resume into second conflict");
         let second_resume_path = match resumed {
             RewriteCommandOutcome::Completed => panic!("expected second suspension"),
             RewriteCommandOutcome::Suspended(state) => state.resume_path.clone(),
@@ -1576,7 +1610,7 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&resume_path).expect("read resume state"))
                 .expect("parse resume state");
         let err = prepare_resume_path_for_new_session(
-            false,
+            ExecutionMode::Apply,
             RewriteCommandKind::Restack,
             &resume_state.original_branch,
             &resume_state.original_head,

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -10,6 +10,7 @@ use crate::branch_names::{
 };
 use crate::commands::common;
 use crate::config::{ListOrder, PrDescriptionMode};
+use crate::execution::ExecutionMode;
 use crate::git::{get_remote_branches_sha, gh_rw, git_is_ancestor, git_rw, sanitize_gh_base_ref};
 use crate::github::{
     fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape, list_open_prs_for_heads,
@@ -269,7 +270,7 @@ fn is_resource_limit_error(err: &anyhow::Error) -> bool {
         || msg.contains("Resource limits for this query exceeded")
 }
 
-fn run_update_chunk(dry: bool, update_inputs: &[String]) -> Result<()> {
+fn run_update_chunk(execution_mode: ExecutionMode, update_inputs: &[String]) -> Result<()> {
     if update_inputs.is_empty() {
         return Ok(());
     }
@@ -282,21 +283,21 @@ fn run_update_chunk(dry: bool, update_inputs: &[String]) -> Result<()> {
     }
     m.push('}');
     gh_rw(
-        dry,
+        execution_mode,
         ["api", "graphql", "-f", &format!("query={}", m)].as_slice(),
     )?;
     Ok(())
 }
 
 fn run_update_chunk_with_retry(
-    dry: bool,
+    execution_mode: ExecutionMode,
     update_inputs: &[String],
     progress_bar: Option<&ProgressBar>,
 ) -> Result<()> {
     if update_inputs.is_empty() {
         return Ok(());
     }
-    match run_update_chunk(dry, update_inputs) {
+    match run_update_chunk(execution_mode, update_inputs) {
         Ok(()) => {
             if let Some(progress_bar) = progress_bar {
                 progress_bar.inc(update_inputs.len() as u64);
@@ -310,8 +311,8 @@ fn run_update_chunk_with_retry(
             );
             let mid = update_inputs.len() / 2;
             let (left, right) = update_inputs.split_at(mid);
-            run_update_chunk_with_retry(dry, left, progress_bar)?;
-            run_update_chunk_with_retry(dry, right, progress_bar)?;
+            run_update_chunk_with_retry(execution_mode, left, progress_bar)?;
+            run_update_chunk_with_retry(execution_mode, right, progress_bar)?;
             Ok(())
         }
         Err(e) => Err(e),
@@ -319,7 +320,7 @@ fn run_update_chunk_with_retry(
 }
 
 fn run_update_mutations(
-    dry: bool,
+    execution_mode: ExecutionMode,
     update_inputs: Vec<String>,
     label: &str,
     max_ops: usize,
@@ -349,7 +350,7 @@ fn run_update_mutations(
         chunk_update_inputs(&update_inputs, max_ops, max_chars)
     };
     for chunk in chunks {
-        if let Err(e) = run_update_chunk_with_retry(dry, &chunk, progress_bar.as_ref()) {
+        if let Err(e) = run_update_chunk_with_retry(execution_mode, &chunk, progress_bar.as_ref()) {
             if let Some(progress_bar) = &progress_bar {
                 progress_bar.finish_and_clear();
             }
@@ -401,7 +402,7 @@ fn build_from_groups_internal(
     prefix: &str,
     skipped_handles: &[String],
     no_pr: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     pr_description_mode: PrDescriptionMode,
     limit: Option<Limit>,
     mut groups: Vec<Group>,
@@ -410,6 +411,7 @@ fn build_from_groups_internal(
     branch_reuse_guard_days: u32,
     render_progress: bool,
 ) -> Result<UpdateExecutionData> {
+    let dry_run = execution_mode == ExecutionMode::DryRun;
     if groups.is_empty() {
         if skipped_handles.is_empty() {
             info!("No groups discovered; nothing to do.");
@@ -570,7 +572,7 @@ fn build_from_groups_internal(
                 }
                 if !base_updates_pre.is_empty() {
                     run_update_mutations(
-                        dry,
+                        execution_mode,
                         base_updates_pre,
                         "Updating PR bases",
                         MAX_BASE_UPDATES_PER_MUTATION,
@@ -606,11 +608,11 @@ fn build_from_groups_internal(
             );
             progress_bar.set_position(ff_refspecs.len() as u64);
             progress_bar.enable_steady_tick(Duration::from_millis(120));
-            let result = git_rw(dry, &args);
+            let result = git_rw(execution_mode, &args);
             progress_bar.finish_and_clear();
             result?;
         } else {
-            git_rw(dry, &args)?;
+            git_rw(execution_mode, &args)?;
         }
     }
 
@@ -656,11 +658,11 @@ fn build_from_groups_internal(
             );
             progress_bar.set_position(force_refspecs.len() as u64);
             progress_bar.enable_steady_tick(Duration::from_millis(120));
-            let result = git_rw(dry, &args);
+            let result = git_rw(execution_mode, &args);
             progress_bar.finish_and_clear();
             result?;
         } else {
-            git_rw(dry, &args)?;
+            git_rw(execution_mode, &args)?;
         }
     }
 
@@ -689,7 +691,7 @@ fn build_from_groups_internal(
         let branch = identity.exact.clone();
         if !no_pr {
             let was_known = prs_by_head.contains_key(&identity.conflict_key);
-            if dry && !was_known {
+            if dry_run && !was_known {
                 pr_actions_by_group[group_idx] = UpdatePrAction::Created;
                 created_without_number.insert(group_idx);
             } else {
@@ -698,7 +700,7 @@ fn build_from_groups_internal(
                     &sanitize_gh_base_ref(&parent_branch),
                     &group.pr_title()?,
                     &group.pr_body()?,
-                    dry,
+                    execution_mode,
                     &mut prs_by_head,
                 )?;
                 pr_numbers_by_group[group_idx] = Some(number);
@@ -766,7 +768,7 @@ fn build_from_groups_internal(
             .collect();
         let mut body_updates: Vec<String> = Vec::new();
         let mut base_updates: Vec<String> = Vec::new();
-        if dry && !created_without_number.is_empty() {
+        if dry_run && !created_without_number.is_empty() {
             for group_idx in group_index_by_number.values().copied() {
                 description_actions_by_group[group_idx] = UpdateEditAction::Updated;
             }
@@ -824,7 +826,7 @@ fn build_from_groups_internal(
         if !base_updates.is_empty() || !body_updates.is_empty() {
             if !base_updates.is_empty() {
                 run_update_mutations(
-                    dry,
+                    execution_mode,
                     base_updates,
                     "Updating PR bases",
                     MAX_BASE_UPDATES_PER_MUTATION,
@@ -835,7 +837,7 @@ fn build_from_groups_internal(
             }
             if !body_updates.is_empty() {
                 run_update_mutations(
-                    dry,
+                    execution_mode,
                     body_updates,
                     "Updating PR descriptions",
                     MAX_BODY_UPDATES_PER_MUTATION,
@@ -915,7 +917,7 @@ pub fn build_from_groups_with_summary(
     prefix: &str,
     skipped_handles: &[String],
     no_pr: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     pr_description_mode: PrDescriptionMode,
     limit: Option<Limit>,
     groups: Vec<Group>,
@@ -928,7 +930,7 @@ pub fn build_from_groups_with_summary(
         prefix,
         skipped_handles,
         no_pr,
-        dry,
+        execution_mode,
         pr_description_mode,
         limit,
         groups,
@@ -945,7 +947,7 @@ pub fn build_from_groups(
     prefix: &str,
     skipped_handles: &[String],
     no_pr: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     pr_description_mode: PrDescriptionMode,
     limit: Option<Limit>,
     groups: Vec<Group>,
@@ -958,7 +960,7 @@ pub fn build_from_groups(
         prefix,
         skipped_handles,
         no_pr,
-        dry,
+        execution_mode,
         pr_description_mode,
         limit,
         groups,
@@ -978,7 +980,7 @@ pub fn build_from_tags(
     prefix: &str,
     ignore_tag: &str,
     no_pr: bool,
-    dry: bool,
+    execution_mode: ExecutionMode,
     pr_description_mode: PrDescriptionMode,
     limit: Option<Limit>,
     list_order: ListOrder,
@@ -992,7 +994,7 @@ pub fn build_from_tags(
         prefix,
         &skipped_handles,
         no_pr,
-        dry,
+        execution_mode,
         pr_description_mode,
         limit,
         groups,
@@ -1011,6 +1013,7 @@ mod tests {
     };
     use crate::branch_names::group_branch_identities;
     use crate::config::{ListOrder, PrDescriptionMode};
+    use crate::execution::ExecutionMode;
     use crate::github::TerminalPrState;
     use crate::parsing::{split_groups_for_update, Group};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
@@ -1128,7 +1131,7 @@ mod tests {
             "dank-spr/",
             &skipped_handles,
             false,
-            false,
+            ExecutionMode::Apply,
             PrDescriptionMode::Overwrite,
             None,
             pushable_groups,
@@ -1161,7 +1164,7 @@ mod tests {
             "dank-spr/",
             "ignore",
             true,
-            true,
+            ExecutionMode::DryRun,
             PrDescriptionMode::Overwrite,
             None,
             ListOrder::RecentOnBottom,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,0 +1,15 @@
+//! Execution policy for commands that can change repository or GitHub state.
+//!
+//! CLI parsing converts command-local `--dry-run` flags into this type at the
+//! boundary. Command implementations use it to decide whether state-changing IO
+//! should be applied or only reported.
+
+/// Whether a state-changing command should apply changes or report them only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExecutionMode {
+    /// Execute state-changing operations.
+    #[default]
+    Apply,
+    /// Report state-changing operations without applying them.
+    DryRun,
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tracing::{error, info};
 
+use crate::execution::ExecutionMode;
+
 pub fn ensure_tool(name: &str) -> Result<()> {
     let status = Command::new(name)
         .arg("--version")
@@ -43,31 +45,36 @@ pub fn git_ro_in(path: &str, args: &[&str]) -> Result<String> {
     git_ro(argv.as_slice())
 }
 
-pub fn git_rw(dry: bool, args: &[&str]) -> Result<String> {
-    if dry {
-        // Allow executing safe local ops in dry-run to mimic real flow closely
-        let mut idx = 0;
-        let mut in_tmp = false;
-        if let Some(first) = args.first() {
-            if *first == "-C" && args.len() >= 2 {
-                idx = 2;
-                in_tmp = args[1].starts_with("/tmp/spr-");
+pub fn git_rw(execution_mode: ExecutionMode, args: &[&str]) -> Result<String> {
+    match execution_mode {
+        ExecutionMode::Apply => {
+            verbose_log_cmd("git", args);
+            run("git", args)
+        }
+        ExecutionMode::DryRun => {
+            // Allow executing safe local ops in dry-run to mimic real flow closely
+            let mut idx = 0;
+            let mut in_tmp = false;
+            if let Some(first) = args.first() {
+                if *first == "-C" && args.len() >= 2 {
+                    idx = 2;
+                    in_tmp = args[1].starts_with("/tmp/spr-");
+                }
+            }
+            let sub = args.get(idx).copied().unwrap_or("");
+            let is_push = sub == "push";
+            let is_worktree = sub == "worktree";
+            let is_commit_tree = sub == "commit-tree";
+            let allow = (in_tmp && !is_push) || is_worktree || is_commit_tree;
+            if allow {
+                info!("DRY-RUN (exec): git {}", shellish(args));
+                run("git", args)
+            } else {
+                info!("DRY-RUN: git {}", shellish(args));
+                Ok(String::new())
             }
         }
-        let sub = args.get(idx).copied().unwrap_or("");
-        let is_push = sub == "push";
-        let is_worktree = sub == "worktree";
-        let is_commit_tree = sub == "commit-tree";
-        let allow = (in_tmp && !is_push) || is_worktree || is_commit_tree;
-        if allow {
-            info!("DRY-RUN (exec): git {}", shellish(args));
-            return run("git", args);
-        }
-        info!("DRY-RUN: git {}", shellish(args));
-        return Ok(String::new());
     }
-    verbose_log_cmd("git", args);
-    run("git", args)
 }
 
 pub fn gh_ro(args: &[&str]) -> Result<String> {
@@ -78,24 +85,27 @@ pub fn gh_ro(args: &[&str]) -> Result<String> {
     run("gh", args)
 }
 
-pub fn gh_rw(dry: bool, args: &[&str]) -> Result<String> {
-    if dry {
-        let printable = if args.contains(&"--body") {
-            let mut v = args.to_vec();
-            if let Some(i) = v.iter().position(|a| *a == "--body") {
-                if i + 1 < v.len() {
-                    v[i + 1] = "<elided-body>";
+pub fn gh_rw(execution_mode: ExecutionMode, args: &[&str]) -> Result<String> {
+    match execution_mode {
+        ExecutionMode::Apply => {
+            verbose_log_cmd("gh", args);
+            run("gh", args)
+        }
+        ExecutionMode::DryRun => {
+            let printable = if args.contains(&"--body") {
+                let mut v = args.to_vec();
+                if let Some(i) = v.iter().position(|a| *a == "--body") {
+                    if i + 1 < v.len() {
+                        v[i + 1] = "<elided-body>";
+                    }
                 }
-            }
-            v
-        } else {
-            args.to_vec()
-        };
-        info!("DRY-RUN: gh {}", shellish(&printable));
-        Ok(String::new())
-    } else {
-        verbose_log_cmd("gh", args);
-        run("gh", args)
+                v
+            } else {
+                args.to_vec()
+            };
+            info!("DRY-RUN: gh {}", shellish(&printable));
+            Ok(String::new())
+        }
     }
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,6 +15,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::info;
 
 use crate::branch_names::{canonical_branch_conflict_key, CanonicalBranchConflictKey};
+use crate::execution::ExecutionMode;
 use crate::git::{gh_ro, gh_rw, git_ro};
 
 #[derive(Debug, Deserialize, Clone)]
@@ -1104,13 +1105,13 @@ pub fn list_open_pr_heads() -> Result<HashSet<String>> {
 /// Creates a new pull request for the given branch and parent if one does not already exist,
 /// and returns the PR number. If a PR for the branch already exists (as tracked in `prs_by_head`),
 /// returns its number without making any changes. The function updates the `prs_by_head` map as needed.
-/// If `dry` is true, no actual changes are made on GitHub.
+/// In [`ExecutionMode::DryRun`], no actual changes are made on GitHub.
 pub fn upsert_pr_cached(
     branch: &str,
     parent: &str,
     title: &str,
     body: &str,
-    dry: bool,
+    execution_mode: ExecutionMode,
     prs_by_head: &mut HashMap<CanonicalBranchConflictKey, u64>,
 ) -> Result<u64> {
     let branch_key = head_key(branch);
@@ -1122,7 +1123,7 @@ pub fn upsert_pr_cached(
     let (owner, name) = get_repo_owner_name()?;
     let path = format!("repos/{}/{}/pulls", owner, name);
     let created_number = gh_rw(
-        dry,
+        execution_mode,
         [
             "api",
             &path,
@@ -1142,7 +1143,7 @@ pub fn upsert_pr_cached(
         .as_slice(),
     )?;
     let mut num: u64 = created_number.trim().parse().unwrap_or(0);
-    if num == 0 && !dry {
+    if num == 0 && execution_mode == ExecutionMode::Apply {
         if let Some(existing) = get_resolved_open_pr_match(branch)? {
             num = existing.number;
         }
@@ -1155,7 +1156,11 @@ pub fn upsert_pr_cached(
 }
 
 /// Append a warning line to a specific PR body (idempotent). Returns Ok(()) whether updated or skipped.
-pub fn append_warning_to_pr(number: u64, warning: &str, dry: bool) -> Result<()> {
+pub fn append_warning_to_pr(
+    number: u64,
+    warning: &str,
+    execution_mode: ExecutionMode,
+) -> Result<()> {
     let bodies = fetch_pr_bodies_graphql(&[number])?;
     if let Some(info) = bodies.get(&number) {
         let body = info.body.clone();
@@ -1177,7 +1182,7 @@ pub fn append_warning_to_pr(number: u64, warning: &str, dry: bool) -> Result<()>
         ));
         m.push('}');
         gh_rw(
-            dry,
+            execution_mode,
             ["api", "graphql", "-f", &format!("query={}", m)].as_slice(),
         )?;
         info!("Appended warning to PR #{}", number);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,13 @@ use clap::{error::ErrorKind, Parser};
 use std::ffi::OsString;
 use std::path::Path;
 
+use crate::execution::ExecutionMode;
+
 mod branch_names;
 mod cli;
 mod commands;
 mod config;
+mod execution;
 mod format;
 mod git;
 mod github;
@@ -103,8 +106,8 @@ fn init_tools(needs_gh: bool) -> Result<()> {
     Ok(())
 }
 
-fn set_dry_run_env(dry_run: bool, assume_existing_prs: bool) {
-    if dry_run {
+fn set_dry_run_env(execution_mode: ExecutionMode, assume_existing_prs: bool) {
+    if execution_mode == ExecutionMode::DryRun {
         std::env::set_var("SPR_DRY_RUN", "1");
         if assume_existing_prs {
             std::env::set_var("SPR_DRY_ASSUME_EXISTING", "1");
@@ -249,7 +252,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
     if let crate::cli::Cmd::Resume { path, .. } = &cli.cmd {
         return Ok(CommandOutput::Machine(ensure_resume_completed(
             output_format,
-            crate::commands::resume_rewrite(cli.dry_run, path)?,
+            crate::commands::resume_rewrite(path)?,
         )?));
     }
 
@@ -274,10 +277,12 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             assume_existing_prs,
             pr_description_mode: pr_description_mode_override,
             allow_branch_reuse,
+            dry_run,
             output: _,
             extent,
         } => {
-            set_dry_run_env(cli.dry_run, assume_existing_prs);
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, assume_existing_prs);
             let pr_description_mode = pr_description_mode_override.unwrap_or(pr_description_mode);
             if restack {
                 Err(anyhow::anyhow!(
@@ -323,7 +328,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         &prefix,
                         &skipped_handles,
                         no_pr,
-                        cli.dry_run,
+                        execution_mode,
                         pr_description_mode,
                         limit,
                         groups,
@@ -339,14 +344,14 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                             ignore_tag: ignore_tag.clone(),
                         },
                         crate::update_output::UpdateOptions {
-                            dry_run: cli.dry_run,
+                            dry_run: execution_mode == ExecutionMode::DryRun,
                             no_pr,
                             pr_description_mode,
                         },
                         resolved_extent,
                         execution,
                     );
-                    if !cli.dry_run {
+                    if execution_mode == ExecutionMode::Apply {
                         crate::stack_metadata::refresh_metadata_for_current_checkout(
                             &metadata_refresh_context.base,
                             &metadata_refresh_context.prefix,
@@ -362,7 +367,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         &prefix,
                         &skipped_handles,
                         no_pr,
-                        cli.dry_run,
+                        execution_mode,
                         pr_description_mode,
                         limit,
                         groups,
@@ -370,7 +375,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         allow_branch_reuse,
                         branch_reuse_guard_days,
                     )?;
-                    if !cli.dry_run {
+                    if execution_mode == ExecutionMode::Apply {
                         crate::stack_metadata::refresh_metadata_for_current_checkout(
                             &metadata_refresh_context.base,
                             &metadata_refresh_context.prefix,
@@ -385,9 +390,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             after,
             safe,
             preview,
+            dry_run,
             output: _,
         } => {
-            set_dry_run_env(cli.dry_run, false);
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             if preview {
                 Ok(CommandOutput::RestackPreview(
                     crate::restack_output::preview(crate::commands::preview_restack_after(
@@ -405,15 +412,20 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         &metadata_refresh_context,
                         &after,
                         safe,
-                        cli.dry_run,
+                        execution_mode,
                         restack_conflict_policy,
                         dirty_worktree_policy,
                     )?,
                 )?))
             }
         }
-        crate::cli::Cmd::DropMergedPrefix { safe, output: _ } => {
-            set_dry_run_env(cli.dry_run, false);
+        crate::cli::Cmd::DropMergedPrefix {
+            safe,
+            dry_run,
+            output: _,
+        } => {
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr drop-merged-prefix",
@@ -421,7 +433,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 crate::commands::drop_merged_prefix(
                     &metadata_refresh_context,
                     safe,
-                    cli.dry_run,
+                    execution_mode,
                     restack_conflict_policy,
                     dirty_worktree_policy,
                 )?,
@@ -429,9 +441,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
         }
         crate::cli::Cmd::Absorb {
             allow_replayed_duplicates,
+            dry_run,
             output: _,
         } => {
-            set_dry_run_env(cli.dry_run, false);
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             let options = crate::commands::AbsorbOptions {
                 copied_later_stack_commit_policy: if allow_replayed_duplicates {
                     crate::commands::CopiedLaterStackCommitPolicy::AllowKeepNonSeedDuplicates
@@ -447,14 +461,15 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &base,
                     &prefix,
                     &ignore_tag,
-                    cli.dry_run,
+                    execution_mode,
                     dirty_worktree_policy,
                     options,
                 )?,
             )?))
         }
-        crate::cli::Cmd::Prep { output: _ } => {
-            set_dry_run_env(cli.dry_run, false);
+        crate::cli::Cmd::Prep { dry_run, output: _ } => {
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             if cli.until.is_some() && cli.exact.is_some() {
                 return Err(anyhow::anyhow!("--until conflicts with --exact"));
             }
@@ -476,7 +491,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 pr_description_mode,
                 list_order,
                 selection,
-                cli.dry_run,
+                execution_mode,
             )?;
             if output_format == crate::cli::OutputFormat::Json {
                 Ok(CommandOutput::Maintenance(Box::new(
@@ -548,9 +563,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             which,
             r#unsafe,
             no_restack,
+            dry_run,
             output: _,
         } => {
-            set_dry_run_env(cli.dry_run, false);
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             let mode = which.unwrap_or(match cfg.land.as_str() {
                 "per-pr" | "perpr" | "per_pr" => crate::cli::LandCmd::PerPr,
                 _ => crate::cli::LandCmd::Flatten,
@@ -564,7 +581,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &prefix,
                     &ignore_tag,
                     &until,
-                    cli.dry_run,
+                    execution_mode,
                     r#unsafe,
                 )?,
                 crate::cli::LandCmd::PerPr => crate::commands::land_per_pr_until(
@@ -572,7 +589,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &prefix,
                     &ignore_tag,
                     &until,
-                    cli.dry_run,
+                    execution_mode,
                     r#unsafe,
                 )?,
             };
@@ -582,7 +599,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &metadata_refresh_context,
                     landed_count,
                     false,
-                    cli.dry_run,
+                    execution_mode,
                     restack_conflict_policy,
                     dirty_worktree_policy,
                 )?;
@@ -613,9 +630,10 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 ),
             ))
         }
-        crate::cli::Cmd::RelinkPrs { output: _ } => {
-            set_dry_run_env(cli.dry_run, false);
-            let summary = crate::commands::relink_prs(&base, &prefix, &ignore_tag, cli.dry_run)?;
+        crate::cli::Cmd::RelinkPrs { dry_run, output: _ } => {
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
+            let summary = crate::commands::relink_prs(&base, &prefix, &ignore_tag, execution_mode)?;
             if output_format == crate::cli::OutputFormat::Json {
                 Ok(CommandOutput::Maintenance(Box::new(
                     crate::maintenance_output::relink_prs_summary(summary),
@@ -625,9 +643,10 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 Ok(CommandOutput::None)
             }
         }
-        crate::cli::Cmd::Cleanup { output: _ } => {
-            set_dry_run_env(cli.dry_run, false);
-            let summary = crate::commands::cleanup_remote_branches(&prefix, cli.dry_run)?;
+        crate::cli::Cmd::Cleanup { dry_run, output: _ } => {
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
+            let summary = crate::commands::cleanup_remote_branches(&prefix, execution_mode)?;
             if output_format == crate::cli::OutputFormat::Json {
                 Ok(CommandOutput::Maintenance(Box::new(
                     crate::maintenance_output::cleanup_summary(summary),
@@ -641,9 +660,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             target,
             tail,
             safe,
+            dry_run,
             output: _,
         } => {
-            set_dry_run_env(cli.dry_run, false);
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr fix-pr",
@@ -653,7 +674,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &target,
                     tail,
                     safe,
-                    cli.dry_run,
+                    execution_mode,
                     dirty_worktree_policy,
                 )?,
             )?))
@@ -662,9 +683,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             range,
             after,
             safe,
+            dry_run,
             output: _,
         } => {
-            set_dry_run_env(cli.dry_run, false);
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr move",
@@ -677,7 +700,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &after,
                     crate::commands::MoveExecutionOptions {
                         safe,
-                        dry: cli.dry_run,
+                        execution_mode,
                         dirty_worktree_policy,
                     },
                 )?,
@@ -846,7 +869,7 @@ mod tests {
         apply_working_directory_override, command_requires_gh, json_command_for_raw_args,
         parse_failure_as_json_output, resolve_update_pr_limit, run_cli, CommandOutput,
     };
-    use crate::cli::{OutputArgs, OutputFormat};
+    use crate::cli::{DryRunArgs, OutputArgs, OutputFormat};
     use crate::json_output::{ErrorPayload, JsonCommand, JsonError, EXIT_FAILURE};
     use crate::maintenance_output::{
         MaintenancePayload, PrepNextChildAction, ResolvedPrepSelection,
@@ -983,6 +1006,7 @@ mod tests {
     fn absorb_is_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::Absorb {
             allow_replayed_duplicates: false,
+            dry_run: DryRunArgs::default(),
             output: OutputArgs::human(),
         }));
     }
@@ -991,6 +1015,7 @@ mod tests {
     fn drop_merged_prefix_requires_github_cli() {
         assert!(command_requires_gh(&crate::cli::Cmd::DropMergedPrefix {
             safe: true,
+            dry_run: DryRunArgs::default(),
             output: OutputArgs::human(),
         }));
     }
@@ -1019,6 +1044,7 @@ mod tests {
             assume_existing_prs: false,
             pr_description_mode: None,
             allow_branch_reuse: false,
+            dry_run: DryRunArgs::default(),
             output: OutputArgs::human(),
             extent: None,
         }));
@@ -1033,6 +1059,7 @@ mod tests {
             assume_existing_prs: false,
             pr_description_mode: None,
             allow_branch_reuse: false,
+            dry_run: DryRunArgs::default(),
             output: OutputArgs::json(),
             extent: None,
         }));
@@ -1396,10 +1423,10 @@ mod tests {
             "main",
             "--prefix",
             "dank-spr/",
-            "--dry-run",
             "--until",
             "1",
             "prep",
+            "--dry-run",
             "--json",
         ])
         .unwrap();
@@ -1909,8 +1936,8 @@ mod tests {
             "main",
             "--prefix",
             "dank-spr/",
-            "--dry-run",
             "update",
+            "--dry-run",
             "--json",
             "--no-pr",
         ])
@@ -1967,8 +1994,8 @@ mod tests {
             "main",
             "--prefix",
             "dank-spr/",
-            "--dry-run",
             "update",
+            "--dry-run",
             "--json",
             "--no-pr",
             "pr",
@@ -2004,8 +2031,8 @@ mod tests {
             "main",
             "--prefix",
             "dank-spr/",
-            "--dry-run",
             "update",
+            "--dry-run",
             "--json",
             "--no-pr",
             "pr",
@@ -2041,8 +2068,8 @@ mod tests {
             "main",
             "--prefix",
             "dank-spr/",
-            "--dry-run",
             "update",
+            "--dry-run",
             "--json",
             "--no-pr",
             "commits",


### PR DESCRIPTION
Restrict --dry-run to commands that can change local or GitHub state so read-only commands such as status, list, and resolve-stack reject a no-op flag instead of accepting it.

Parse DryRunArgs only at the Clap boundary, then thread ExecutionMode through mutating command, git, and GitHub write paths so execution policy is modeled explicitly outside CLI parsing.

Compatibility: the old global spelling spr --dry-run update is no longer accepted; use command-local spelling such as spr update --dry-run.

Validation: cargo check, cargo clippy --tests, cargo fmt, cargo test, final cargo clippy --tests.

<!-- spr-stack:start -->
**Stack**:
-   #129
-   #128
- ➡ #127

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->