### PR TITLE
spr: align local PR branches with stack tips on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ pr_description_mode: overwrite | stack_only
 # one of: "recent_on_bottom" (default) or "recent_on_top"
 list_order: recent_on_bottom
 
+# Optional local synchronization for branches named like `prefix + <tag>`.
+# - `off` (default): do not create or move local per-PR branches
+# - `update-existing`: move matching local branches that already exist
+# - `create-or-update`: create missing matching local branches and move existing ones
+local_pr_branches: off
+
 # How `spr restack` behaves on cherry-pick conflicts
 # - `halt` (default): suspend, leave the temp worktree in place, and resume
 #   with `spr resume <path>`
@@ -133,7 +139,7 @@ Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > git discovery (`origin/HEAD`)
 - Base has no built-in fallback; if discovery fails, set `base` explicitly
-- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `restack_conflict = halt`, `dirty_worktree = halt`
+- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `local_pr_branches = off`, `restack_conflict = halt`, `dirty_worktree = halt`
 
 Global flags
 ------------
@@ -141,6 +147,7 @@ Global flags
 - `--cd <PATH>`: change to `PATH` before loading repo config or running git/gh commands
 - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
+- `--local-pr-branches <off|update-existing|create-or-update>`: override local per-PR branch synchronization for this run
 - `--until <N|0|label|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
 - `--exact <I|label|pr:<label>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
@@ -191,6 +198,7 @@ Behavior:
 - Updates PR bodies with a visualized stack block and correct `baseRefName`
   - When `pr_description_mode` is `stack_only`, only the stack block (between markers) is updated; the rest of the body is preserved
   - May temporarily set existing PR bases to the repo base while pushing, then re-chain them to match the local stack
+- When `local_pr_branches` is enabled, synchronizes local branches named exactly like the synthetic PR branches after the update succeeds. `update-existing` only moves existing local branches; `create-or-update` also creates missing ones.
 
 ### spr restack
 
@@ -221,6 +229,7 @@ Behavior:
 - Uses the existing temp-worktree cherry-pick executor when the plan is not one contiguous suffix,
   or when the fast rebase conflicts and can be aborted cleanly.
 - Updates the current branch to the rebuilt tip
+- When `local_pr_branches` is enabled, synchronizes local synthetic PR branches to the final rewritten group tips after a successful rewrite.
 - With `--safe`, a backup tag named like `backup/restack/<current-branch>-<short-sha>` is created first
 - Conflict handling is controlled by `restack_conflict` in config.
 - Before rewriting the checked-out branch, `spr restack` follows the `dirty_worktree` config.
@@ -256,6 +265,7 @@ Behavior:
 - With `--safe`, creates a local backup tag named like `backup/drop-merged-prefix/<current-branch>-<short-sha>` before moving the branch
 - Does not merge, close, retarget, comment on, push, or otherwise mutate GitHub PRs
 - Does not run `spr update`; run it afterwards to publish the remaining open PR branch updates
+- When `local_pr_branches` is enabled, synchronizes local synthetic PR branches for the remaining stack after the local rewrite succeeds.
 
 ### spr absorb
 
