### PR TITLE
cli: accept --json in user-expected positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,13 +346,25 @@ Behavior:
 
 Machine-readable `--json` mode:
 
-- Supported on `spr list pr`, `spr list commit`, `spr status`, `spr update`, `spr prep`,
-  `spr relink-prs`, `spr cleanup`, `spr restack`, `spr absorb`, `spr move`, `spr fix-pr`,
-  `spr land`, `spr resume`, and `spr resolve-stack`
+- `--json` is a global output mode. It can appear before the command, after the command, or
+  between a parent command and leaf subcommand, as long as it appears before a literal `--`
+  passthrough marker. For example, `spr --json status`, `spr status --json`,
+  `spr --json list commit`, `spr list --json commit`, and `spr list commit --json` are
+  equivalent. A `--json` token after `--` is preserved as payload and does not change `spr`
+  output mode.
+- Supported on operational commands including `spr list pr`, `spr list commit`, `spr status`,
+  `spr update`, `spr prep`, `spr relink-prs`, `spr cleanup`, `spr restack`, `spr absorb`,
+  `spr move`, `spr fix-pr`, `spr land`, `spr resume`, and `spr resolve-stack`
+- Also supported for display output: `spr --json --help`, `spr --help --json`,
+  `spr --json help list commit`, `spr list commit --help --json`, `spr --json --version`, and
+  `spr --version --json` each emit one structured JSON object
 - In `--json` mode, stdout is exactly one JSON object and stderr is normally empty
 - Summary-style commands (`list pr`, `list commit`, `status`, `update`, `prep`, `relink-prs`,
   and `cleanup`) share the same top-level shape: `schema_version`, `command`,
   `result: "summary"`, and `data`
