### PR TITLE
absorb: support targeted suffix transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Behavior:
 - On cherry-pick conflict, `spr absorb` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`
 - Does not update GitHub; inspect the rewritten stack first, then run `spr update`
 - When `local_pr_branches` is enabled, synchronizes local synthetic PR branches to the absorbed stack's final group tips after the local rewrite succeeds. A branch checked out in any worktree is reported as blocked and is not moved.
+- `--from <N|label|pr:<label>>` constrains absorb to one explicit selected-and-higher suffix.
+- `--query-changed-branches --json` reports the stack branch plus every synthetic PR branch whose logical tip would change if the absorb rewrite ran, without creating backup tags, temp worktrees, or rewrite side effects. When paired with `--from`, it reports the full selected suffix even when only some branches currently have absorbable tails, so callers can query and apply one stable transaction boundary.
 
 Typical workflow:
 
@@ -306,6 +308,13 @@ Override example for intentionally keeping both an earlier copied follow-up comm
 
 ```bash
 spr absorb --allow-replayed-duplicates
+
+# Query the branch names that an absorb rewrite would change without rewriting anything.
+spr absorb --query-changed-branches --json
+
+# For a planned lower-group fix, query and apply the same explicit suffix.
+spr absorb --from pr:beta --query-changed-branches --json
+spr absorb --from pr:beta --json
 ```
 
 ### spr resolve-stack

--- a/src/absorb_output.rs
+++ b/src/absorb_output.rs
@@ -1,0 +1,63 @@
+//! Output contract for read-only absorb branch queries.
+
+use serde::Serialize;
+
+use crate::json_output::{JsonCommand, JSON_OUTPUT_SCHEMA_VERSION};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AbsorbQueryResult {
+    Query,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AbsorbChangedBranchesOutput {
+    pub schema_version: u32,
+    pub command: JsonCommand,
+    pub result: AbsorbQueryResult,
+    pub data: AbsorbChangedBranchesData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AbsorbChangedBranchesData {
+    pub changed_branches: Vec<String>,
+}
+
+pub fn changed_branches(changed_branches: Vec<String>) -> AbsorbChangedBranchesOutput {
+    AbsorbChangedBranchesOutput {
+        schema_version: JSON_OUTPUT_SCHEMA_VERSION,
+        command: JsonCommand::Absorb,
+        result: AbsorbQueryResult::Query,
+        data: AbsorbChangedBranchesData { changed_branches },
+    }
+}
+
+impl AbsorbChangedBranchesOutput {
+    pub fn exit_code(&self) -> i32 {
+        crate::json_output::EXIT_SUCCESS
+    }
+
+    pub fn render_human(&self) -> String {
+        if self.data.changed_branches.is_empty() {
+            "No branches would change.".to_string()
+        } else {
+            self.data.changed_branches.join("\n")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{changed_branches, AbsorbQueryResult};
+
+    #[test]
+    fn changed_branch_output_uses_query_envelope() {
+        let output = changed_branches(vec!["stack".to_string(), "dank-spr/alpha".to_string()]);
+
+        assert_eq!(output.result, AbsorbQueryResult::Query);
+        let json = serde_json::to_value(&output).unwrap();
+        assert_eq!(json["command"], "absorb");
+        assert_eq!(json["result"], "query");
+        assert_eq!(json["data"]["changed_branches"][0], "stack");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -155,12 +155,20 @@ pub enum Cmd {
 
     /// Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch
     #[command(
-        long_about = "Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.\n\nIf you append commits to the end of a local PR branch such as `user-spr/alpha`, run `spr absorb` while the stack branch is checked out. `spr` rebuilds the local stack so the new commits become part of the matching PR group. The PR-group order stays the same.\n\nThis command is local-only: it rewrites the current stack branch, creates a backup tag, and does not update GitHub. After checking the result, run `spr update`.\n\nOnly exact local branches named `prefix + tag` are considered. If one of those branches still points at rewritten-equivalent stack commits, `spr absorb` accepts that prefix only when the branch still descends from the same stack merge-base and the matched pre-tail commit ends at the same tree as the canonical stack prefix. A no-op rewritten match is reported as `skip (rewritten-equivalent prefix)`, and only commits appended above that proven prefix are absorbed. `spr absorb` also refuses to operate when two live PR groups would derive synthetic branch names that differ only by case.\n\nExample:\n- The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`.\n- Check out `user-spr/alpha` and append 2 commits.\n- Check out the stack branch.\n- Run `spr absorb`.\n- Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same.\n- Then run `spr update`.\n\nOn cherry-pick conflict, `spr absorb` leaves the temp rewrite worktree in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and run the printed resume command.\n\nAdvanced:\n- By default, absorb blocks copied later commits when replaying the stack would become empty or ambiguous.\n- `--allow-replayed-duplicates` allows an earlier copied non-seed follow-up commit to coexist with its later replayed copy by keeping both commits in the rewritten stack."
+        long_about = "Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.\n\nIf you append commits to the end of a local PR branch such as `user-spr/alpha`, run `spr absorb` while the stack branch is checked out. `spr` rebuilds the local stack so the new commits become part of the matching PR group. The PR-group order stays the same.\n\nThis command is local-only: it rewrites the current stack branch, creates a backup tag, and does not update GitHub. After checking the result, run `spr update`.\n\nOnly exact local branches named `prefix + tag` are considered. If one of those branches still points at rewritten-equivalent stack commits, `spr absorb` accepts that prefix only when the branch still descends from the same stack merge-base and the matched pre-tail commit ends at the same tree as the canonical stack prefix. A no-op rewritten match is reported as `skip (rewritten-equivalent prefix)`, and only commits appended above that proven prefix are absorbed. `spr absorb` also refuses to operate when two live PR groups would derive synthetic branch names that differ only by case.\n\nUse `--from <N|label|pr:<label>>` to constrain absorb to one PR group and every group above it. For example, `spr absorb --from pr:beta` considers only the `pr:beta..top` suffix and leaves unrelated lower-group branch tails out of scope.\n\nExample:\n- The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`.\n- Check out `user-spr/alpha` and append 2 commits.\n- Check out the stack branch.\n- Run `spr absorb`.\n- Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same.\n- Then run `spr update`.\n\nOn cherry-pick conflict, `spr absorb` leaves the temp rewrite worktree in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and run the printed resume command.\n\nAdvanced:\n- By default, absorb blocks copied later commits when replaying the stack would become empty or ambiguous.\n- `--allow-replayed-duplicates` allows an earlier copied non-seed follow-up commit to coexist with its later replayed copy by keeping both commits in the rewritten stack."
     )]
     Absorb {
+        /// Absorb only this PR group and every group above it
+        #[arg(long, value_name = "N|label|pr:<label>")]
+        from: Option<crate::selectors::GroupSelector>,
+
         /// Allow replayed duplicates and keep both copies when the later replay is non-seed
         #[arg(long)]
         allow_replayed_duplicates: bool,
+
+        /// Print the branch names that an absorb rewrite would change without rewriting
+        #[arg(long, conflicts_with = "dry_run")]
+        query_changed_branches: bool,
 
         #[command(flatten)]
         dry_run: DryRunArgs,
@@ -322,6 +330,32 @@ mod tests {
                 allow_replayed_duplicates,
                 ..
             } => assert!(allow_replayed_duplicates),
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn absorb_changed_branch_query_flag_parses() {
+        let cli = Cli::try_parse_from(["spr", "absorb", "--query-changed-branches"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Absorb {
+                query_changed_branches,
+                ..
+            } => assert!(query_changed_branches),
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn absorb_from_selector_parses() {
+        let cli = Cli::try_parse_from(["spr", "absorb", "--from", "pr:beta"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Absorb {
+                from: Some(crate::selectors::GroupSelector::Stable(handle)),
+                ..
+            } => assert_eq!(handle.tag, "beta"),
             other => panic!("unexpected command: {:?}", other),
         }
     }

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -22,11 +22,12 @@ use crate::commands::rewrite_resume::{
 use crate::config::DirtyWorktreePolicy;
 use crate::execution::ExecutionMode;
 use crate::git::{
-    git_commit_message, git_commit_parent_count, git_commit_tree, git_is_ancestor,
-    git_local_branch_tip, git_merge_base, git_patch_ids_for_commits, git_rev_list_range,
-    git_rev_parse,
+    git_commit_message, git_commit_parent_count, git_commit_tree, git_current_branch,
+    git_is_ancestor, git_local_branch_tip, git_merge_base, git_patch_ids_for_commits,
+    git_rev_list_range, git_rev_parse,
 };
 use crate::parsing::{derive_local_groups_with_ignored, Group};
+use crate::selectors::{resolve_group_index, GroupSelector};
 
 /// Rebuilds the current stack branch by folding append-only local per-PR branch
 /// tails back into their owning PR groups.
@@ -47,11 +48,13 @@ pub fn absorb_branch_tails(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    from: Option<&GroupSelector>,
     execution_mode: ExecutionMode,
     dirty_worktree_policy: DirtyWorktreePolicy,
     options: AbsorbOptions,
 ) -> Result<RewriteCommandOutcome> {
-    let (_stack_head, plan) = build_plan_for_current_stack(base, prefix, ignore_tag, options)?;
+    let (_stack_head, plan) =
+        build_plan_for_current_stack(base, prefix, ignore_tag, from, options)?;
     let validation = validate_absorb_plan(&plan);
     if !matches!(validation, AbsorbPlanValidation::NoGroups) {
         emit_absorb_summary(&plan);
@@ -78,6 +81,52 @@ pub fn absorb_branch_tails(
             dirty_worktree_policy,
         ),
     }
+}
+
+/// Returns the local branch names the current absorb transaction may move.
+///
+/// A tail inserted into an earlier group rewrites that group and every later
+/// group in the stack, even if optional local synthetic-branch synchronization
+/// is disabled for the actual command. Untargeted queries return the realized
+/// changed suffix. Targeted queries return the requested suffix so callers can
+/// protect the whole transaction boundary before running apply mode.
+pub fn query_absorb_changed_branches(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    from: Option<&GroupSelector>,
+    options: AbsorbOptions,
+) -> Result<Vec<String>> {
+    let (_stack_head, plan) =
+        build_plan_for_current_stack(base, prefix, ignore_tag, from, options)?;
+    match validate_absorb_plan(&plan) {
+        AbsorbPlanValidation::NoGroups => Ok(Vec::new()),
+        AbsorbPlanValidation::NoAbsorbableGroups if plan.requested_start_index.is_some() => {
+            changed_branches_for_plan(prefix, &plan)
+        }
+        AbsorbPlanValidation::NoAbsorbableGroups => Ok(Vec::new()),
+        AbsorbPlanValidation::Blocked { lines } => Err(anyhow!(
+            "Refusing to query changed branches until blocking branches are fixed:\n{}",
+            lines.join("\n")
+        )),
+        AbsorbPlanValidation::ReadyToRewrite => changed_branches_for_plan(prefix, &plan),
+    }
+}
+
+fn changed_branches_for_plan(prefix: &str, plan: &RewritePlan) -> Result<Vec<String>> {
+    let first_changed_group = plan.requested_start_index.unwrap_or_else(|| {
+        plan.groups
+            .iter()
+            .position(|group| group.source.is_absorbable())
+            .expect("ready-to-rewrite absorb plan should contain an absorbable group")
+    });
+    let mut changed_branches = vec![git_current_branch()?];
+    changed_branches.extend(
+        plan.groups[first_changed_group..]
+            .iter()
+            .map(|group| synthetic_branch_name(prefix, &group.group.tag)),
+    );
+    Ok(changed_branches)
 }
 
 /// CLI-configurable behavior switches for `spr absorb`.
@@ -109,6 +158,7 @@ struct RewritePlan {
     merge_base: String,
     leading_ignored: Vec<String>,
     groups: Vec<GroupRewritePlan>,
+    requested_start_index: Option<usize>,
     operations: Vec<CherryPickOp>,
 }
 
@@ -290,6 +340,7 @@ struct AbsorbTail {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AbsorbSkipReason {
+    BeforeRequestedSuffix,
     MissingBranch,
     Unchanged,
     RewrittenEquivalentPrefix,
@@ -299,6 +350,7 @@ enum AbsorbSkipReason {
 impl std::fmt::Display for AbsorbSkipReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::BeforeRequestedSuffix => write!(f, "before requested suffix"),
             Self::MissingBranch => write!(f, "missing local branch"),
             Self::Unchanged => write!(f, "branch unchanged"),
             Self::RewrittenEquivalentPrefix => write!(f, "rewritten-equivalent prefix"),
@@ -403,9 +455,13 @@ fn build_plan_for_current_stack(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    from: Option<&GroupSelector>,
     options: AbsorbOptions,
 ) -> Result<(String, RewritePlan)> {
     let (merge_base, leading_ignored, groups) = derive_local_groups_with_ignored(base, ignore_tag)?;
+    let requested_start_index = from
+        .map(|selector| resolve_group_index(&groups, selector))
+        .transpose()?;
     if groups.is_empty() {
         Ok((
             git_rev_parse("HEAD")?,
@@ -413,6 +469,7 @@ fn build_plan_for_current_stack(
                 merge_base,
                 leading_ignored,
                 groups: Vec::new(),
+                requested_start_index: None,
                 operations: Vec::new(),
             },
         ))
@@ -421,8 +478,14 @@ fn build_plan_for_current_stack(
         let stack_head = git_rev_parse("HEAD")?;
         let preliminary_group_plans = groups
             .into_iter()
+            .enumerate()
             .map(|group| {
-                build_preliminary_group_rewrite_plan(group, prefix, &merge_base, &stack_head)
+                let (index, group) = group;
+                if requested_start_index.is_some_and(|start| index < start) {
+                    build_out_of_scope_group_rewrite_plan(group, prefix)
+                } else {
+                    build_preliminary_group_rewrite_plan(group, prefix, &merge_base, &stack_head)
+                }
             })
             .collect::<Result<Vec<_>>>()?;
         let later_owned_patch_maps = build_later_owned_patch_maps(&preliminary_group_plans)?;
@@ -440,10 +503,36 @@ fn build_plan_for_current_stack(
                 merge_base,
                 leading_ignored,
                 groups: group_plans,
+                requested_start_index,
                 operations,
             },
         ))
     }
+}
+
+fn build_out_of_scope_group_rewrite_plan(
+    group: Group,
+    prefix: &str,
+) -> Result<PreliminaryGroupRewritePlan> {
+    let tag = group.tag.clone();
+    let branch_name = synthetic_branch_name(prefix, &group.tag);
+    let group_tip = group
+        .commits
+        .last()
+        .cloned()
+        .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+    Ok(PreliminaryGroupRewritePlan {
+        group,
+        source: PreliminarySourceBranchRecord {
+            tag,
+            branch_name,
+            group_tip,
+            source_tip: None,
+            classification: PreliminaryAbsorbClassification::Resolved(AbsorbClassification::Skip(
+                AbsorbSkipReason::BeforeRequestedSuffix,
+            )),
+        },
+    })
 }
 
 fn build_preliminary_group_rewrite_plan(
@@ -1079,10 +1168,10 @@ fn short_sha(sha: &str) -> &str {
 mod tests {
     use super::{
         absorb_branch_tails, build_plan_for_current_stack, build_rewrite_operations,
-        validate_absorb_plan, AbsorbBlocker, AbsorbClassification, AbsorbOptions,
-        AbsorbPlanValidation, AbsorbSkipReason, AbsorbTail, CopiedLaterStackCommitPolicy,
-        GroupRewritePlan, LaterReplayedCommit, LaterReplayedCommitKind, RewritePlan,
-        SourceBranchRecord,
+        query_absorb_changed_branches, validate_absorb_plan, AbsorbBlocker, AbsorbClassification,
+        AbsorbOptions, AbsorbPlanValidation, AbsorbSkipReason, AbsorbTail,
+        CopiedLaterStackCommitPolicy, GroupRewritePlan, LaterReplayedCommit,
+        LaterReplayedCommitKind, RewritePlan, SourceBranchRecord,
     };
     use crate::commands::common::{CherryPickEmptyPolicy, CherryPickOp};
     use crate::commands::rewrite_resume::{resume_rewrite, RewriteResumeState};
@@ -1090,6 +1179,7 @@ mod tests {
     use crate::config::DirtyWorktreePolicy;
     use crate::execution::ExecutionMode;
     use crate::parsing::{derive_local_groups_with_ignored, Group};
+    use crate::selectors::{GroupSelector, StableHandle};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
     use std::env;
     use std::fs;
@@ -1195,6 +1285,7 @@ mod tests {
             "main",
             "dank-spr/",
             "ignore",
+            None,
             ExecutionMode::DryRun,
             DirtyWorktreePolicy::Halt,
             AbsorbOptions::default(),
@@ -1540,6 +1631,7 @@ mod tests {
             &repo.base_branch,
             &repo.prefix,
             &repo.ignore_tag,
+            None,
             options,
         )
         .unwrap();
@@ -1841,6 +1933,7 @@ mod tests {
                 },
                 ..blocked_group
             }],
+            requested_start_index: None,
             operations: Vec::new(),
         };
 
@@ -1974,6 +2067,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2006,6 +2100,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2044,6 +2139,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2084,6 +2180,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 absorb_override_options(),
@@ -2180,6 +2277,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2282,6 +2380,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2319,6 +2418,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2354,6 +2454,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::DryRun,
                 crate::config::DirtyWorktreePolicy::Discard,
                 default_absorb_options(),
@@ -2396,6 +2497,7 @@ mod tests {
                 &repo.base_branch,
                 &repo.prefix,
                 &repo.ignore_tag,
+                None,
                 ExecutionMode::Apply,
                 DirtyWorktreePolicy::Halt,
                 default_absorb_options(),
@@ -2464,6 +2566,7 @@ mod tests {
             &repo.base_branch,
             &repo.prefix,
             &repo.ignore_tag,
+            None,
             default_absorb_options(),
         )
         .unwrap();
@@ -2472,6 +2575,168 @@ mod tests {
         assert!(
             plan.operations.len() >= 4,
             "rewrite plan should include leading replay plus group operations"
+        );
+    }
+
+    #[test]
+    fn changed_branch_query_reports_rewritten_suffix_without_side_effects() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let original_head = rev_parse(&repo.repo, "HEAD");
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let _guard = DirGuard::change_to(&repo.repo);
+        let changed_branches = query_absorb_changed_branches(
+            &repo.base_branch,
+            &repo.prefix,
+            &repo.ignore_tag,
+            None,
+            default_absorb_options(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            changed_branches,
+            vec![
+                repo.stack_branch.clone(),
+                "dank-spr/alpha".to_string(),
+                "dank-spr/beta".to_string(),
+                "dank-spr/gamma".to_string(),
+            ]
+        );
+        assert_eq!(rev_parse(&repo.repo, "HEAD"), original_head);
+        assert!(tags_with_pattern(&repo.repo, "backup/absorb/*").is_empty());
+        assert!(branches_with_pattern(&repo.repo, "spr/tmp-absorb-*").is_empty());
+    }
+
+    #[test]
+    fn targeted_changed_branch_query_reports_requested_suffix() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let from = GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        });
+        let _guard = DirGuard::change_to(&repo.repo);
+        let changed_branches = query_absorb_changed_branches(
+            &repo.base_branch,
+            &repo.prefix,
+            &repo.ignore_tag,
+            Some(&from),
+            default_absorb_options(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            changed_branches,
+            vec![
+                repo.stack_branch.clone(),
+                "dank-spr/beta".to_string(),
+                "dank-spr/gamma".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn targeted_absorb_ignores_lower_tails_and_absorbs_suffix_tails() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        let _alpha_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/alpha",
+            "alpha.txt",
+            "alpha-1\nalpha-2\nalpha-branch\n",
+            "feat: alpha branch tail",
+        );
+        let _beta_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/beta",
+            "beta.txt",
+            "beta-1\nbeta-branch\n",
+            "feat: beta branch tail",
+        );
+        let _gamma_branch_tip = append_commit_to_branch(
+            &repo.repo,
+            "dank-spr/gamma",
+            "gamma.txt",
+            "gamma-1\ngamma-branch\n",
+            "feat: gamma branch tail",
+        );
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let from = GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        });
+        {
+            let _guard = DirGuard::change_to(&repo.repo);
+            absorb_branch_tails(
+                &repo.base_branch,
+                &repo.prefix,
+                &repo.ignore_tag,
+                Some(&from),
+                ExecutionMode::Apply,
+                crate::config::DirtyWorktreePolicy::Discard,
+                default_absorb_options(),
+            )
+            .unwrap();
+        }
+
+        let _guard = DirGuard::change_to(&repo.repo);
+        let (_merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored(&repo.base_branch, &repo.ignore_tag).unwrap();
+        assert!(leading_ignored.is_empty());
+        assert_eq!(groups[0].commits.len(), 2, "alpha should remain unchanged");
+        assert_eq!(groups[1].commits.len(), 2, "beta should absorb its tail");
+        assert_eq!(groups[2].commits.len(), 2, "gamma should absorb its tail");
+        assert_ne!(
+            rev_parse(&repo.repo, "dank-spr/alpha"),
+            *groups[0].commits.last().unwrap(),
+            "the lower alpha tail should remain pending after targeted absorb"
+        );
+    }
+
+    #[test]
+    fn targeted_absorb_rejects_missing_selector() {
+        let _lock = lock_cwd();
+        let repo = setup_three_group_stack();
+        let _keep_dir_alive = repo.dir.path();
+        git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
+
+        let from = GroupSelector::Stable(StableHandle {
+            tag: "missing".to_string(),
+        });
+        let _guard = DirGuard::change_to(&repo.repo);
+        let err = query_absorb_changed_branches(
+            &repo.base_branch,
+            &repo.prefix,
+            &repo.ignore_tag,
+            Some(&from),
+            default_absorb_options(),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("No outstanding PR group matches stable handle `pr:missing`."),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,7 +13,9 @@ pub mod restack;
 pub mod rewrite_resume;
 pub mod update;
 
-pub use absorb::{absorb_branch_tails, AbsorbOptions, CopiedLaterStackCommitPolicy};
+pub use absorb::{
+    absorb_branch_tails, query_absorb_changed_branches, AbsorbOptions, CopiedLaterStackCommitPolicy,
+};
 pub use cleanup::{cleanup_remote_branches, print_cleanup_summary};
 pub use drop_merged_prefix::drop_merged_prefix;
 pub use fix_pr::fix_pr_tail;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::execution::ExecutionMode;
 
+mod absorb_output;
 mod branch_names;
 mod cli;
 mod commands;
@@ -91,6 +92,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
 #[derive(Debug)]
 enum CommandOutput {
     None,
+    AbsorbQuery(crate::absorb_output::AbsorbChangedBranchesOutput),
     Machine(crate::machine_output::MachineOutput),
     ReadOnly(crate::read_only_output::ReadOnlyOutput),
     RestackPreview(crate::restack_output::RestackPreviewOutput),
@@ -572,11 +574,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             )?))
         }
         crate::cli::Cmd::Absorb {
+            from,
             allow_replayed_duplicates,
+            query_changed_branches,
             dry_run,
         } => {
-            let execution_mode = ExecutionMode::from(dry_run);
-            set_dry_run_env(execution_mode, false);
             let options = crate::commands::AbsorbOptions {
                 copied_later_stack_commit_policy: if allow_replayed_duplicates {
                     crate::commands::CopiedLaterStackCommitPolicy::AllowKeepNonSeedDuplicates
@@ -584,10 +586,25 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     crate::commands::CopiedLaterStackCommitPolicy::Block
                 },
             };
+            if query_changed_branches {
+                let changed_branches = crate::commands::query_absorb_changed_branches(
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                    from.as_ref(),
+                    options,
+                )?;
+                return Ok(CommandOutput::AbsorbQuery(
+                    crate::absorb_output::changed_branches(changed_branches),
+                ));
+            }
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
             let outcome = crate::commands::absorb_branch_tails(
                 &base,
                 &prefix,
                 &ignore_tag,
+                from.as_ref(),
                 execution_mode,
                 dirty_worktree_policy,
                 options,
@@ -970,6 +987,13 @@ fn main() {
     match run_cli(cli, output_format) {
         Ok(output) => match output {
             CommandOutput::None => {}
+            CommandOutput::AbsorbQuery(output) => {
+                if output_format == crate::cli::OutputFormat::Json {
+                    exit_with_json(&output, output.exit_code());
+                } else {
+                    println!("{}", output.render_human());
+                }
+            }
             CommandOutput::Machine(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
                     exit_with_json(&output, output.exit_code());
@@ -1188,7 +1212,9 @@ mod tests {
     #[test]
     fn absorb_is_local_only_for_tool_checks() {
         assert!(!command_requires_gh(&crate::cli::Cmd::Absorb {
+            from: None,
             allow_replayed_duplicates: false,
+            query_changed_branches: false,
             dry_run: DryRunArgs::default(),
         }));
     }


### PR DESCRIPTION
Add an explicit suffix selector and a side-effect-free changed-branch query to `spr absorb`. Together they let callers lock and apply the same selected-and-higher suffix instead of rediscovering a moving boundary between planning and execution.

# Problem Solved

Lower-stack fixes need to protect every branch that may move during absorb. Before this change, callers could inspect the stack and then run a broader absorb later, but they had no single stable transaction boundary that both steps shared.

# Mental model

Selecting beta means "operate on beta and every group above it." The query form reports exactly the branches that same suffix would rewrite, and the apply form reuses the same selector when it performs the absorb.

# Tests

Validation covers selector parsing, changed-branch queries, missing selectors, and a targeted absorb that leaves lower-group tails pending while absorbing the chosen suffix.

- `cargo test`

<!-- spr-stack:start -->
**Stack**:
-   #136
-   #135
-   #134
-   #133
-   #132
- ➡ #131

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->