@@ -276,6 +286,7 @@ Behavior:
 - Before rewriting the checked-out branch, `spr absorb` follows the `dirty_worktree` config.
 - On cherry-pick conflict, `spr absorb` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`
 - Does not update GitHub; inspect the rewritten stack first, then run `spr update`
+- When `local_pr_branches` is enabled, synchronizes local synthetic PR branches to the absorbed stack's final group tips after the local rewrite succeeds. A branch checked out in any worktree is reported as blocked and is not moved.
 
 Typical workflow:
 
@@ -369,8 +380,8 @@ Machine-readable `--json` mode:
   bottom-up stack order, even when `list_order: recent_on_top` changes the human display order.
   Each group's `remote.kind` encodes whether there is no matching PR, a PR without CI/review
   data, or a PR with typed CI/review status.
-- `spr update --json` writes repo context, resolved extent metadata, warnings, skipped groups, and
-  per-group branch or PR actions
+- `spr update --json` writes repo context, resolved extent metadata, warnings, skipped groups,
+  per-group branch or PR actions, and `local_pr_branch_actions`
 - `spr prep --json` writes the resolved selection, selected-group rewrite actions, replay counts,
   next-child warning action, and the nested update summary for the rewritten tip
 - `spr relink-prs --json` writes the expected local head/base chain plus one decision per PR head
@@ -381,7 +392,8 @@ Machine-readable `--json` mode:
   remaining groups, ignored-segment count, planned cherry-pick operation count, operations that a
   real run would perform, and the checks not validated by preview
 - `spr restack --json` without `--preview` keeps the rewrite lifecycle contract:
-  it writes one completed or suspended object, not a preview object
+  it writes one completed or suspended object, not a preview object. Completed rewrite JSON includes
+  `local_pr_branch_actions`, which is empty unless local per-PR branch sync is enabled.
 - JSON errors across commands use one typed error envelope with `result: "error"` plus
   `error_kind` values such as `synthetic_branch_name_collision`, `invalid_arguments`, and
   `internal`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -289,6 +289,9 @@ pub struct Cli {
     /// Global branch prefix for per-PR branches
     #[arg(long, global = true)]
     pub prefix: Option<String>,
+    /// Sync local per-PR branches named like synthetic PR branches
+    #[arg(long, global = true, value_enum)]
+    pub local_pr_branches: Option<crate::config::LocalPrBranchSyncPolicy>,
     /// Global until (used by prep/land). Accepts 0, a local PR number, or a stable handle
     #[arg(long, global = true, value_name = "N|0|label|pr:<label>")]
     pub until: Option<crate::selectors::InclusiveSelector>,
@@ -304,6 +307,7 @@ pub struct Cli {
 #[cfg(test)]
 mod tests {
     use super::{Cli, Cmd, OutputFormat};
+    use crate::config::LocalPrBranchSyncPolicy;
     use crate::execution::ExecutionMode;
     use clap::{CommandFactory, Parser};
     use std::ffi::OsString;
@@ -477,6 +481,29 @@ mod tests {
             }
             other => panic!("unexpected command: {:?}", other),
         }
+    }
+
+    #[test]
+    fn global_local_pr_branch_sync_override_parses_before_command() {
+        let cli = Cli::try_parse_from(["spr", "--local-pr-branches", "update-existing", "absorb"])
+            .unwrap();
+
+        assert_eq!(
+            cli.local_pr_branches,
+            Some(LocalPrBranchSyncPolicy::UpdateExisting)
+        );
+        assert!(matches!(cli.cmd, Cmd::Absorb { .. }));
+    }
+
+    #[test]
+    fn global_local_pr_branch_sync_override_parses_after_command() {
+        let cli = Cli::try_parse_from(["spr", "update", "--local-pr-branches", "create-or-update"])
+            .unwrap();
+
+        assert_eq!(
+            cli.local_pr_branches,
+            Some(LocalPrBranchSyncPolicy::CreateOrUpdate)
+        );
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub use relink_prs::{print_relink_prs_summary, relink_prs};
 pub use resolve_stack::{looks_like_pr_url, resolve_stack, ResolveStackOutput};
 pub use restack::{preview_restack_after, restack_after, restack_after_count};
 pub use rewrite_resume::{
-    resume_rewrite, RewriteCommandKind, RewriteCommandOutcome, RewriteSuspendedState,
+    resume_context, resume_rewrite, RewriteCommandKind, RewriteCommandOutcome,
+    RewriteSuspendedState,
 };
 pub use update::{build_from_groups, build_from_groups_with_summary};

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -383,6 +383,7 @@ pub fn prep_squash(
         list_order,
         true,
         0,
+        crate::config::LocalPrBranchSyncPolicy::Off,
     )?;
     let update_summary = UpdateSummaryData::from_execution(
         UpdateRepoContext {
@@ -395,6 +396,7 @@ pub fn prep_squash(
             dry_run,
             no_pr: false,
             pr_description_mode,
+            local_pr_branches: crate::config::LocalPrBranchSyncPolicy::Off,
         },
         resolved_extent,
         update_execution,

--- a/src/commands/rewrite_resume.rs
+++ b/src/commands/rewrite_resume.rs
@@ -37,6 +37,11 @@ pub enum RewriteCommandOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteResumeContext {
+    pub original_worktree_root: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RewriteSuspendedState {
     pub command_kind: RewriteCommandKind,
     pub original_worktree_root: String,
@@ -306,6 +311,15 @@ pub fn resume_rewrite(path: &Path) -> Result<RewriteCommandOutcome> {
         &remaining_operations,
         true,
     )
+}
+
+pub fn resume_context(path: &Path) -> Result<RewriteResumeContext> {
+    let resume_path = absolute_path(path)?;
+    let state = read_resume_state(&resume_path)?;
+    validate_resume_state_against_current_repo(&resume_path, &state)?;
+    Ok(RewriteResumeContext {
+        original_worktree_root: state.original_worktree_root,
+    })
 }
 
 fn continue_rewrite_operations(

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -9,7 +9,7 @@ use crate::branch_names::{
     canonical_branch_conflict_key, group_branch_identities, CanonicalBranchConflictKey,
 };
 use crate::commands::common;
-use crate::config::{ListOrder, PrDescriptionMode};
+use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
 use crate::execution::ExecutionMode;
 use crate::git::{get_remote_branches_sha, gh_rw, git_is_ancestor, git_rw, sanitize_gh_base_ref};
 use crate::github::{
@@ -393,6 +393,7 @@ fn empty_update_execution(skipped_handles: &[String]) -> UpdateExecutionData {
         warnings: update_warnings(skipped_handles),
         skipped_groups: skipped_group_data(skipped_handles),
         groups: Vec::new(),
+        local_pr_branch_actions: Vec::new(),
     }
 }
 
@@ -409,6 +410,7 @@ fn build_from_groups_internal(
     list_order: ListOrder,
     allow_branch_reuse: bool,
     branch_reuse_guard_days: u32,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
     render_progress: bool,
 ) -> Result<UpdateExecutionData> {
     let dry_run = execution_mode == ExecutionMode::DryRun;
@@ -876,6 +878,23 @@ fn build_from_groups_internal(
     let remote_url_prefix = get_repo_owner_name()
         .ok()
         .map(|(owner, name)| format!("https://github.com/{owner}/{name}/pull/"));
+    let local_pr_targets = planned
+        .iter()
+        .enumerate()
+        .map(
+            |(group_idx, planned_push)| crate::local_pr_branches::LocalPrBranchTarget {
+                stable_handle: common::stable_handle_text(&groups[group_idx].tag),
+                branch_name: planned_push.branch.clone(),
+                tip: planned_push.target_sha.clone(),
+            },
+        )
+        .collect::<Vec<_>>();
+    let local_pr_branch_actions = crate::local_pr_branches::sync_local_pr_branches(
+        local_pr_branch_policy,
+        execution_mode,
+        &local_pr_targets,
+    )?;
+
     let groups = groups
         .iter()
         .zip(branch_identities.iter())
@@ -908,6 +927,7 @@ fn build_from_groups_internal(
         warnings: update_warnings(skipped_handles),
         skipped_groups: skipped_group_data(skipped_handles),
         groups,
+        local_pr_branch_actions,
     })
 }
 
@@ -924,6 +944,7 @@ pub fn build_from_groups_with_summary(
     list_order: ListOrder,
     allow_branch_reuse: bool,
     branch_reuse_guard_days: u32,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<UpdateExecutionData> {
     build_from_groups_internal(
         base,
@@ -937,6 +958,7 @@ pub fn build_from_groups_with_summary(
         list_order,
         allow_branch_reuse,
         branch_reuse_guard_days,
+        local_pr_branch_policy,
         false,
     )
 }
@@ -954,6 +976,7 @@ pub fn build_from_groups(
     list_order: ListOrder,
     allow_branch_reuse: bool,
     branch_reuse_guard_days: u32,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<()> {
     build_from_groups_internal(
         base,
@@ -967,6 +990,7 @@ pub fn build_from_groups(
         list_order,
         allow_branch_reuse,
         branch_reuse_guard_days,
+        local_pr_branch_policy,
         true,
     )?;
     Ok(())
@@ -1001,6 +1025,7 @@ pub fn build_from_tags(
         list_order,
         true,
         0,
+        LocalPrBranchSyncPolicy::Off,
     )
 }
 
@@ -1012,7 +1037,7 @@ mod tests {
         pr_number_for_head, recent_pr_age, recent_pr_age_blocks_recreation, terminal_pr_action,
     };
     use crate::branch_names::group_branch_identities;
-    use crate::config::{ListOrder, PrDescriptionMode};
+    use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
     use crate::execution::ExecutionMode;
     use crate::github::TerminalPrState;
     use crate::parsing::{split_groups_for_update, Group};
@@ -1138,6 +1163,7 @@ mod tests {
             ListOrder::RecentOnTop,
             false,
             180,
+            LocalPrBranchSyncPolicy::Off,
         )
         .unwrap();
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,19 @@ pub enum PrDescriptionMode {
     StackOnly,
 }
 
+/// Opt-in policy for keeping local per-PR branches aligned with stack group tips.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+pub enum LocalPrBranchSyncPolicy {
+    /// Preserve existing behavior: do not create or move local per-PR branches.
+    Off,
+    /// Move local per-PR branches that already exist, but do not create missing branches.
+    UpdateExisting,
+    /// Create missing local per-PR branches and move existing ones.
+    CreateOrUpdate,
+}
+
 /// Behavior when `spr restack` encounters a cherry-pick conflict.
 ///
 /// This is YAML-deserializable and avoids stringly-typed policy handling.
@@ -109,6 +122,8 @@ pub struct FileConfig {
     pub pr_description_mode: Option<PrDescriptionMode>,
     /// Order for printing PR/commit lists and update progress output.
     pub list_order: Option<ListOrder>,
+    /// Whether to synchronize local per-PR branches named like synthetic PR branches.
+    pub local_pr_branches: Option<LocalPrBranchSyncPolicy>,
     /// Behavior when `spr restack` encounters a cherry-pick conflict.
     ///
     /// Supported values:
@@ -140,6 +155,8 @@ pub struct Config {
     pub pr_description_mode: PrDescriptionMode,
     /// Order for printing PR/commit lists and update progress output.
     pub list_order: ListOrder,
+    /// Whether to synchronize local per-PR branches named like synthetic PR branches.
+    pub local_pr_branches: LocalPrBranchSyncPolicy,
     /// Behavior when `spr restack` encounters a cherry-pick conflict.
     pub restack_conflict: RestackConflictPolicy,
     /// Behavior when a branch-rewriting command sees local changes.
@@ -184,6 +201,7 @@ fn default_config() -> Config {
         ignore_tag: "ignore".to_string(),
         pr_description_mode: PrDescriptionMode::Overwrite,
         list_order: ListOrder::RecentOnTop,
+        local_pr_branches: LocalPrBranchSyncPolicy::Off,
         restack_conflict: RestackConflictPolicy::Halt,
         dirty_worktree: DirtyWorktreePolicy::Halt,
         branch_reuse_guard_days: 180,
@@ -209,6 +227,9 @@ fn apply_overrides(config: &Config, overrides: FileConfig) -> Config {
     }
     if let Some(list_order) = overrides.list_order {
         merged.list_order = list_order;
+    }
+    if let Some(local_pr_branches) = overrides.local_pr_branches {
+        merged.local_pr_branches = local_pr_branches;
     }
     if let Some(restack_conflict) = overrides.restack_conflict {
         merged.restack_conflict = restack_conflict;
@@ -258,7 +279,8 @@ pub fn load_config() -> Result<Config> {
 mod tests {
     use super::{
         apply_overrides, default_config, normalize_config, normalize_prefix, read_config_file,
-        DirtyWorktreePolicy, FileConfig, PrDescriptionMode, RestackConflictPolicy,
+        DirtyWorktreePolicy, FileConfig, LocalPrBranchSyncPolicy, PrDescriptionMode,
+        RestackConflictPolicy,
     };
     use std::fs;
     use tempfile::tempdir;
@@ -363,6 +385,27 @@ restack_conflict: rollback
     }
 
     #[test]
+    fn default_config_leaves_local_pr_branch_sync_off() {
+        let cfg = default_config();
+
+        assert_eq!(cfg.local_pr_branches, LocalPrBranchSyncPolicy::Off);
+    }
+
+    #[test]
+    fn read_config_file_parses_local_pr_branch_sync_policy() {
+        let dir = tempdir().unwrap();
+        let mut path = dir.path().to_path_buf();
+        path.push(".spr_multicommit_cfg.yml");
+        fs::write(&path, "local_pr_branches: create-or-update\n").unwrap();
+
+        let cfg = read_config_file(&path).unwrap().unwrap();
+        assert_eq!(
+            cfg.local_pr_branches,
+            Some(LocalPrBranchSyncPolicy::CreateOrUpdate)
+        );
+    }
+
+    #[test]
     // Verifies: YAML config parsing accepts an integer value for branch_reuse_guard_days.
     // Catches: regressions where the new config key is rejected or parsed with the wrong type.
     fn read_config_file_parses_branch_reuse_guard_days_integer() {
@@ -389,6 +432,7 @@ restack_conflict: rollback
                 ignore_tag: None,
                 pr_description_mode: None,
                 list_order: None,
+                local_pr_branches: None,
                 restack_conflict: None,
                 dirty_worktree: None,
                 branch_reuse_guard_days: Some(30),
@@ -396,6 +440,30 @@ restack_conflict: rollback
         );
 
         assert_eq!(merged.branch_reuse_guard_days, 30);
+    }
+
+    #[test]
+    fn apply_overrides_updates_local_pr_branch_sync_policy() {
+        let merged = apply_overrides(
+            &default_config(),
+            FileConfig {
+                base: None,
+                prefix: None,
+                land: None,
+                ignore_tag: None,
+                pr_description_mode: None,
+                list_order: None,
+                local_pr_branches: Some(LocalPrBranchSyncPolicy::UpdateExisting),
+                restack_conflict: None,
+                dirty_worktree: None,
+                branch_reuse_guard_days: None,
+            },
+        );
+
+        assert_eq!(
+            merged.local_pr_branches,
+            LocalPrBranchSyncPolicy::UpdateExisting
+        );
     }
 
     #[test]

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -290,6 +290,7 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
             } else if arg == "--cd"
                 || arg == "--base"
                 || arg == "--prefix"
+                || arg == "--local-pr-branches"
                 || arg == "--until"
                 || arg == "--exact"
                 || arg == "-b"

--- a/src/local_pr_branches.rs
+++ b/src/local_pr_branches.rs
@@ -1,0 +1,463 @@
+//! Optional synchronization for local per-PR branches.
+//!
+//! The synthetic branch name for a PR group is `prefix + tag`. Remote updates
+//! already use those names, and this module optionally keeps matching local
+//! branches pointed at the same group tips.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::collections::HashSet;
+use tracing::info;
+
+use crate::branch_names::synthetic_branch_name;
+use crate::config::LocalPrBranchSyncPolicy;
+use crate::execution::ExecutionMode;
+use crate::git::{git_is_ancestor, git_local_branch_tip, git_ro, git_rw};
+use crate::parsing::Group;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalPrBranchTarget {
+    pub stable_handle: String,
+    pub branch_name: String,
+    pub tip: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalPrBranchActionKind {
+    Created,
+    Updated,
+    Skipped,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LocalPrBranchAction {
+    pub stable_handle: String,
+    pub branch: String,
+    pub old_tip: Option<String>,
+    pub new_tip: String,
+    pub action: LocalPrBranchActionKind,
+    pub reason: String,
+    pub backup_tag: Option<String>,
+}
+
+struct PlannedLocalPrBranchAction {
+    target: LocalPrBranchTarget,
+    old_tip: Option<String>,
+    action: LocalPrBranchActionKind,
+    reason: String,
+}
+
+pub fn targets_from_groups(prefix: &str, groups: &[Group]) -> Result<Vec<LocalPrBranchTarget>> {
+    groups
+        .iter()
+        .map(|group| {
+            let tip = group
+                .commits
+                .last()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Group {} has no commits", group.tag))?;
+            Ok(LocalPrBranchTarget {
+                stable_handle: crate::commands::common::stable_handle_text(&group.tag),
+                branch_name: synthetic_branch_name(prefix, &group.tag),
+                tip,
+            })
+        })
+        .collect()
+}
+
+pub fn sync_local_pr_branches(
+    policy: LocalPrBranchSyncPolicy,
+    execution_mode: ExecutionMode,
+    targets: &[LocalPrBranchTarget],
+) -> Result<Vec<LocalPrBranchAction>> {
+    if policy == LocalPrBranchSyncPolicy::Off || targets.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let checked_out_branches = checked_out_local_branches()?;
+    let planned = targets
+        .iter()
+        .map(|target| plan_action(policy, target, &checked_out_branches))
+        .collect::<Result<Vec<_>>>()?;
+    let actions = planned
+        .into_iter()
+        .map(|planned| apply_action(execution_mode, planned))
+        .collect::<Result<Vec<_>>>()?;
+    emit_actions(&actions);
+    Ok(actions)
+}
+
+fn plan_action(
+    policy: LocalPrBranchSyncPolicy,
+    target: &LocalPrBranchTarget,
+    checked_out_branches: &HashSet<String>,
+) -> Result<PlannedLocalPrBranchAction> {
+    let old_tip = git_local_branch_tip(&target.branch_name)?;
+    let (action, reason) = if let Some(old_tip) = old_tip.as_deref() {
+        if old_tip == target.tip {
+            (
+                LocalPrBranchActionKind::Skipped,
+                "already at target".to_string(),
+            )
+        } else if checked_out_branches.contains(&target.branch_name) {
+            (
+                LocalPrBranchActionKind::Blocked,
+                "branch is checked out in a worktree".to_string(),
+            )
+        } else {
+            (
+                LocalPrBranchActionKind::Updated,
+                "move existing local branch to target".to_string(),
+            )
+        }
+    } else if policy == LocalPrBranchSyncPolicy::CreateOrUpdate {
+        (
+            LocalPrBranchActionKind::Created,
+            "create missing local branch at target".to_string(),
+        )
+    } else {
+        (
+            LocalPrBranchActionKind::Skipped,
+            "missing local branch and policy is update-existing".to_string(),
+        )
+    };
+
+    Ok(PlannedLocalPrBranchAction {
+        target: target.clone(),
+        old_tip,
+        action,
+        reason,
+    })
+}
+
+fn apply_action(
+    execution_mode: ExecutionMode,
+    planned: PlannedLocalPrBranchAction,
+) -> Result<LocalPrBranchAction> {
+    let backup_tag = match planned.action {
+        LocalPrBranchActionKind::Created => {
+            git_rw(
+                execution_mode,
+                [
+                    "branch",
+                    planned.target.branch_name.as_str(),
+                    planned.target.tip.as_str(),
+                ]
+                .as_slice(),
+            )
+            .with_context(|| {
+                format!(
+                    "failed to create local PR branch {} at {}",
+                    planned.target.branch_name, planned.target.tip
+                )
+            })?;
+            None
+        }
+        LocalPrBranchActionKind::Updated => {
+            let backup_tag = backup_tag_for_non_fast_forward(
+                execution_mode,
+                &planned.target.branch_name,
+                planned.old_tip.as_deref(),
+                &planned.target.tip,
+            )?;
+            git_rw(
+                execution_mode,
+                [
+                    "branch",
+                    "-f",
+                    planned.target.branch_name.as_str(),
+                    planned.target.tip.as_str(),
+                ]
+                .as_slice(),
+            )
+            .with_context(|| {
+                format!(
+                    "failed to move local PR branch {} to {}",
+                    planned.target.branch_name, planned.target.tip
+                )
+            })?;
+            backup_tag
+        }
+        LocalPrBranchActionKind::Skipped | LocalPrBranchActionKind::Blocked => None,
+    };
+
+    Ok(LocalPrBranchAction {
+        stable_handle: planned.target.stable_handle,
+        branch: planned.target.branch_name,
+        old_tip: planned.old_tip,
+        new_tip: planned.target.tip,
+        action: planned.action,
+        reason: planned.reason,
+        backup_tag,
+    })
+}
+
+fn backup_tag_for_non_fast_forward(
+    execution_mode: ExecutionMode,
+    branch_name: &str,
+    old_tip: Option<&str>,
+    new_tip: &str,
+) -> Result<Option<String>> {
+    let Some(old_tip) = old_tip else {
+        return Ok(None);
+    };
+    if git_is_ancestor(old_tip, new_tip)? {
+        return Ok(None);
+    }
+
+    let backup_tag = format!(
+        "backup/local-pr-branches/{}-{}",
+        branch_name,
+        short_sha(old_tip)
+    );
+    git_rw(
+        execution_mode,
+        ["tag", "-f", &backup_tag, old_tip].as_slice(),
+    )
+    .with_context(|| {
+        format!(
+            "failed to create backup tag {} for local PR branch {} at {}",
+            backup_tag, branch_name, old_tip
+        )
+    })?;
+    Ok(Some(backup_tag))
+}
+
+fn checked_out_local_branches() -> Result<HashSet<String>> {
+    let output = git_ro(["worktree", "list", "--porcelain"].as_slice())
+        .context("failed to list git worktrees")?;
+    Ok(output
+        .lines()
+        .filter_map(|line| line.strip_prefix("branch refs/heads/"))
+        .map(str::to_string)
+        .collect())
+}
+
+fn emit_actions(actions: &[LocalPrBranchAction]) {
+    for action in actions {
+        let old_tip = action
+            .old_tip
+            .as_deref()
+            .map(short_sha)
+            .unwrap_or("missing");
+        let new_tip = short_sha(&action.new_tip);
+        let verb = match action.action {
+            LocalPrBranchActionKind::Created => "created",
+            LocalPrBranchActionKind::Updated => "updated",
+            LocalPrBranchActionKind::Skipped => "skipped",
+            LocalPrBranchActionKind::Blocked => "blocked",
+        };
+        info!(
+            "local branch {} -> {} {}..{} ({})",
+            action.branch, verb, old_tip, new_tip, action.reason
+        );
+    }
+}
+
+fn short_sha(sha: &str) -> &str {
+    if sha.len() > 8 {
+        &sha[..8]
+    } else {
+        sha
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sync_local_pr_branches, LocalPrBranchActionKind, LocalPrBranchTarget};
+    use crate::config::LocalPrBranchSyncPolicy;
+    use crate::execution::ExecutionMode;
+    use crate::test_support::{commit_file, git, init_repo, lock_cwd, DirGuard};
+    use std::path::Path;
+
+    fn rev_parse(repo: &Path, revision: &str) -> String {
+        git(repo, ["rev-parse", revision].as_slice())
+            .trim()
+            .to_string()
+    }
+
+    fn branch_tip(repo: &Path, branch: &str) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .current_dir(repo)
+            .args([
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{branch}^{{commit}}"),
+            ])
+            .output()
+            .unwrap();
+        if out.status.success() {
+            Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+        } else {
+            None
+        }
+    }
+
+    fn target(branch_name: &str, tip: &str) -> LocalPrBranchTarget {
+        LocalPrBranchTarget {
+            stable_handle: "pr:alpha".to_string(),
+            branch_name: branch_name.to_string(),
+            tip: tip.to_string(),
+        }
+    }
+
+    #[test]
+    fn off_policy_leaves_missing_branch_unreported_and_absent() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let head = rev_parse(&repo, "HEAD");
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::Off,
+            ExecutionMode::Apply,
+            &[target("dank-spr/alpha", &head)],
+        )
+        .unwrap();
+
+        assert!(actions.is_empty());
+        assert!(branch_tip(&repo, "dank-spr/alpha").is_none());
+    }
+
+    #[test]
+    fn update_existing_policy_does_not_create_missing_branch() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let head = rev_parse(&repo, "HEAD");
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::UpdateExisting,
+            ExecutionMode::Apply,
+            &[target("dank-spr/alpha", &head)],
+        )
+        .unwrap();
+
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Skipped);
+        assert!(branch_tip(&repo, "dank-spr/alpha").is_none());
+    }
+
+    #[test]
+    fn create_or_update_policy_creates_missing_branch() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let head = rev_parse(&repo, "HEAD");
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::CreateOrUpdate,
+            ExecutionMode::Apply,
+            &[target("dank-spr/alpha", &head)],
+        )
+        .unwrap();
+
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Created);
+        assert_eq!(branch_tip(&repo, "dank-spr/alpha"), Some(head));
+    }
+
+    #[test]
+    fn update_existing_policy_moves_existing_branch() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let old_tip = rev_parse(&repo, "HEAD");
+        git(&repo, ["branch", "dank-spr/alpha", &old_tip].as_slice());
+        let new_tip = commit_file(&repo, "alpha.txt", "alpha\n", "feat: alpha");
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::UpdateExisting,
+            ExecutionMode::Apply,
+            &[target("dank-spr/alpha", &new_tip)],
+        )
+        .unwrap();
+
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Updated);
+        assert_eq!(actions[0].old_tip.as_deref(), Some(old_tip.as_str()));
+        assert_eq!(branch_tip(&repo, "dank-spr/alpha"), Some(new_tip));
+    }
+
+    #[test]
+    fn dry_run_reports_create_without_creating_branch() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let head = rev_parse(&repo, "HEAD");
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::CreateOrUpdate,
+            ExecutionMode::DryRun,
+            &[target("dank-spr/alpha", &head)],
+        )
+        .unwrap();
+
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Created);
+        assert!(branch_tip(&repo, "dank-spr/alpha").is_none());
+    }
+
+    #[test]
+    fn checked_out_local_branch_is_reported_as_blocked_and_left_unchanged() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let old_tip = rev_parse(&repo, "HEAD");
+        git(&repo, ["branch", "dank-spr/alpha", &old_tip].as_slice());
+        let worktree_parent = tempfile::tempdir().unwrap();
+        let worktree_path = worktree_parent.path().join("alpha-worktree");
+        git(
+            &repo,
+            [
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "dank-spr/alpha",
+            ]
+            .as_slice(),
+        );
+        let new_tip = commit_file(&repo, "alpha.txt", "alpha\n", "feat: alpha");
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::UpdateExisting,
+            ExecutionMode::Apply,
+            &[target("dank-spr/alpha", &new_tip)],
+        )
+        .unwrap();
+
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Blocked);
+        assert_eq!(branch_tip(&repo, "dank-spr/alpha"), Some(old_tip));
+    }
+
+    #[test]
+    fn non_fast_forward_update_creates_backup_tag_at_old_branch_tip() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let target_tip = rev_parse(&repo, "HEAD");
+        let old_tip = commit_file(&repo, "alpha.txt", "alpha\n", "feat: alpha");
+        git(&repo, ["branch", "dank-spr/alpha", &old_tip].as_slice());
+
+        let actions = sync_local_pr_branches(
+            LocalPrBranchSyncPolicy::UpdateExisting,
+            ExecutionMode::Apply,
+            &[target("dank-spr/alpha", &target_tip)],
+        )
+        .unwrap();
+
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Updated);
+        let backup_tag = actions[0].backup_tag.as_deref().unwrap();
+        assert_eq!(
+            rev_parse(&repo, &format!("refs/tags/{backup_tag}")),
+            old_tip
+        );
+        assert_eq!(branch_tip(&repo, "dank-spr/alpha"), Some(target_tip));
+    }
+}

--- a/src/machine_output.rs
+++ b/src/machine_output.rs
@@ -57,7 +57,9 @@ pub struct MachineSuspendedPayload {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "result", rename_all = "snake_case")]
 pub enum MachinePayload {
-    Completed,
+    Completed {
+        local_pr_branch_actions: Vec<crate::local_pr_branches::LocalPrBranchAction>,
+    },
     Suspended {
         #[serde(flatten)]
         details: Box<MachineSuspendedPayload>,
@@ -65,11 +67,16 @@ pub enum MachinePayload {
 }
 
 impl MachineOutput {
-    pub fn completed(command: MachineCommand) -> Self {
+    pub fn completed_with_local_pr_branch_actions(
+        command: MachineCommand,
+        local_pr_branch_actions: Vec<crate::local_pr_branches::LocalPrBranchAction>,
+    ) -> Self {
         Self {
             schema_version: JSON_OUTPUT_SCHEMA_VERSION,
             command,
-            payload: MachinePayload::Completed,
+            payload: MachinePayload::Completed {
+                local_pr_branch_actions,
+            },
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod git;
 mod github;
 mod json_output;
 mod limit;
+mod local_pr_branches;
 mod machine_output;
 mod maintenance_output;
 mod parsing;
@@ -159,11 +160,15 @@ fn ensure_rewrite_completed(
     command_name: &str,
     machine_command: crate::machine_output::MachineCommand,
     outcome: crate::commands::RewriteCommandOutcome,
+    local_pr_branch_actions: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 ) -> Result<crate::machine_output::MachineOutput> {
     if outcome == crate::commands::RewriteCommandOutcome::Completed {
-        Ok(crate::machine_output::MachineOutput::completed(
-            machine_command,
-        ))
+        Ok(
+            crate::machine_output::MachineOutput::completed_with_local_pr_branch_actions(
+                machine_command,
+                local_pr_branch_actions,
+            ),
+        )
     } else if let crate::commands::RewriteCommandOutcome::Suspended(state) = outcome {
         if output_format == crate::cli::OutputFormat::Json {
             Ok(crate::machine_output::MachineOutput::suspended(
@@ -179,20 +184,27 @@ fn ensure_rewrite_completed(
             ))
         }
     } else {
-        Ok(crate::machine_output::MachineOutput::completed(
-            machine_command,
-        ))
+        Ok(
+            crate::machine_output::MachineOutput::completed_with_local_pr_branch_actions(
+                machine_command,
+                local_pr_branch_actions,
+            ),
+        )
     }
 }
 
 fn ensure_resume_completed(
     output_format: crate::cli::OutputFormat,
     outcome: crate::commands::RewriteCommandOutcome,
+    local_pr_branch_actions: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 ) -> Result<crate::machine_output::MachineOutput> {
     if outcome == crate::commands::RewriteCommandOutcome::Completed {
-        Ok(crate::machine_output::MachineOutput::completed(
-            crate::machine_output::MachineCommand::Resume,
-        ))
+        Ok(
+            crate::machine_output::MachineOutput::completed_with_local_pr_branch_actions(
+                crate::machine_output::MachineCommand::Resume,
+                local_pr_branch_actions,
+            ),
+        )
     } else if let crate::commands::RewriteCommandOutcome::Suspended(state) = outcome {
         if output_format == crate::cli::OutputFormat::Json {
             Ok(crate::machine_output::MachineOutput::suspended(
@@ -207,9 +219,48 @@ fn ensure_resume_completed(
             ))
         }
     } else {
-        Ok(crate::machine_output::MachineOutput::completed(
-            crate::machine_output::MachineCommand::Resume,
-        ))
+        Ok(
+            crate::machine_output::MachineOutput::completed_with_local_pr_branch_actions(
+                crate::machine_output::MachineCommand::Resume,
+                local_pr_branch_actions,
+            ),
+        )
+    }
+}
+
+fn sync_local_pr_branches_for_current_stack(
+    policy: crate::config::LocalPrBranchSyncPolicy,
+    execution_mode: ExecutionMode,
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<Vec<crate::local_pr_branches::LocalPrBranchAction>> {
+    if policy == crate::config::LocalPrBranchSyncPolicy::Off {
+        return Ok(Vec::new());
+    }
+
+    let (_merge_base, _leading_ignored, groups) =
+        crate::parsing::derive_local_groups_with_ignored(base, ignore_tag)?;
+    crate::branch_names::group_branch_identities(&groups, prefix)?;
+    let targets = crate::local_pr_branches::targets_from_groups(prefix, &groups)?;
+    crate::local_pr_branches::sync_local_pr_branches(policy, execution_mode, &targets)
+}
+
+fn sync_actions_after_completed_rewrite(
+    outcome: &crate::commands::RewriteCommandOutcome,
+    policy: crate::config::LocalPrBranchSyncPolicy,
+    execution_mode: ExecutionMode,
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<Vec<crate::local_pr_branches::LocalPrBranchAction>> {
+    if execution_mode == ExecutionMode::DryRun {
+        return Ok(Vec::new());
+    }
+    if *outcome == crate::commands::RewriteCommandOutcome::Completed {
+        sync_local_pr_branches_for_current_stack(policy, execution_mode, base, prefix, ignore_tag)
+    } else {
+        Ok(Vec::new())
     }
 }
 
@@ -251,9 +302,71 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
     apply_working_directory_override(cli.cd.as_deref())?;
     init_tools(command_requires_gh(&cli.cmd))?;
     if let crate::cli::Cmd::Resume { path, .. } = &cli.cmd {
+        let resume_path = if path.is_absolute() {
+            path.clone()
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        let resume_context = crate::commands::resume_context(&resume_path)?;
+        std::env::set_current_dir(&resume_context.original_worktree_root).with_context(|| {
+            format!(
+                "failed to change to original rewrite worktree {}",
+                resume_context.original_worktree_root
+            )
+        })?;
+        let explicit_local_pr_branch_policy = cli.local_pr_branches;
+        let sync_context = if explicit_local_pr_branch_policy
+            == Some(crate::config::LocalPrBranchSyncPolicy::Off)
+        {
+            None
+        } else {
+            match crate::config::load_config() {
+                Ok(cfg) => {
+                    let policy = explicit_local_pr_branch_policy.unwrap_or(cfg.local_pr_branches);
+                    if policy == crate::config::LocalPrBranchSyncPolicy::Off {
+                        None
+                    } else {
+                        match resolve_base_prefix(&cfg, cli.base.clone(), cli.prefix.clone()) {
+                            Ok(context) => Some((policy, context)),
+                            Err(err) if explicit_local_pr_branch_policy.is_none() => {
+                                tracing::warn!(
+                                    "Skipping local PR branch sync after resume because base and prefix could not be resolved: {err:#}"
+                                );
+                                None
+                            }
+                            Err(err) => return Err(err),
+                        }
+                    }
+                }
+                Err(err) if explicit_local_pr_branch_policy.is_none() => {
+                    tracing::warn!(
+                        "Skipping local PR branch sync after resume because config could not be loaded: {err:#}"
+                    );
+                    None
+                }
+                Err(err) => return Err(err),
+            }
+        };
+        let outcome = crate::commands::resume_rewrite(&resume_path)?;
+        let local_pr_branch_actions = if let (
+            crate::commands::RewriteCommandOutcome::Completed,
+            Some((policy, (base, prefix, ignore_tag))),
+        ) = (&outcome, sync_context)
+        {
+            sync_local_pr_branches_for_current_stack(
+                policy,
+                ExecutionMode::Apply,
+                &base,
+                &prefix,
+                &ignore_tag,
+            )?
+        } else {
+            Vec::new()
+        };
         return Ok(CommandOutput::Machine(ensure_resume_completed(
             output_format,
-            crate::commands::resume_rewrite(path)?,
+            outcome,
+            local_pr_branch_actions,
         )?));
     }
 
@@ -270,6 +383,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
     let dirty_worktree_policy = cfg.dirty_worktree;
     let list_order = cfg.list_order;
     let branch_reuse_guard_days = cfg.branch_reuse_guard_days;
+    let local_pr_branch_policy = cli.local_pr_branches.unwrap_or(cfg.local_pr_branches);
     match cli.cmd {
         crate::cli::Cmd::Update {
             from,
@@ -335,6 +449,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         list_order,
                         allow_branch_reuse,
                         branch_reuse_guard_days,
+                        local_pr_branch_policy,
                     )?;
                     let summary = crate::update_output::UpdateSummaryData::from_execution(
                         crate::update_output::UpdateRepoContext {
@@ -347,6 +462,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                             dry_run: execution_mode == ExecutionMode::DryRun,
                             no_pr,
                             pr_description_mode,
+                            local_pr_branches: local_pr_branch_policy,
                         },
                         resolved_extent,
                         execution,
@@ -374,6 +490,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         list_order,
                         allow_branch_reuse,
                         branch_reuse_guard_days,
+                        local_pr_branch_policy,
                     )?;
                     if execution_mode == ExecutionMode::Apply {
                         crate::stack_metadata::refresh_metadata_for_current_checkout(
@@ -403,35 +520,55 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     )?),
                 ))
             } else {
+                let outcome = crate::commands::restack_after(
+                    &metadata_refresh_context,
+                    &after,
+                    safe,
+                    execution_mode,
+                    restack_conflict_policy,
+                    dirty_worktree_policy,
+                )?;
+                let local_pr_branch_actions = sync_actions_after_completed_rewrite(
+                    &outcome,
+                    local_pr_branch_policy,
+                    execution_mode,
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                )?;
                 Ok(CommandOutput::Machine(ensure_rewrite_completed(
                     output_format,
                     "spr restack",
                     crate::machine_output::MachineCommand::Restack,
-                    crate::commands::restack_after(
-                        &metadata_refresh_context,
-                        &after,
-                        safe,
-                        execution_mode,
-                        restack_conflict_policy,
-                        dirty_worktree_policy,
-                    )?,
+                    outcome,
+                    local_pr_branch_actions,
                 )?))
             }
         }
         crate::cli::Cmd::DropMergedPrefix { safe, dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
+            let outcome = crate::commands::drop_merged_prefix(
+                &metadata_refresh_context,
+                safe,
+                execution_mode,
+                restack_conflict_policy,
+                dirty_worktree_policy,
+            )?;
+            let local_pr_branch_actions = sync_actions_after_completed_rewrite(
+                &outcome,
+                local_pr_branch_policy,
+                execution_mode,
+                &base,
+                &prefix,
+                &ignore_tag,
+            )?;
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr drop-merged-prefix",
                 crate::machine_output::MachineCommand::DropMergedPrefix,
-                crate::commands::drop_merged_prefix(
-                    &metadata_refresh_context,
-                    safe,
-                    execution_mode,
-                    restack_conflict_policy,
-                    dirty_worktree_policy,
-                )?,
+                outcome,
+                local_pr_branch_actions,
             )?))
         }
         crate::cli::Cmd::Absorb {
@@ -447,18 +584,28 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     crate::commands::CopiedLaterStackCommitPolicy::Block
                 },
             };
+            let outcome = crate::commands::absorb_branch_tails(
+                &base,
+                &prefix,
+                &ignore_tag,
+                execution_mode,
+                dirty_worktree_policy,
+                options,
+            )?;
+            let local_pr_branch_actions = sync_actions_after_completed_rewrite(
+                &outcome,
+                local_pr_branch_policy,
+                execution_mode,
+                &base,
+                &prefix,
+                &ignore_tag,
+            )?;
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr absorb",
                 crate::machine_output::MachineCommand::Absorb,
-                crate::commands::absorb_branch_tails(
-                    &base,
-                    &prefix,
-                    &ignore_tag,
-                    execution_mode,
-                    dirty_worktree_policy,
-                    options,
-                )?,
+                outcome,
+                local_pr_branch_actions,
             )?))
         }
         crate::cli::Cmd::Prep { dry_run } => {
@@ -586,7 +733,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     r#unsafe,
                 )?,
             };
-            if !no_restack {
+            let local_pr_branch_actions = if !no_restack {
                 // After landing the first N PRs, restack the remaining commits onto the latest base
                 let outcome = crate::commands::restack_after_count(
                     &metadata_refresh_context,
@@ -596,7 +743,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     restack_conflict_policy,
                     dirty_worktree_policy,
                 )?;
-                if let crate::commands::RewriteCommandOutcome::Suspended(state) = outcome {
+                if let crate::commands::RewriteCommandOutcome::Suspended(state) = &outcome {
                     let post_success_hint = Some(
                         "GitHub landing already succeeded; resolve the local restack conflict and run the printed `spr resume <path>` command instead of rerunning `spr land`."
                             .to_string(),
@@ -605,7 +752,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         return Ok(CommandOutput::Machine(
                             crate::machine_output::MachineOutput::suspended(
                                 crate::machine_output::MachineCommand::Land,
-                                *state,
+                                (**state).clone(),
                                 post_success_hint,
                             ),
                         ));
@@ -616,10 +763,21 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         ));
                     }
                 }
-            }
+                sync_actions_after_completed_rewrite(
+                    &outcome,
+                    local_pr_branch_policy,
+                    execution_mode,
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                )?
+            } else {
+                Vec::new()
+            };
             Ok(CommandOutput::Machine(
-                crate::machine_output::MachineOutput::completed(
+                crate::machine_output::MachineOutput::completed_with_local_pr_branch_actions(
                     crate::machine_output::MachineCommand::Land,
+                    local_pr_branch_actions,
                 ),
             ))
         }
@@ -657,18 +815,28 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
+            let outcome = crate::commands::fix_pr_tail(
+                &metadata_refresh_context,
+                &target,
+                tail,
+                safe,
+                execution_mode,
+                dirty_worktree_policy,
+            )?;
+            let local_pr_branch_actions = sync_actions_after_completed_rewrite(
+                &outcome,
+                local_pr_branch_policy,
+                execution_mode,
+                &base,
+                &prefix,
+                &ignore_tag,
+            )?;
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr fix-pr",
                 crate::machine_output::MachineCommand::FixPr,
-                crate::commands::fix_pr_tail(
-                    &metadata_refresh_context,
-                    &target,
-                    tail,
-                    safe,
-                    execution_mode,
-                    dirty_worktree_policy,
-                )?,
+                outcome,
+                local_pr_branch_actions,
             )?))
         }
         crate::cli::Cmd::Move {
@@ -679,22 +847,32 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
+            let outcome = crate::commands::move_groups_after(
+                &base,
+                &prefix,
+                &ignore_tag,
+                &range,
+                &after,
+                crate::commands::MoveExecutionOptions {
+                    safe,
+                    execution_mode,
+                    dirty_worktree_policy,
+                },
+            )?;
+            let local_pr_branch_actions = sync_actions_after_completed_rewrite(
+                &outcome,
+                local_pr_branch_policy,
+                execution_mode,
+                &base,
+                &prefix,
+                &ignore_tag,
+            )?;
             Ok(CommandOutput::Machine(ensure_rewrite_completed(
                 output_format,
                 "spr move",
                 crate::machine_output::MachineCommand::Move,
-                crate::commands::move_groups_after(
-                    &base,
-                    &prefix,
-                    &ignore_tag,
-                    &range,
-                    &after,
-                    crate::commands::MoveExecutionOptions {
-                        safe,
-                        execution_mode,
-                        dirty_worktree_policy,
-                    },
-                )?,
+                outcome,
+                local_pr_branch_actions,
             )?))
         }
     }
@@ -879,7 +1057,7 @@ mod tests {
     use crate::maintenance_output::{
         MaintenancePayload, PrepNextChildAction, ResolvedPrepSelection,
     };
-    use crate::parsing::Group;
+    use crate::parsing::{derive_local_groups_with_ignored, Group};
     use crate::read_only_output::ReadOnlyPayload;
     use crate::selectors::{GroupSelector, StableHandle};
     use crate::test_support::{
@@ -892,7 +1070,7 @@ mod tests {
     use std::ffi::OsString;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -1133,6 +1311,26 @@ mod tests {
 
     fn install_failing_gh_wrapper() -> (TempDir, EnvVarGuard) {
         install_gh_wrapper("#!/bin/sh\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n")
+    }
+
+    fn local_branch_exists(repo: &Path, branch: &str) -> bool {
+        Command::new("git")
+            .current_dir(repo)
+            .args([
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{branch}^{{commit}}"),
+            ])
+            .status()
+            .unwrap()
+            .success()
+    }
+
+    fn rev_parse(repo: &Path, revision: &str) -> String {
+        git(repo, ["rev-parse", revision].as_slice())
+            .trim()
+            .to_string()
     }
 
     fn prep_json_gh_script(log_path: &std::path::Path) -> String {
@@ -1950,9 +2148,14 @@ mod tests {
                 assert_eq!(data.repo.ignore_tag, "ignore");
                 assert!(data.options.dry_run);
                 assert!(data.options.no_pr);
+                assert_eq!(
+                    data.options.local_pr_branches,
+                    crate::config::LocalPrBranchSyncPolicy::Off
+                );
                 assert_eq!(data.extent, ResolvedUpdateLimit::All);
                 assert!(data.warnings.is_empty());
                 assert!(data.skipped_groups.is_empty());
+                assert!(data.local_pr_branch_actions.is_empty());
                 assert_eq!(data.groups.len(), 2);
                 assert_eq!(data.groups[0].stable_handle, "pr:alpha");
                 assert_eq!(
@@ -1972,6 +2175,146 @@ mod tests {
             }
             other => panic!("unexpected command output: {:?}", other),
         }
+    }
+
+    #[test]
+    fn update_json_no_pr_reports_opted_in_local_branch_sync_actions() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "update",
+            "--dry-run",
+            "--json",
+            "--no-pr",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Update(output) => {
+                let data = output.data;
+                assert_eq!(
+                    data.options.local_pr_branches,
+                    crate::config::LocalPrBranchSyncPolicy::CreateOrUpdate
+                );
+                assert_eq!(data.local_pr_branch_actions.len(), 2);
+                assert_eq!(data.local_pr_branch_actions[0].stable_handle, "pr:alpha");
+                assert_eq!(data.local_pr_branch_actions[0].branch, "dank-spr/alpha");
+                assert_eq!(
+                    data.local_pr_branch_actions[0].action,
+                    crate::local_pr_branches::LocalPrBranchActionKind::Created
+                );
+                assert_eq!(data.local_pr_branch_actions[0].old_tip, None);
+                assert_eq!(
+                    data.local_pr_branch_actions[0].new_tip,
+                    data.groups[0].target_sha
+                );
+                assert_eq!(data.local_pr_branch_actions[1].stable_handle, "pr:beta");
+                assert_eq!(data.local_pr_branch_actions[1].branch, "dank-spr/beta");
+                assert_eq!(
+                    data.local_pr_branch_actions[1].action,
+                    crate::local_pr_branches::LocalPrBranchActionKind::Created
+                );
+                assert!(!local_branch_exists(&repo, "dank-spr/alpha"));
+                assert!(!local_branch_exists(&repo, "dank-spr/beta"));
+            }
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn absorb_with_local_pr_branch_sync_updates_rewritten_local_branch_tip() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let alpha_tip = rev_parse(&repo, "HEAD~1");
+        let beta_tip = rev_parse(&repo, "HEAD");
+        git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        git(&repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
+        git(&repo, ["checkout", "dank-spr/alpha"].as_slice());
+        commit_file(
+            &repo,
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo, ["checkout", "stack"].as_slice());
+        let stale_beta_branch_tip = rev_parse(&repo, "dank-spr/beta");
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "absorb",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Machine(output) => match output.payload {
+                crate::machine_output::MachinePayload::Completed {
+                    local_pr_branch_actions,
+                } => {
+                    assert_eq!(local_pr_branch_actions.len(), 2);
+                    assert_eq!(local_pr_branch_actions[0].stable_handle, "pr:alpha");
+                    assert!(matches!(
+                        local_pr_branch_actions[0].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                            | crate::local_pr_branches::LocalPrBranchActionKind::Skipped
+                    ));
+                    assert_eq!(local_pr_branch_actions[1].stable_handle, "pr:beta");
+                    assert_eq!(
+                        local_pr_branch_actions[1].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                    );
+                }
+                other => panic!("unexpected machine payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+
+        let _guard = DirGuard::change_to(&repo);
+        let (_merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored("main", "ignore").unwrap();
+        assert!(leading_ignored.is_empty());
+        let rewritten_alpha_tip = groups[0].commits.last().unwrap();
+        let rewritten_beta_tip = groups[1].commits.last().unwrap();
+        assert_ne!(
+            rewritten_beta_tip, &stale_beta_branch_tip,
+            "absorb should replay beta above the absorbed alpha tail"
+        );
+        assert_eq!(
+            rev_parse(&repo, "dank-spr/alpha"),
+            *rewritten_alpha_tip,
+            "local alpha branch should move to the rewritten alpha group tip"
+        );
+        assert_eq!(
+            rev_parse(&repo, "dank-spr/beta"),
+            *rewritten_beta_tip,
+            "local beta branch should move to the rewritten beta group tip"
+        );
     }
 
     #[test]

--- a/src/update_output.rs
+++ b/src/update_output.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
 
-use crate::config::PrDescriptionMode;
+use crate::config::{LocalPrBranchSyncPolicy, PrDescriptionMode};
 use crate::json_output::JsonCommand;
+use crate::local_pr_branches::LocalPrBranchAction;
 use crate::summary_output::SummaryOutput;
 
 pub type UpdateOutput = SummaryOutput<UpdateSummaryData>;
@@ -14,6 +15,7 @@ pub struct UpdateSummaryData {
     pub warnings: Vec<String>,
     pub skipped_groups: Vec<SkippedUpdateGroupData>,
     pub groups: Vec<UpdateGroupData>,
+    pub local_pr_branch_actions: Vec<LocalPrBranchAction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -29,6 +31,7 @@ pub struct UpdateOptions {
     pub dry_run: bool,
     pub no_pr: bool,
     pub pr_description_mode: PrDescriptionMode,
+    pub local_pr_branches: LocalPrBranchSyncPolicy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -44,6 +47,7 @@ pub struct UpdateExecutionData {
     pub warnings: Vec<String>,
     pub skipped_groups: Vec<SkippedUpdateGroupData>,
     pub groups: Vec<UpdateGroupData>,
+    pub local_pr_branch_actions: Vec<LocalPrBranchAction>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -113,6 +117,7 @@ impl UpdateSummaryData {
             warnings: execution.warnings,
             skipped_groups: execution.skipped_groups,
             groups: execution.groups,
+            local_pr_branch_actions: execution.local_pr_branch_actions,
         }
     }
 }


### PR DESCRIPTION
# Problem Solved

`spr` already publishes each PR group through synthetic remote branches like `<prefix><tag>`, but the matching local branches were not kept in sync by the tool. When a stack was updated, restacked, or absorbed, those local per-PR branches could be missing or left at old group tips. That made non-top PR fixes depend on manual reconciliation and made it easy to check out a stale local branch before appending fix commits.

# Mental model

This adds an opt-in `local_pr_branches` policy:

- `off`: preserve the current default behavior and do not touch local per-PR branches.
- `update-existing`: move matching local branches that already exist.
- `create-or-update`: create missing matching local branches and move existing ones.

When the policy is enabled, successful `spr update` and completed local rewrite commands align local `<prefix><tag>` branches with the checked-out stack branch's parsed PR group tips. Branches checked out in another worktree are reported as blocked. Branches with unabsorbed local tail commits are also blocked so those commits can be folded back with `spr absorb` before another sync-capable command moves the branch. Rewrites remember pre-rewrite group tips so higher PR branches can still move safely after a lower group is absorbed and replayed.

# Non-goals

- Do not change the default behavior; local PR branch sync remains disabled unless config or CLI opts in.
- Do not delete local branches.
- Do not reset a branch that is checked out in another worktree.
- Do not treat arbitrary divergent local branch history as safe to overwrite.

# Tradeoffs

The feature is conservative by default and explicit when enabled. That means stale or divergent local branch state can block synchronization, but the block is intentional: it prevents accidental loss of local branch-tail work and forces the operator to choose between `spr absorb` and manual inspection.

# Architecture

The change adds a typed `local_pr_branches` config/CLI policy and a shared local branch synchronization module. `spr update` builds local branch targets from the same planned PR-group branch targets it pushes. Local rewrite commands rescan the final stack after a completed rewrite and synchronize branch refs from the resulting group tips. JSON outputs include local branch action records so callers can tell which branches were created, moved, skipped, or blocked.

# Observability

`spr update --json` reports `data.local_pr_branch_actions`. Completed rewrite JSON payloads report top-level `local_pr_branch_actions`. Each action includes the stable PR handle, branch name, old tip, new tip, action, reason, and backup tag field, which lets callers distinguish "already current", "missing but update-existing", "checked out in another worktree", "unabsorbed local commits", and "diverged from target" cases without scraping logs.

# Tests

Validation covered the policy parser, CLI override, local branch planner, JSON output surface, update dry-run behavior, and absorb rewrite synchronization path:

- `cargo test`

<!-- spr-stack:start -->
**Stack**:
- ➡ #129

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