+- JSON help uses `result: "help"` and includes the resolved command path, usage, options,
+  positionals, subcommands, aliases, and `rendered_text` containing Clap's normal human help
+- JSON version uses `result: "version"` and includes the binary name and Cargo package version
 - `spr list --json pr`, `spr list --json commit`, and `spr status --json` always emit canonical
   bottom-up stack order, even when `list_order: recent_on_top` changes the human display order.
   Each group's `remote.kind` encodes whether there is no matching PR, a PR without CI/review

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,23 +38,12 @@ pub enum OutputFormat {
 #[derive(Args, Debug, Clone, Copy, Default)]
 pub struct OutputArgs {
     /// Emit a single machine-readable JSON object to stdout
-    #[arg(long = "json")]
+    #[arg(long = "json", global = true)]
     json_requested: bool,
 }
 
 impl OutputArgs {
     #[cfg(test)]
-    pub fn human() -> Self {
-        Self::default()
-    }
-
-    #[cfg(test)]
-    pub fn json() -> Self {
-        Self {
-            json_requested: true,
-        }
-    }
-
     pub fn format(self) -> OutputFormat {
         if self.json_requested {
             OutputFormat::Json
@@ -125,9 +114,6 @@ pub enum Cmd {
         #[command(flatten)]
         dry_run: DryRunArgs,
 
-        #[command(flatten)]
-        output: OutputArgs,
-
         /// Limit how much to update (optional sub-mode)
         #[command(subcommand)]
         extent: Option<Extent>,
@@ -152,9 +138,6 @@ pub enum Cmd {
 
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Drop bottom PR groups whose GitHub PRs already merged, without landing or mutating PRs
@@ -168,9 +151,6 @@ pub enum Cmd {
 
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch
@@ -184,9 +164,6 @@ pub enum Cmd {
 
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Prepare PRs for landing (e.g., squash) and halt early on case-colliding synthetic branch names
@@ -194,9 +171,6 @@ pub enum Cmd {
         // selection is provided via global --until/--exact flags
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Resume a suspended local rewrite from a resume-state file
@@ -207,26 +181,18 @@ pub enum Cmd {
         /// Explicit path to the suspended rewrite's resume-state JSON file
         #[arg(value_name = "PATH")]
         path: PathBuf,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// List entities and halt early on case-colliding synthetic branch names
     #[command(alias = "ls")]
     List {
-        #[command(flatten)]
-        output: OutputArgs,
         #[command(subcommand)]
         what: ListWhat,
     },
 
     /// Status overview (alias for `list pr`) with the same early synthetic branch-collision guard
     #[command(alias = "stat")]
-    Status {
-        #[command(flatten)]
-        output: OutputArgs,
-    },
+    Status,
 
     /// Find the owning stack branch for a PR branch or report that the target is already a stack branch
     #[command(
@@ -235,8 +201,6 @@ pub enum Cmd {
     ResolveStack {
         /// Optional target: current branch, local branch, remote-qualified branch, or PR URL
         target: Option<String>,
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Land PRs (merge variants) and halt early on case-colliding synthetic branch names
@@ -252,17 +216,12 @@ pub enum Cmd {
         no_restack: bool,
         #[command(flatten)]
         dry_run: DryRunArgs,
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Relink PR stack to match local commit stack and halt early on case-colliding synthetic branch names
     RelinkPrs {
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Delete remote branches with the configured prefix whose PRs are all closed
@@ -270,9 +229,6 @@ pub enum Cmd {
     Cleanup {
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Move the last M commits (top of stack) to the tail of a selected PR group
@@ -288,8 +244,6 @@ pub enum Cmd {
         safe: bool,
         #[command(flatten)]
         dry_run: DryRunArgs,
-        #[command(flatten)]
-        output: OutputArgs,
     },
 
     /// Reorder local PR groups by moving one or a range to come after a target PR, halting early on case-colliding synthetic branch names
@@ -305,30 +259,7 @@ pub enum Cmd {
         safe: bool,
         #[command(flatten)]
         dry_run: DryRunArgs,
-        #[command(flatten)]
-        output: OutputArgs,
     },
-}
-
-impl Cmd {
-    pub fn output_format(&self) -> OutputFormat {
-        match self {
-            Self::Restack { output, .. }
-            | Self::DropMergedPrefix { output, .. }
-            | Self::Absorb { output, .. }
-            | Self::ResolveStack { output, .. }
-            | Self::Resume { output, .. }
-            | Self::Land { output, .. }
-            | Self::FixPr { output, .. }
-            | Self::Status { output, .. }
-            | Self::Prep { output, .. }
-            | Self::RelinkPrs { output, .. }
-            | Self::Cleanup { output, .. }
-            | Self::Move { output, .. } => output.format(),
-            Self::List { output, .. } => output.format(),
-            Self::Update { output, .. } => output.format(),
-        }
-    }
 }
 
 #[derive(Subcommand, Debug, Clone, Copy)]
@@ -364,6 +295,8 @@ pub struct Cli {
     /// Global exact (used by prep). Accepts a local PR number or a stable handle
     #[arg(long, global = true, value_name = "I|label|pr:<label>")]
     pub exact: Option<crate::selectors::GroupSelector>,
+    #[command(flatten)]
+    pub output: OutputArgs,
     #[command(subcommand)]
     pub cmd: Cmd,
 }
@@ -373,6 +306,7 @@ mod tests {
     use super::{Cli, Cmd, OutputFormat};
     use crate::execution::ExecutionMode;
     use clap::{CommandFactory, Parser};
+    use std::ffi::OsString;
     use std::path::PathBuf;
 
     #[test]
@@ -430,9 +364,9 @@ mod tests {
         .unwrap();
 
         match cli.cmd {
-            Cmd::Resume { path, output } => {
+            Cmd::Resume { path } => {
                 assert_eq!(path, PathBuf::from(".git/spr/resume/restack-example.json"));
-                assert_eq!(output.format(), OutputFormat::Json);
+                assert_eq!(cli.output.format(), OutputFormat::Json);
             }
             other => panic!("unexpected command: {:?}", other),
         }
@@ -452,16 +386,43 @@ mod tests {
     #[test]
     fn rewrite_commands_report_json_mode() {
         let restack = Cli::try_parse_from(["spr", "restack", "--after", "1", "--json"]).unwrap();
-        assert_eq!(restack.cmd.output_format(), OutputFormat::Json);
+        assert_eq!(restack.output.format(), OutputFormat::Json);
 
         let drop_merged = Cli::try_parse_from(["spr", "drop-merged-prefix", "--json"]).unwrap();
-        assert_eq!(drop_merged.cmd.output_format(), OutputFormat::Json);
+        assert_eq!(drop_merged.output.format(), OutputFormat::Json);
 
         let land = Cli::try_parse_from(["spr", "land", "--json"]).unwrap();
-        assert_eq!(land.cmd.output_format(), OutputFormat::Json);
+        assert_eq!(land.output.format(), OutputFormat::Json);
 
         let list = Cli::try_parse_from(["spr", "list", "--json", "pr"]).unwrap();
-        assert_eq!(list.cmd.output_format(), OutputFormat::Json);
+        assert_eq!(list.output.format(), OutputFormat::Json);
+    }
+
+    #[test]
+    fn json_prescan_accepts_all_documented_placements() {
+        let cases = [
+            vec!["spr", "--json", "status"],
+            vec!["spr", "status", "--json"],
+            vec!["spr", "--json", "list", "commit"],
+            vec!["spr", "list", "--json", "commit"],
+            vec!["spr", "list", "commit", "--json"],
+        ];
+
+        for case in cases {
+            let scan = crate::json_output::scan_json_output_request(
+                case.iter().map(OsString::from).collect(),
+            );
+            let cli = Cli::try_parse_from(scan.clap_args).unwrap();
+
+            assert!(scan.requested, "case did not request JSON: {case:?}");
+            assert!(matches!(
+                cli.cmd,
+                Cmd::Status
+                    | Cmd::List {
+                        what: super::ListWhat::Commit
+                    }
+            ));
+        }
     }
 
     #[test]
@@ -483,13 +444,12 @@ mod tests {
                 safe,
                 preview,
                 dry_run,
-                output,
             } => {
                 assert_eq!(after.to_string(), "pr:alpha");
                 assert!(safe);
                 assert!(preview);
                 assert_eq!(ExecutionMode::from(dry_run), ExecutionMode::Apply);
-                assert_eq!(output.format(), OutputFormat::Json);
+                assert_eq!(cli.output.format(), OutputFormat::Json);
             }
             other => panic!("unexpected command: {:?}", other),
         }
@@ -537,7 +497,7 @@ mod tests {
     fn update_json_flag_enables_json_mode() {
         let cli = Cli::try_parse_from(["spr", "update", "--json"]).unwrap();
 
-        assert_eq!(cli.cmd.output_format(), OutputFormat::Json);
+        assert_eq!(cli.output.format(), OutputFormat::Json);
     }
 
     #[test]
@@ -546,11 +506,10 @@ mod tests {
 
         match cli.cmd {
             Cmd::Update {
-                output,
                 extent: Some(super::Extent::Pr { legacy_n, .. }),
                 ..
             } => {
-                assert_eq!(output.format(), OutputFormat::Json);
+                assert_eq!(cli.output.format(), OutputFormat::Json);
                 assert_eq!(legacy_n, Some(1));
             }
             other => panic!("unexpected command: {:?}", other),
@@ -563,10 +522,9 @@ mod tests {
 
         match cli.cmd {
             Cmd::List {
-                output,
                 what: super::ListWhat::Pr,
             } => {
-                assert_eq!(output.format(), OutputFormat::Json);
+                assert_eq!(cli.output.format(), OutputFormat::Json);
             }
             other => panic!("unexpected command: {:?}", other),
         }
@@ -578,20 +536,25 @@ mod tests {
 
         match cli.cmd {
             Cmd::List {
-                output,
                 what: super::ListWhat::Commit,
             } => {
-                assert_eq!(output.format(), OutputFormat::Json);
+                assert_eq!(cli.output.format(), OutputFormat::Json);
             }
             other => panic!("unexpected command: {:?}", other),
         }
     }
 
     #[test]
-    fn list_json_flag_after_leaf_subcommand_is_rejected() {
-        let err = Cli::try_parse_from(["spr", "list", "pr", "--json"]).unwrap_err();
+    fn list_json_flag_after_leaf_subcommand_is_global() {
+        let cli = Cli::try_parse_from(["spr", "list", "pr", "--json"]).unwrap();
 
-        assert!(err.to_string().contains("unexpected argument '--json'"));
+        assert!(matches!(
+            cli.cmd,
+            Cmd::List {
+                what: super::ListWhat::Pr
+            }
+        ));
+        assert_eq!(cli.output.format(), OutputFormat::Json);
     }
 
     #[test]
@@ -599,19 +562,16 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "status", "--json"]).unwrap();
 
         match cli.cmd {
-            Cmd::Status { output } => {
-                assert_eq!(output.format(), OutputFormat::Json);
-            }
+            Cmd::Status => assert_eq!(cli.output.format(), OutputFormat::Json),
             other => panic!("unexpected command: {:?}", other),
         }
     }
 
     #[test]
-    fn update_help_includes_json_flag() {
-        let mut cli = Cli::command();
-        let update = cli.find_subcommand_mut("update").unwrap();
+    fn root_help_includes_json_flag() {
+        let cli = Cli::command();
 
-        assert!(update
+        assert!(cli
             .get_arguments()
             .any(|argument| argument.get_long() == Some("json")));
     }
@@ -641,10 +601,8 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "status", "--cd", "/tmp/example"]).unwrap();
 
         assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
-        assert!(matches!(
-            cli.cmd,
-            Cmd::Status { output } if output.format() == OutputFormat::Human
-        ));
+        assert!(matches!(cli.cmd, Cmd::Status));
+        assert_eq!(cli.output.format(), OutputFormat::Human);
     }
 
     #[test]
@@ -652,9 +610,7 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "--cd", "/tmp/example", "status"]).unwrap();
 
         assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
-        assert!(matches!(
-            cli.cmd,
-            Cmd::Status { output } if output.format() == OutputFormat::Human
-        ));
+        assert!(matches!(cli.cmd, Cmd::Status));
+        assert_eq!(cli.output.format(), OutputFormat::Human);
     }
 }

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -1,3 +1,5 @@
+use anyhow::{anyhow, Result};
+use clap::{Arg, Command, CommandFactory};
 use serde::Serialize;
 use std::ffi::{OsStr, OsString};
 
@@ -10,6 +12,8 @@ pub const EXIT_SUSPENDED: i32 = 2;
 #[serde(rename_all = "kebab-case")]
 pub enum JsonCommand {
     Cli,
+    Help,
+    Version,
     Restack,
     DropMergedPrefix,
     Absorb,
@@ -26,6 +30,96 @@ pub enum JsonCommand {
     Prep,
     RelinkPrs,
     Cleanup,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Result of scanning raw argv for a global JSON output request before Clap parsing.
+///
+/// `clap_args` preserves argv order except for exact `--json` tokens before the first literal
+/// `--`. Tokens after `--` are passthrough payload and remain untouched.
+pub struct JsonArgScan {
+    pub requested: bool,
+    pub clap_args: Vec<OsString>,
+}
+
+/// Non-operational JSON result kinds for display-only CLI output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisplayResult {
+    Help,
+    Version,
+}
+
+/// Structured JSON representation of Clap help for a resolved command path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HelpOutput {
+    pub schema_version: u32,
+    pub command: JsonCommand,
+    pub result: DisplayResult,
+    pub data: HelpData,
+}
+
+/// Agent-oriented command metadata plus Clap's rendered human help text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HelpData {
+    pub command_path: Vec<String>,
+    pub name: String,
+    pub about: Option<String>,
+    pub long_about: Option<String>,
+    pub usage: String,
+    pub aliases: Vec<String>,
+    pub options: Vec<HelpOption>,
+    pub positionals: Vec<HelpPositional>,
+    pub subcommands: Vec<HelpSubcommand>,
+    pub rendered_text: String,
+}
+
+/// Structured metadata for an option accepted by a command or inherited globally.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HelpOption {
+    pub long: Option<String>,
+    pub short: Option<char>,
+    pub value_name: Option<String>,
+    pub required: bool,
+    pub global: bool,
+    pub help: Option<String>,
+    pub default_values: Vec<String>,
+    pub possible_values: Vec<String>,
+}
+
+/// Structured metadata for a positional argument accepted by a command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HelpPositional {
+    pub name: String,
+    pub value_name: Option<String>,
+    pub required: bool,
+    pub help: Option<String>,
+    pub possible_values: Vec<String>,
+}
+
+/// Structured metadata for a visible subcommand of the resolved help target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HelpSubcommand {
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub about: Option<String>,
+    pub has_subcommands: bool,
+}
+
+/// Structured JSON representation of binary version output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VersionOutput {
+    pub schema_version: u32,
+    pub command: JsonCommand,
+    pub result: DisplayResult,
+    pub data: VersionData,
+}
+
+/// Package identity reported by JSON version output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VersionData {
+    pub name: String,
+    pub version: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -108,6 +202,72 @@ impl ErrorOutput {
     }
 }
 
+impl HelpOutput {
+    pub fn exit_code(&self) -> i32 {
+        EXIT_SUCCESS
+    }
+}
+
+impl VersionOutput {
+    pub fn exit_code(&self) -> i32 {
+        EXIT_SUCCESS
+    }
+}
+
+/// Detect and remove global `--json` tokens before Clap handles display exits or parse errors.
+pub fn scan_json_output_request(args: Vec<OsString>) -> JsonArgScan {
+    struct ScanState {
+        requested: bool,
+        clap_args: Vec<OsString>,
+        passthrough: bool,
+    }
+
+    let state = args.into_iter().fold(
+        ScanState {
+            requested: false,
+            clap_args: Vec::new(),
+            passthrough: false,
+        },
+        |state, arg| {
+            let ScanState {
+                requested,
+                clap_args,
+                passthrough,
+            } = state;
+            if passthrough {
+                ScanState {
+                    requested,
+                    clap_args: clap_args.into_iter().chain(std::iter::once(arg)).collect(),
+                    passthrough,
+                }
+            } else if arg.as_os_str() == OsStr::new("--json") {
+                ScanState {
+                    requested: true,
+                    clap_args,
+                    passthrough,
+                }
+            } else if arg.as_os_str() == OsStr::new("--") {
+                ScanState {
+                    requested,
+                    clap_args: clap_args.into_iter().chain(std::iter::once(arg)).collect(),
+                    passthrough: true,
+                }
+            } else {
+                ScanState {
+                    requested,
+                    clap_args: clap_args.into_iter().chain(std::iter::once(arg)).collect(),
+                    passthrough,
+                }
+            }
+        },
+    );
+
+    JsonArgScan {
+        requested: state.requested,
+        clap_args: state.clap_args,
+    }
+}
+
 pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
     let mut skip_value = false;
     let mut saw_list = false;
@@ -115,7 +275,19 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
         if skip_value {
             skip_value = false;
         } else if let Some(arg) = arg.to_str() {
-            if arg == "--cd"
+            if arg == "--" {
+                return if saw_list {
+                    JsonCommand::List
+                } else {
+                    JsonCommand::Cli
+                };
+            } else if arg == "--json" {
+                continue;
+            } else if arg == "--version" || arg == "-V" {
+                return JsonCommand::Version;
+            } else if arg == "--help" || arg == "-h" || arg == "help" {
+                return JsonCommand::Help;
+            } else if arg == "--cd"
                 || arg == "--base"
                 || arg == "--prefix"
                 || arg == "--until"
@@ -170,15 +342,229 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
     }
 }
 
-pub fn raw_args_request_json(args: &[OsString]) -> bool {
-    args.iter()
-        .skip(1)
-        .any(|arg| arg.as_os_str() == OsStr::new("--json"))
+/// Build structured help output for either `spr help <path>` or `<path> --help`.
+pub fn help_output_for_args(args: &[OsString]) -> Result<HelpOutput> {
+    let scan = scan_json_output_request(args.to_vec());
+    let tokens = help_command_tokens(&scan.clap_args);
+    let root = crate::cli::Cli::command();
+    let global_options = root
+        .get_arguments()
+        .filter(|arg| arg.is_global_set() && !arg.is_hide_set())
+        .map(help_option)
+        .collect();
+    let (command_path, command) = resolve_command_path(root, &tokens)?;
+    Ok(HelpOutput {
+        schema_version: JSON_OUTPUT_SCHEMA_VERSION,
+        command: JsonCommand::Help,
+        result: DisplayResult::Help,
+        data: help_data(command_path, command, global_options),
+    })
+}
+
+/// Build structured version output from Cargo package metadata.
+pub fn version_output() -> VersionOutput {
+    VersionOutput {
+        schema_version: JSON_OUTPUT_SCHEMA_VERSION,
+        command: JsonCommand::Version,
+        result: DisplayResult::Version,
+        data: VersionData {
+            name: env!("CARGO_PKG_NAME").to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+    }
+}
+
+fn help_command_tokens(args: &[OsString]) -> Vec<String> {
+    let mut command = crate::cli::Cli::command();
+    let mut tokens = Vec::new();
+    let mut skip_value = false;
+    let mut help_subcommand = false;
+    for arg in args.iter().skip(1) {
+        if arg.as_os_str() == OsStr::new("--") {
+            break;
+        } else if skip_value {
+            skip_value = false;
+        } else if let Some(arg) = arg.to_str() {
+            if help_subcommand {
+                tokens.push(arg.to_string());
+            } else if arg == "help" {
+                tokens.clear();
+                help_subcommand = true;
+            } else if arg == "--help" || arg == "-h" {
+                break;
+            } else if let Some(subcommand) = matching_subcommand(&command, arg) {
+                tokens.push(subcommand.get_name().to_string());
+                command = subcommand.clone();
+            } else if option_consumes_value(&command, arg) {
+                skip_value = true;
+            }
+        }
+    }
+    tokens
+}
+
+fn resolve_command_path(root: Command, tokens: &[String]) -> Result<(Vec<String>, Command)> {
+    tokens.iter().try_fold(
+        (vec![root.get_name().to_string()], root),
+        |(command_path, command), token| {
+            if let Some(subcommand) = matching_subcommand(&command, token) {
+                let next_command = subcommand.clone();
+                let next_path = command_path
+                    .into_iter()
+                    .chain(std::iter::once(next_command.get_name().to_string()))
+                    .collect();
+                Ok((next_path, next_command))
+            } else {
+                Err(anyhow!("unknown help command path component `{token}`"))
+            }
+        },
+    )
+}
+
+fn matching_subcommand<'a>(command: &'a Command, token: &str) -> Option<&'a Command> {
+    command.get_subcommands().find(|subcommand| {
+        subcommand.get_name() == token || subcommand.get_all_aliases().any(|alias| alias == token)
+    })
+}
+
+fn option_consumes_value(command: &Command, token: &str) -> bool {
+    if let Some(long) = token.strip_prefix("--") {
+        if token.contains('=') {
+            false
+        } else {
+            let name = long.split('=').next().unwrap_or(long);
+            command
+                .get_arguments()
+                .find(|arg| arg.get_long() == Some(name))
+                .map(arg_takes_value)
+                .unwrap_or(false)
+        }
+    } else if let Some(short) = token.strip_prefix('-') {
+        if short.chars().count() == 1 {
+            let short = short.chars().next().unwrap();
+            command
+                .get_arguments()
+                .find(|arg| arg.get_short() == Some(short))
+                .map(arg_takes_value)
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+fn arg_takes_value(arg: &Arg) -> bool {
+    arg.get_num_args().is_some() || arg.get_value_names().is_some()
+}
+
+fn help_data(
+    command_path: Vec<String>,
+    command: Command,
+    inherited_options: Vec<HelpOption>,
+) -> HelpData {
+    let mut usage_command = command.clone();
+    let mut help_command = command.clone();
+    let options = if command_path.len() == 1 {
+        command
+            .get_arguments()
+            .filter(|arg| !arg.is_positional() && !arg.is_hide_set())
+            .map(help_option)
+            .collect()
+    } else {
+        inherited_options
+            .into_iter()
+            .chain(
+                command
+                    .get_arguments()
+                    .filter(|arg| !arg.is_positional() && !arg.is_hide_set())
+                    .map(help_option),
+            )
+            .collect()
+    };
+    HelpData {
+        command_path,
+        name: command.get_name().to_string(),
+        about: command.get_about().map(ToString::to_string),
+        long_about: command.get_long_about().map(ToString::to_string),
+        usage: usage_command.render_usage().to_string(),
+        aliases: command.get_all_aliases().map(ToString::to_string).collect(),
+        options,
+        positionals: command
+            .get_arguments()
+            .filter(|arg| arg.is_positional() && !arg.is_hide_set())
+            .map(help_positional)
+            .collect(),
+        subcommands: command
+            .get_subcommands()
+            .filter(|subcommand| !subcommand.is_hide_set())
+            .map(help_subcommand)
+            .collect(),
+        rendered_text: help_command.render_help().to_string(),
+    }
+}
+
+fn help_option(arg: &Arg) -> HelpOption {
+    HelpOption {
+        long: arg.get_long().map(ToString::to_string),
+        short: arg.get_short(),
+        value_name: value_name(arg),
+        required: arg.is_required_set(),
+        global: arg.is_global_set(),
+        help: arg.get_help().map(ToString::to_string),
+        default_values: default_values(arg),
+        possible_values: possible_values(arg),
+    }
+}
+
+fn help_positional(arg: &Arg) -> HelpPositional {
+    HelpPositional {
+        name: arg.get_id().to_string(),
+        value_name: value_name(arg),
+        required: arg.is_required_set(),
+        help: arg.get_help().map(ToString::to_string),
+        possible_values: possible_values(arg),
+    }
+}
+
+fn help_subcommand(command: &Command) -> HelpSubcommand {
+    HelpSubcommand {
+        name: command.get_name().to_string(),
+        aliases: command.get_all_aliases().map(ToString::to_string).collect(),
+        about: command.get_about().map(ToString::to_string),
+        has_subcommands: command.get_subcommands().next().is_some(),
+    }
+}
+
+fn value_name(arg: &Arg) -> Option<String> {
+    arg.get_value_names()
+        .map(|names| names.iter().map(ToString::to_string).collect::<Vec<_>>())
+        .filter(|names| !names.is_empty())
+        .map(|names| names.join(" "))
+}
+
+fn default_values(arg: &Arg) -> Vec<String> {
+    arg.get_default_values()
+        .iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn possible_values(arg: &Arg) -> Vec<String> {
+    arg.get_possible_values()
+        .into_iter()
+        .filter(|value| !value.is_hide_set())
+        .map(|value| value.get_name().to_string())
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{command_for_raw_args, raw_args_request_json, JsonCommand};
+    use super::{
+        command_for_raw_args, help_output_for_args, scan_json_output_request, version_output,
+        DisplayResult, JsonCommand,
+    };
     use std::ffi::OsString;
 
     #[test]
@@ -230,6 +616,113 @@ mod tests {
             OsString::from("--json"),
         ];
 
-        assert!(raw_args_request_json(&args));
+        assert!(scan_json_output_request(args).requested);
+    }
+
+    #[test]
+    fn scan_json_output_request_removes_json_before_passthrough() {
+        let scan = scan_json_output_request(vec![
+            OsString::from("spr"),
+            OsString::from("--json"),
+            OsString::from("list"),
+            OsString::from("commit"),
+            OsString::from("--"),
+            OsString::from("--json"),
+        ]);
+
+        assert!(scan.requested);
+        assert_eq!(
+            scan.clap_args,
+            vec![
+                OsString::from("spr"),
+                OsString::from("list"),
+                OsString::from("commit"),
+                OsString::from("--"),
+                OsString::from("--json"),
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_json_output_request_is_idempotent_before_passthrough() {
+        let scan = scan_json_output_request(vec![
+            OsString::from("spr"),
+            OsString::from("--json"),
+            OsString::from("--json"),
+            OsString::from("status"),
+        ]);
+
+        assert!(scan.requested);
+        assert_eq!(
+            scan.clap_args,
+            vec![OsString::from("spr"), OsString::from("status")]
+        );
+    }
+
+    #[test]
+    fn raw_args_do_not_detect_json_after_passthrough() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("status"),
+            OsString::from("--"),
+            OsString::from("--json"),
+        ];
+
+        assert!(!scan_json_output_request(args).requested);
+    }
+
+    #[test]
+    fn command_detection_ignores_json_and_stops_at_passthrough() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("--json"),
+            OsString::from("--"),
+            OsString::from("status"),
+        ];
+
+        assert_eq!(command_for_raw_args(&args), JsonCommand::Cli);
+    }
+
+    #[test]
+    fn help_output_resolves_help_subcommand_path() {
+        let output = help_output_for_args(&[
+            OsString::from("spr"),
+            OsString::from("--json"),
+            OsString::from("help"),
+            OsString::from("list"),
+            OsString::from("commit"),
+        ])
+        .unwrap();
+
+        assert_eq!(output.command, JsonCommand::Help);
+        assert_eq!(output.result, DisplayResult::Help);
+        assert_eq!(output.data.command_path, ["spr", "list", "commit"]);
+        assert_eq!(output.data.name, "commit");
+        assert!(!output.data.rendered_text.is_empty());
+    }
+
+    #[test]
+    fn help_output_resolves_trailing_help_path() {
+        let output = help_output_for_args(&[
+            OsString::from("spr"),
+            OsString::from("list"),
+            OsString::from("commit"),
+            OsString::from("--help"),
+            OsString::from("--json"),
+        ])
+        .unwrap();
+
+        assert_eq!(output.data.command_path, ["spr", "list", "commit"]);
+        assert!(!output.data.options.is_empty());
+    }
+
+    #[test]
+    fn version_output_uses_package_metadata() {
+        let output = version_output();
+
+        assert_eq!(output.command, JsonCommand::Version);
+        assert_eq!(output.result, DisplayResult::Version);
+        assert_eq!(output.data.name, "spr");
+        assert_eq!(output.data.version, env!("CARGO_PKG_VERSION"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{error::ErrorKind, Parser};
+use serde::Serialize;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -70,13 +71,13 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
         | crate::cli::Cmd::Absorb { .. }
         | crate::cli::Cmd::Resume { .. }
         | crate::cli::Cmd::FixPr { .. } => false,
-        crate::cli::Cmd::ResolveStack { target, .. } => target
+        crate::cli::Cmd::ResolveStack { target } => target
             .as_deref()
             .map(crate::commands::looks_like_pr_url)
             .unwrap_or(false),
         crate::cli::Cmd::Update { no_pr, .. } => !*no_pr,
         crate::cli::Cmd::List { .. }
-        | crate::cli::Cmd::Status { .. }
+        | crate::cli::Cmd::Status
         | crate::cli::Cmd::Prep { .. }
         | crate::cli::Cmd::DropMergedPrefix { .. }
         | crate::cli::Cmd::Land { .. }
@@ -278,7 +279,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             pr_description_mode: pr_description_mode_override,
             allow_branch_reuse,
             dry_run,
-            output: _,
             extent,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
@@ -391,7 +391,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             safe,
             preview,
             dry_run,
-            output: _,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
@@ -419,11 +418,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 )?))
             }
         }
-        crate::cli::Cmd::DropMergedPrefix {
-            safe,
-            dry_run,
-            output: _,
-        } => {
+        crate::cli::Cmd::DropMergedPrefix { safe, dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
@@ -442,7 +437,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
         crate::cli::Cmd::Absorb {
             allow_replayed_duplicates,
             dry_run,
-            output: _,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
@@ -467,7 +461,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 )?,
             )?))
         }
-        crate::cli::Cmd::Prep { dry_run, output: _ } => {
+        crate::cli::Cmd::Prep { dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
             if cli.until.is_some() && cli.exact.is_some() {
@@ -539,7 +533,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 Ok(CommandOutput::None)
             }
         }
-        crate::cli::Cmd::Status { output: _ } => {
+        crate::cli::Cmd::Status => {
             if output_format == crate::cli::OutputFormat::Json {
                 match read_only_pr_list_output(
                     crate::json_output::JsonCommand::Status,
@@ -555,7 +549,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 Ok(CommandOutput::None)
             }
         }
-        crate::cli::Cmd::ResolveStack { target, output: _ } => Ok(CommandOutput::ResolveStack(
+        crate::cli::Cmd::ResolveStack { target } => Ok(CommandOutput::ResolveStack(
             crate::commands::resolve_stack(target, &ignore_tag)?,
         )),
         crate::cli::Cmd::Resume { .. } => unreachable!("handled before config loading"),
@@ -564,7 +558,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             r#unsafe,
             no_restack,
             dry_run,
-            output: _,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
@@ -630,7 +623,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 ),
             ))
         }
-        crate::cli::Cmd::RelinkPrs { dry_run, output: _ } => {
+        crate::cli::Cmd::RelinkPrs { dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
             let summary = crate::commands::relink_prs(&base, &prefix, &ignore_tag, execution_mode)?;
@@ -643,7 +636,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 Ok(CommandOutput::None)
             }
         }
-        crate::cli::Cmd::Cleanup { dry_run, output: _ } => {
+        crate::cli::Cmd::Cleanup { dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
             let summary = crate::commands::cleanup_remote_branches(&prefix, execution_mode)?;
@@ -661,7 +654,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             tail,
             safe,
             dry_run,
-            output: _,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
@@ -684,7 +676,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             after,
             safe,
             dry_run,
-            output: _,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
@@ -734,23 +725,20 @@ fn init_logging(verbose: bool, output_format: crate::cli::OutputFormat) {
     }
 }
 
-fn raw_args_request_json(args: &[OsString]) -> bool {
-    crate::json_output::raw_args_request_json(args)
-}
-
 fn json_command_for_raw_args(args: &[OsString]) -> crate::json_output::JsonCommand {
     crate::json_output::command_for_raw_args(args)
 }
 
 fn parse_failure_as_json_output(
     args: &[OsString],
+    json_requested: bool,
     err: &clap::Error,
 ) -> Option<crate::json_output::ErrorOutput> {
     let is_display_only = matches!(
         err.kind(),
         ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
     );
-    if raw_args_request_json(args) && !is_display_only {
+    if json_requested && !is_display_only {
         Some(crate::json_output::ErrorOutput::invalid_arguments(
             json_command_for_raw_args(args),
             err.to_string(),
@@ -760,20 +748,45 @@ fn parse_failure_as_json_output(
     }
 }
 
+fn exit_with_json<T: Serialize>(output: &T, exit_code: i32) -> ! {
+    println!("{}", serde_json::to_string(output).unwrap());
+    std::process::exit(exit_code);
+}
+
 fn main() {
     let raw_args: Vec<OsString> = std::env::args_os().collect();
-    let cli = match crate::cli::Cli::try_parse_from(raw_args.clone()) {
+    let json_scan = crate::json_output::scan_json_output_request(raw_args.clone());
+    let cli = match crate::cli::Cli::try_parse_from(json_scan.clap_args.clone()) {
         Ok(cli) => cli,
         Err(err) => {
-            if let Some(output) = parse_failure_as_json_output(&raw_args, &err) {
-                println!("{}", serde_json::to_string(&output).unwrap());
-                std::process::exit(output.exit_code());
+            if json_scan.requested && err.kind() == ErrorKind::DisplayHelp {
+                match crate::json_output::help_output_for_args(&raw_args) {
+                    Ok(output) => exit_with_json(&output, output.exit_code()),
+                    Err(err) => {
+                        let output = crate::json_output::ErrorOutput::internal(
+                            crate::json_output::JsonCommand::Help,
+                            format!("{err:#}"),
+                        );
+                        exit_with_json(&output, output.exit_code());
+                    }
+                }
+            } else if json_scan.requested && err.kind() == ErrorKind::DisplayVersion {
+                let output = crate::json_output::version_output();
+                exit_with_json(&output, output.exit_code());
+            } else if let Some(output) =
+                parse_failure_as_json_output(&raw_args, json_scan.requested, &err)
+            {
+                exit_with_json(&output, output.exit_code());
             } else {
                 err.exit();
             }
         }
     };
-    let output_format = cli.cmd.output_format();
+    let output_format = if json_scan.requested {
+        crate::cli::OutputFormat::Json
+    } else {
+        crate::cli::OutputFormat::Human
+    };
     init_logging(cli.verbose, output_format);
     let command = json_command_for_cli(&cli.cmd);
     match run_cli(cli, output_format) {
@@ -781,46 +794,39 @@ fn main() {
             CommandOutput::None => {}
             CommandOutput::Machine(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(output.exit_code());
+                    exit_with_json(&output, output.exit_code());
                 }
             }
             CommandOutput::ReadOnly(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(output.exit_code());
+                    exit_with_json(&output, output.exit_code());
                 }
             }
             CommandOutput::RestackPreview(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(output.exit_code());
+                    exit_with_json(&output, output.exit_code());
                 } else {
                     println!("{}", output.render_human());
                 }
             }
             CommandOutput::Update(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(output.exit_code());
+                    exit_with_json(&output, output.exit_code());
                 }
             }
             CommandOutput::Maintenance(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(output.exit_code());
+                    exit_with_json(&output, output.exit_code());
                 }
             }
             CommandOutput::Error(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(output.exit_code());
+                    exit_with_json(&output, output.exit_code());
                 }
             }
             CommandOutput::ResolveStack(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
-                    println!("{}", serde_json::to_string(&output).unwrap());
-                    std::process::exit(crate::json_output::EXIT_SUCCESS);
+                    exit_with_json(&output, crate::json_output::EXIT_SUCCESS);
                 } else {
                     println!("{}", output.render_human());
                 }
@@ -829,8 +835,7 @@ fn main() {
         Err(err) => {
             if output_format == crate::cli::OutputFormat::Json {
                 let output = crate::json_output::ErrorOutput::internal(command, format!("{err:#}"));
-                println!("{}", serde_json::to_string(&output).unwrap());
-                std::process::exit(output.exit_code());
+                exit_with_json(&output, output.exit_code());
             } else {
                 eprintln!("Error: {err:#}");
                 std::process::exit(crate::json_output::EXIT_FAILURE);
@@ -857,7 +862,7 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
             crate::cli::ListWhat::Pr => crate::machine_output::MachineCommand::ListPr,
             crate::cli::ListWhat::Commit => crate::machine_output::MachineCommand::ListCommit,
         },
-        crate::cli::Cmd::Status { .. } => crate::machine_output::MachineCommand::Status,
+        crate::cli::Cmd::Status => crate::machine_output::MachineCommand::Status,
         crate::cli::Cmd::RelinkPrs { .. } => crate::machine_output::MachineCommand::RelinkPrs,
         crate::cli::Cmd::Cleanup { .. } => crate::machine_output::MachineCommand::Cleanup,
     }
@@ -869,7 +874,7 @@ mod tests {
         apply_working_directory_override, command_requires_gh, json_command_for_raw_args,
         parse_failure_as_json_output, resolve_update_pr_limit, run_cli, CommandOutput,
     };
-    use crate::cli::{DryRunArgs, OutputArgs, OutputFormat};
+    use crate::cli::{DryRunArgs, OutputFormat};
     use crate::json_output::{ErrorPayload, JsonCommand, JsonError, EXIT_FAILURE};
     use crate::maintenance_output::{
         MaintenancePayload, PrepNextChildAction, ResolvedPrepSelection,
@@ -1007,7 +1012,6 @@ mod tests {
         assert!(!command_requires_gh(&crate::cli::Cmd::Absorb {
             allow_replayed_duplicates: false,
             dry_run: DryRunArgs::default(),
-            output: OutputArgs::human(),
         }));
     }
 
@@ -1016,7 +1020,6 @@ mod tests {
         assert!(command_requires_gh(&crate::cli::Cmd::DropMergedPrefix {
             safe: true,
             dry_run: DryRunArgs::default(),
-            output: OutputArgs::human(),
         }));
     }
 
@@ -1024,15 +1027,12 @@ mod tests {
     fn resume_is_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::Resume {
             path: std::path::PathBuf::from(".git/spr/resume/example.json"),
-            output: OutputArgs::human(),
         }));
     }
 
     #[test]
     fn status_requires_github_cli() {
-        assert!(command_requires_gh(&crate::cli::Cmd::Status {
-            output: OutputArgs::human()
-        }));
+        assert!(command_requires_gh(&crate::cli::Cmd::Status));
     }
 
     #[test]
@@ -1045,7 +1045,6 @@ mod tests {
             pr_description_mode: None,
             allow_branch_reuse: false,
             dry_run: DryRunArgs::default(),
-            output: OutputArgs::human(),
             extent: None,
         }));
     }
@@ -1060,7 +1059,6 @@ mod tests {
             pr_description_mode: None,
             allow_branch_reuse: false,
             dry_run: DryRunArgs::default(),
-            output: OutputArgs::json(),
             extent: None,
         }));
     }
@@ -1069,7 +1067,6 @@ mod tests {
     fn resolve_stack_without_pr_url_stays_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::ResolveStack {
             target: Some("dank-spr/alpha".to_string()),
-            output: OutputArgs::human(),
         }));
     }
 
@@ -1077,7 +1074,6 @@ mod tests {
     fn resolve_stack_pr_url_requires_github_cli() {
         assert!(command_requires_gh(&crate::cli::Cmd::ResolveStack {
             target: Some("https://github.com/o/r/pull/17".to_string()),
-            output: OutputArgs::json(),
         }));
     }
 
@@ -1241,8 +1237,8 @@ mod tests {
             OsString::from("--json"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output =
-            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+        let output = parse_failure_as_json_output(&args, true, &err)
+            .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::Restack);
         match output.payload {
@@ -1266,8 +1262,8 @@ mod tests {
             OsString::from("--bogus"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output =
-            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+        let output = parse_failure_as_json_output(&args, true, &err)
+            .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::ListPr);
         assert_eq!(output.schema_version, 1);
@@ -1291,8 +1287,8 @@ mod tests {
             OsString::from("--bogus"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output =
-            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+        let output = parse_failure_as_json_output(&args, true, &err)
+            .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::Update);
     }
@@ -1306,8 +1302,8 @@ mod tests {
             OsString::from("--bogus"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output =
-            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+        let output = parse_failure_as_json_output(&args, true, &err)
+            .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::Prep);
     }
@@ -1321,8 +1317,8 @@ mod tests {
             OsString::from("--bogus"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output =
-            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+        let output = parse_failure_as_json_output(&args, true, &err)
+            .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::RelinkPrs);
     }
@@ -1336,8 +1332,8 @@ mod tests {
             OsString::from("--bogus"),
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
-        let output =
-            parse_failure_as_json_output(&args, &err).expect("json parse failure should serialize");
+        let output = parse_failure_as_json_output(&args, true, &err)
+            .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::Cleanup);
     }
@@ -1347,11 +1343,11 @@ mod tests {
         let args = vec![OsString::from("spr"), OsString::from("restack")];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected parse error");
 
-        assert!(parse_failure_as_json_output(&args, &err).is_none());
+        assert!(parse_failure_as_json_output(&args, false, &err).is_none());
     }
 
     #[test]
-    fn help_request_with_json_stays_human() {
+    fn help_request_with_json_is_not_parse_failure() {
         let args = vec![
             OsString::from("spr"),
             OsString::from("restack"),
@@ -1360,7 +1356,7 @@ mod tests {
         ];
         let err = crate::cli::Cli::try_parse_from(args.clone()).expect_err("expected help output");
 
-        assert!(parse_failure_as_json_output(&args, &err).is_none());
+        assert!(parse_failure_as_json_output(&args, true, &err).is_none());
     }
 
     fn init_local_stack_repo() -> TempDir {

--- a/tests/global_json.rs
+++ b/tests/global_json.rs
@@ -1,0 +1,93 @@
+use serde_json::Value;
+use std::process::Command;
+
+fn run_spr(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_spr"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn stdout_json(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn json_help_outputs_structured_root_help() {
+    let output = run_spr(&["--json", "--help"]);
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let json = stdout_json(&output);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "help");
+    assert_eq!(json["result"], "help");
+    assert_eq!(json["data"]["command_path"], serde_json::json!(["spr"]));
+    assert!(json["data"]["options"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|option| option["long"] == "json" && option["global"] == true));
+    assert!(!json["data"]["rendered_text"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn json_help_outputs_structured_nested_help() {
+    for args in [
+        ["--json", "help", "list", "commit"],
+        ["list", "commit", "--help", "--json"],
+    ] {
+        let output = run_spr(&args);
+
+        assert!(output.status.success(), "args failed: {args:?}");
+        assert!(
+            output.stderr.is_empty(),
+            "stderr for {args:?} was not empty"
+        );
+        let json = stdout_json(&output);
+        assert_eq!(json["command"], "help");
+        assert_eq!(json["result"], "help");
+        assert_eq!(
+            json["data"]["command_path"],
+            serde_json::json!(["spr", "list", "commit"])
+        );
+        assert!(!json["data"]["options"].as_array().unwrap().is_empty());
+        assert!(!json["data"]["rendered_text"].as_str().unwrap().is_empty());
+    }
+}
+
+#[test]
+fn json_version_outputs_package_metadata() {
+    for args in [["--json", "--version"], ["--version", "--json"]] {
+        let output = run_spr(&args);
+
+        assert!(output.status.success(), "args failed: {args:?}");
+        assert!(
+            output.stderr.is_empty(),
+            "stderr for {args:?} was not empty"
+        );
+        let json = stdout_json(&output);
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["command"], "version");
+        assert_eq!(json["result"], "version");
+        assert_eq!(json["data"]["name"], "spr");
+        assert_eq!(json["data"]["version"], env!("CARGO_PKG_VERSION"));
+    }
+}
+
+#[test]
+fn json_parse_error_outputs_error_object() {
+    let output = run_spr(&["--json", "definitely-not-a-command"]);
+
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    let json = stdout_json(&output);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cli");
+    assert_eq!(json["result"], "error");
+    assert_eq!(json["error_kind"], "invalid_arguments");
+    assert!(json["message"]
+        .as_str()
+        .unwrap()
+        .contains("definitely-not-a-command"));
+}


### PR DESCRIPTION
Before this change, JSON mode was still implemented as a command-local option in many paths. Reasonable invocations such as spr --json status, spr --json list commit, or spr list commit --json could be rejected because --json appeared in the wrong place for that particular subcommand shape.

Make --json a CLI-wide structured output request by pre-scanning argv before Clap handles normal parsing, display help, display version, and parse errors. Repeated --json tokens before -- are idempotent, and nearly every user-expected placement before -- now selects JSON output for the requested command.

Add structured JSON help and version envelopes while preserving operational JSON schemas. Cover parser placement, passthrough, display-output, and parse-error behavior with unit and binary integration tests, and document the global contract in README.

Compatibility: --json after -- remains passthrough payload and does not request spr JSON output.

Validation: CARGO_TARGET_DIR=/private/tmp/spr-multicommit-global-json-output-mode-target cargo clippy --tests; cargo fmt; CARGO_TARGET_DIR=/private/tmp/spr-multicommit-global-json-output-mode-target cargo test; cargo run smoke matrix for JSON help and version placements.

<!-- spr-stack:start -->
**Stack**:
-   #129
- ➡ #128

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->