### PR TITLE
spr: reconcile local PR branches explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ list_order: recent_on_bottom
 # - `off` (default): do not create or move local per-PR branches
 # - `update-existing`: move matching local branches that already exist
 # - `create-or-update`: create missing matching local branches and move existing ones
+# Read-only `list` / `status` commands surface any drift this policy would reconcile.
 local_pr_branches: off
 
 # How `spr restack` behaves on cherry-pick conflicts
@@ -350,6 +351,22 @@ spr resolve-stack
 spr resolve-stack --json https://github.com/org/repo/pull/123
 ```
 
+### spr sync-local-branches
+
+Reconcile local synthetic PR branches with the checked-out stack without publishing or rewriting
+the stack itself.
+
+Behavior:
+
+- Uses the same `local_pr_branches` policy as automatic post-command sync
+- `off` is a no-op unless you override it with `--local-pr-branches`
+- `update-existing` moves only already-present local branches
+- `create-or-update` also creates missing local branches
+- Refuses to move a branch that is checked out in any worktree
+- Useful after manual Git surgery outside `spr`, such as an interactive rebase or manual commit
+  reorder, when the next read-only `spr list` / `spr status` output reports local branch drift
+- Does not touch GitHub or rewrite the checked-out stack branch
+
 ### spr resume
 
 Resume a suspended local rewrite from the exact path printed by `spr restack`,
@@ -373,14 +390,15 @@ Machine-readable `--json` mode:
   equivalent. A `--json` token after `--` is preserved as payload and does not change `spr`
   output mode.
 - Supported on operational commands including `spr list pr`, `spr list commit`, `spr status`,
-  `spr update`, `spr prep`, `spr relink-prs`, `spr cleanup`, `spr restack`, `spr absorb`,
-  `spr move`, `spr fix-pr`, `spr land`, `spr resume`, and `spr resolve-stack`
+  `spr sync-local-branches`, `spr update`, `spr prep`, `spr relink-prs`, `spr cleanup`,
+  `spr restack`, `spr absorb`, `spr move`, `spr fix-pr`, `spr land`, `spr resume`, and
+  `spr resolve-stack`
 - Also supported for display output: `spr --json --help`, `spr --help --json`,
   `spr --json help list commit`, `spr list commit --help --json`, `spr --json --version`, and
   `spr --version --json` each emit one structured JSON object
 - In `--json` mode, stdout is exactly one JSON object and stderr is normally empty
-- Summary-style commands (`list pr`, `list commit`, `status`, `update`, `prep`, `relink-prs`,
-  and `cleanup`) share the same top-level shape: `schema_version`, `command`,
+- Summary-style commands (`list pr`, `list commit`, `status`, `sync-local-branches`, `update`,
+  `prep`, `relink-prs`, and `cleanup`) share the same top-level shape: `schema_version`, `command`,
   `result: "summary"`, and `data`
 - JSON help uses `result: "help"` and includes the resolved command path, usage, options,
   positionals, subcommands, aliases, and `rendered_text` containing Clap's normal human help
@@ -388,7 +406,11 @@ Machine-readable `--json` mode:
 - `spr list --json pr`, `spr list --json commit`, and `spr status --json` always emit canonical
   bottom-up stack order, even when `list_order: recent_on_top` changes the human display order.
   Each group's `remote.kind` encodes whether there is no matching PR, a PR without CI/review
-  data, or a PR with typed CI/review status.
+  data, or a PR with typed CI/review status. When `local_pr_branches` is enabled, those read-only
+  payloads also include `local_pr_branch_drift`, which lists the local branch actions a
+  follow-on `spr sync-local-branches` would need to perform.
+- `spr sync-local-branches --json` writes the effective local branch sync policy plus
+  `local_pr_branch_actions` for the reconciliation it just performed.
 - `spr update --json` writes repo context, resolved extent metadata, warnings, skipped groups,
   per-group branch or PR actions, and `local_pr_branch_actions`
 - `spr prep --json` writes the resolved selection, selected-group rewrite actions, replay counts,
@@ -627,6 +649,8 @@ Behavior:
 - Rewrites local history to ensure selected PRs become single-commit groups
 - Pushes branches (respects `--dry-run`)
 - Adds a warning to the next PR not included in the push
+- When `local_pr_branches` is enabled, the nested update path also synchronizes local synthetic PR
+  branches after the prepared rewrite succeeds.
 - `--json` writes the typed prep summary instead of human log lines
 - In `--dry-run`, prep still computes the hypothetical rewritten commit chain so the JSON summary
   reflects the rewritten stack instead of the current branch tip

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,6 +202,9 @@ pub enum Cmd {
     #[command(alias = "stat")]
     Status,
 
+    /// Reconcile local per-PR branches with the current stack using the configured sync policy
+    SyncLocalBranches,
+
     /// Find the owning stack branch for a PR branch or report that the target is already a stack branch
     #[command(
         long_about = "Find the owning stack branch for a PR branch using repo-local stack metadata.\n\nTargets may be omitted (use the current branch), a local branch name, a remote-qualified branch name such as `origin/dank-spr/alpha`, or a GitHub PR URL. This command is strict and metadata-backed: it does not scan unrelated branches or guess a likely owner."

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -18,7 +18,7 @@ use crate::branch_names::{
     canonical_branch_conflict_key, find_synthetic_branch_name_collision, group_branch_identities,
     CanonicalBranchConflictKey, SyntheticBranchIdentity, SyntheticBranchNameCollision,
 };
-use crate::config::ListOrder;
+use crate::config::{ListOrder, LocalPrBranchSyncPolicy};
 use crate::github::{
     fetch_pr_ci_review_status, list_open_or_merged_prs_for_heads, PrCiReviewStatus, PrCiState,
     PrInfoWithState, PrReviewDecision, PrState,
@@ -87,6 +87,7 @@ pub struct PrGroupData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PrListData {
     pub groups: Vec<PrGroupData>,
+    pub local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -108,6 +109,7 @@ pub struct CommitGroupData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommitListData {
     pub groups: Vec<CommitGroupData>,
+    pub local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 }
 
 /// Maps remote PR state into the two-character status slot used by `spr list pr`.
@@ -290,6 +292,7 @@ fn build_pr_list_data(
     groups: &[Group],
     branch_identities: &[SyntheticBranchIdentity],
     remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
+    local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 ) -> PrListData {
     let groups = groups
         .iter()
@@ -313,13 +316,17 @@ fn build_pr_list_data(
         })
         .collect();
 
-    PrListData { groups }
+    PrListData {
+        groups,
+        local_pr_branch_drift,
+    }
 }
 
 fn build_commit_list_data(
     groups: &[Group],
     branch_identities: &[SyntheticBranchIdentity],
     remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
+    local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 ) -> CommitListData {
     let group_start_indices: Vec<usize> = groups
         .iter()
@@ -361,40 +368,63 @@ fn build_commit_list_data(
         })
         .collect();
 
-    CommitListData { groups }
+    CommitListData {
+        groups,
+        local_pr_branch_drift,
+    }
 }
 
 pub fn collect_pr_list_data_for_json(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> std::result::Result<PrListData, ReadOnlyQueryError> {
     let (groups, branch_identities) = derive_groups_and_identities(base, prefix, ignore_tag)?;
     let remote_by_head =
         fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?;
+    let targets = crate::local_pr_branches::targets_from_groups(prefix, &groups)
+        .map_err(ReadOnlyQueryError::Internal)?;
+    let local_pr_branch_drift =
+        crate::local_pr_branches::plan_local_pr_branch_drift(local_pr_branch_policy, &targets)
+            .map_err(ReadOnlyQueryError::Internal)?;
     Ok(build_pr_list_data(
         &groups,
         &branch_identities,
         &remote_by_head,
+        local_pr_branch_drift,
     ))
 }
 
-pub fn collect_pr_list_data(base: &str, prefix: &str, ignore_tag: &str) -> Result<PrListData> {
-    collect_pr_list_data_for_json(base, prefix, ignore_tag).map_err(anyhow::Error::from)
+pub fn collect_pr_list_data(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
+) -> Result<PrListData> {
+    collect_pr_list_data_for_json(base, prefix, ignore_tag, local_pr_branch_policy)
+        .map_err(anyhow::Error::from)
 }
 
 pub fn collect_commit_list_data_for_json(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> std::result::Result<CommitListData, ReadOnlyQueryError> {
     let (groups, branch_identities) = derive_groups_and_identities(base, prefix, ignore_tag)?;
     let remote_by_head =
         fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?;
+    let targets = crate::local_pr_branches::targets_from_groups(prefix, &groups)
+        .map_err(ReadOnlyQueryError::Internal)?;
+    let local_pr_branch_drift =
+        crate::local_pr_branches::plan_local_pr_branch_drift(local_pr_branch_policy, &targets)
+            .map_err(ReadOnlyQueryError::Internal)?;
     Ok(build_commit_list_data(
         &groups,
         &branch_identities,
         &remote_by_head,
+        local_pr_branch_drift,
     ))
 }
 
@@ -402,8 +432,10 @@ pub fn collect_commit_list_data(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<CommitListData> {
-    collect_commit_list_data_for_json(base, prefix, ignore_tag).map_err(anyhow::Error::from)
+    collect_commit_list_data_for_json(base, prefix, ignore_tag, local_pr_branch_policy)
+        .map_err(anyhow::Error::from)
 }
 
 fn render_pr_list(data: &PrListData, list_order: ListOrder) -> Vec<String> {
@@ -488,6 +520,31 @@ fn render_commit_list(data: &CommitListData, list_order: ListOrder) -> Vec<Strin
     }
 }
 
+fn render_local_pr_branch_drift(
+    drift: &[crate::local_pr_branches::LocalPrBranchAction],
+) -> Vec<String> {
+    drift
+        .iter()
+        .map(|action| match action.action {
+            crate::local_pr_branches::LocalPrBranchActionKind::Created => format!(
+                "local branch {} is missing; run `spr sync-local-branches`",
+                action.branch
+            ),
+            crate::local_pr_branches::LocalPrBranchActionKind::Updated => format!(
+                "local branch {} is stale; run `spr sync-local-branches`",
+                action.branch
+            ),
+            crate::local_pr_branches::LocalPrBranchActionKind::Blocked => format!(
+                "local branch {} is stale but checked out in a worktree; run `spr sync-local-branches` after freeing it",
+                action.branch
+            ),
+            crate::local_pr_branches::LocalPrBranchActionKind::Skipped => {
+                unreachable!("drift output excludes skipped local PR branch actions")
+            }
+        })
+        .collect()
+}
+
 /// Print a per-PR summary for the current local stack.
 ///
 /// The local stack order is derived bottom-up from commits, so local PR numbers are based
@@ -499,9 +556,13 @@ pub fn list_prs_display(
     prefix: &str,
     ignore_tag: &str,
     list_order: ListOrder,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<()> {
-    let data = collect_pr_list_data(base, prefix, ignore_tag)?;
+    let data = collect_pr_list_data(base, prefix, ignore_tag, local_pr_branch_policy)?;
     for line in render_pr_list(&data, list_order) {
+        info!("{line}");
+    }
+    for line in render_local_pr_branch_drift(&data.local_pr_branch_drift) {
         info!("{line}");
     }
     Ok(())
@@ -518,9 +579,13 @@ pub fn list_commits_display(
     prefix: &str,
     ignore_tag: &str,
     list_order: ListOrder,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<()> {
-    let data = collect_commit_list_data(base, prefix, ignore_tag)?;
+    let data = collect_commit_list_data(base, prefix, ignore_tag, local_pr_branch_policy)?;
     for line in render_commit_list(&data, list_order) {
+        info!("{line}");
+    }
+    for line in render_local_pr_branch_drift(&data.local_pr_branch_drift) {
         info!("{line}");
     }
     Ok(())
@@ -651,7 +716,7 @@ mod tests {
             ),
         )]);
 
-        let data = build_pr_list_data(&groups, &branch_identities, &remote_by_head);
+        let data = build_pr_list_data(&groups, &branch_identities, &remote_by_head, Vec::new());
         assert_eq!(data.groups[0].local_pr_number, 1);
         assert_eq!(data.groups[0].stable_handle, "pr:alpha");
         assert_eq!(data.groups[1].local_pr_number, 2);
@@ -739,7 +804,7 @@ mod tests {
             ),
         )]);
 
-        let data = build_commit_list_data(&groups, &branch_identities, &remote_by_head);
+        let data = build_commit_list_data(&groups, &branch_identities, &remote_by_head, Vec::new());
 
         assert_eq!(data.groups[0].stable_handle, "pr:alpha");
         assert_eq!(
@@ -781,6 +846,7 @@ mod tests {
                     },
                 },
             ],
+            local_pr_branch_drift: Vec::new(),
         };
 
         let lines = render_pr_list(&data, ListOrder::RecentOnTop);
@@ -837,6 +903,7 @@ mod tests {
                     }],
                 },
             ],
+            local_pr_branch_drift: Vec::new(),
         };
 
         let lines = render_commit_list(&data, ListOrder::RecentOnTop);
@@ -855,13 +922,50 @@ mod tests {
     }
 
     #[test]
+    fn render_local_pr_branch_drift_suggests_explicit_reconciliation() {
+        let lines = render_local_pr_branch_drift(&[
+            crate::local_pr_branches::LocalPrBranchAction {
+                stable_handle: "pr:alpha".to_string(),
+                branch: "dank-spr/alpha".to_string(),
+                old_tip: Some("aaaaaaaa1".to_string()),
+                new_tip: "bbbbbbbb1".to_string(),
+                action: crate::local_pr_branches::LocalPrBranchActionKind::Updated,
+                reason: "move existing local branch to target".to_string(),
+                backup_tag: None,
+            },
+            crate::local_pr_branches::LocalPrBranchAction {
+                stable_handle: "pr:beta".to_string(),
+                branch: "dank-spr/beta".to_string(),
+                old_tip: None,
+                new_tip: "cccccccc1".to_string(),
+                action: crate::local_pr_branches::LocalPrBranchActionKind::Created,
+                reason: "create missing local branch at target".to_string(),
+                backup_tag: None,
+            },
+        ]);
+
+        assert_eq!(
+            lines,
+            vec![
+                "local branch dank-spr/alpha is stale; run `spr sync-local-branches`",
+                "local branch dank-spr/beta is missing; run `spr sync-local-branches`",
+            ]
+        );
+    }
+
+    #[test]
     fn collect_pr_list_data_for_json_returns_typed_collision_error() {
         let _lock = lock_cwd();
         let repo = init_case_conflicting_stack_repo();
         let _guard = DirGuard::change_to(repo.path());
 
-        let err =
-            collect_pr_list_data_for_json("main", "dank-spr/", "ignore").expect_err("collision");
+        let err = collect_pr_list_data_for_json(
+            "main",
+            "dank-spr/",
+            "ignore",
+            LocalPrBranchSyncPolicy::Off,
+        )
+        .expect_err("collision");
 
         match err {
             ReadOnlyQueryError::SyntheticBranchNameCollision(collision) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,7 +27,7 @@ pub use list::{
     CommitGroupData, CommitListData, PrGroupData, PrListData, ReadOnlyQueryError, RemotePrMetadata,
     RemotePrState,
 };
-pub use prep::{prep_squash, print_prep_summary};
+pub use prep::{prep_squash, print_prep_summary, PrepExecutionOptions};
 pub use r#move::{move_groups_after, MoveExecutionOptions};
 pub use relink_prs::{print_relink_prs_summary, relink_prs};
 pub use resolve_stack::{looks_like_pr_url, resolve_stack, ResolveStackOutput};

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -20,6 +20,14 @@ use crate::update_output::{
     ResolvedUpdateLimit, UpdateOptions, UpdateRepoContext, UpdateSummaryData,
 };
 
+pub struct PrepExecutionOptions {
+    pub pr_description_mode: crate::config::PrDescriptionMode,
+    pub list_order: crate::config::ListOrder,
+    pub local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy,
+    pub selection: crate::cli::PrepSelection,
+    pub execution_mode: ExecutionMode,
+}
+
 fn resolve_prep_window(
     groups: &[crate::parsing::Group],
     selection: &crate::cli::PrepSelection,
@@ -177,11 +185,15 @@ pub fn prep_squash(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-    pr_description_mode: crate::config::PrDescriptionMode,
-    list_order: crate::config::ListOrder,
-    selection: crate::cli::PrepSelection,
-    execution_mode: ExecutionMode,
+    options: PrepExecutionOptions,
 ) -> Result<PrepSummaryData> {
+    let PrepExecutionOptions {
+        pr_description_mode,
+        list_order,
+        local_pr_branch_policy,
+        selection,
+        execution_mode,
+    } = options;
     let dry_run = execution_mode == ExecutionMode::DryRun;
     let (merge_base, groups) = derive_local_groups(base, ignore_tag)?;
     if groups.is_empty() {
@@ -383,7 +395,7 @@ pub fn prep_squash(
         list_order,
         true,
         0,
-        crate::config::LocalPrBranchSyncPolicy::Off,
+        local_pr_branch_policy,
     )?;
     let update_summary = UpdateSummaryData::from_execution(
         UpdateRepoContext {
@@ -396,7 +408,7 @@ pub fn prep_squash(
             dry_run,
             no_pr: false,
             pr_description_mode,
-            local_pr_branches: crate::config::LocalPrBranchSyncPolicy::Off,
+            local_pr_branches: local_pr_branch_policy,
         },
         resolved_extent,
         update_execution,
@@ -484,7 +496,7 @@ pub fn print_prep_summary(summary: &PrepSummaryData) {
 
 #[cfg(test)]
 mod tests {
-    use super::{prep_squash, render_prep_summary, resolve_prep_window};
+    use super::{prep_squash, render_prep_summary, resolve_prep_window, PrepExecutionOptions};
     use crate::cli::PrepSelection;
     use crate::config::{ListOrder, PrDescriptionMode};
     use crate::execution::ExecutionMode;
@@ -572,10 +584,13 @@ mod tests {
             "main",
             "dank-spr/",
             "ignore",
-            PrDescriptionMode::Overwrite,
-            ListOrder::RecentOnBottom,
-            PrepSelection::All,
-            ExecutionMode::DryRun,
+            PrepExecutionOptions {
+                pr_description_mode: PrDescriptionMode::Overwrite,
+                list_order: ListOrder::RecentOnBottom,
+                local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy::Off,
+                selection: PrepSelection::All,
+                execution_mode: ExecutionMode::DryRun,
+            },
         )
         .unwrap_err();
 

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -26,6 +26,7 @@ pub enum JsonCommand {
     ListPr,
     ListCommit,
     Status,
+    SyncLocalBranches,
     Update,
     Prep,
     RelinkPrs,
@@ -320,6 +321,8 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
                 saw_list = true;
             } else if arg == "status" || arg == "stat" {
                 return JsonCommand::Status;
+            } else if arg == "sync-local-branches" {
+                return JsonCommand::SyncLocalBranches;
             } else if arg == "update" || arg == "u" {
                 return JsonCommand::Update;
             } else if arg == "prep" {

--- a/src/local_pr_branches.rs
+++ b/src/local_pr_branches.rs
@@ -89,6 +89,35 @@ pub fn sync_local_pr_branches(
     Ok(actions)
 }
 
+pub fn plan_local_pr_branch_drift(
+    policy: LocalPrBranchSyncPolicy,
+    targets: &[LocalPrBranchTarget],
+) -> Result<Vec<LocalPrBranchAction>> {
+    if policy == LocalPrBranchSyncPolicy::Off || targets.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let checked_out_branches = checked_out_local_branches()?;
+    targets
+        .iter()
+        .map(|target| plan_action(policy, target, &checked_out_branches))
+        .filter_map(|planned| match planned {
+            Ok(planned)
+                if matches!(
+                    planned.action,
+                    LocalPrBranchActionKind::Created
+                        | LocalPrBranchActionKind::Updated
+                        | LocalPrBranchActionKind::Blocked
+                ) =>
+            {
+                Some(Ok(planned.into_action_without_backup_tag()))
+            }
+            Ok(_) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .collect()
+}
+
 fn plan_action(
     policy: LocalPrBranchSyncPolicy,
     target: &LocalPrBranchTarget,
@@ -130,6 +159,20 @@ fn plan_action(
         action,
         reason,
     })
+}
+
+impl PlannedLocalPrBranchAction {
+    fn into_action_without_backup_tag(self) -> LocalPrBranchAction {
+        LocalPrBranchAction {
+            stable_handle: self.target.stable_handle,
+            branch: self.target.branch_name,
+            old_tip: self.old_tip,
+            new_tip: self.target.tip,
+            action: self.action,
+            reason: self.reason,
+            backup_tag: None,
+        }
+    }
 }
 
 fn apply_action(
@@ -266,7 +309,10 @@ fn short_sha(sha: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{sync_local_pr_branches, LocalPrBranchActionKind, LocalPrBranchTarget};
+    use super::{
+        plan_local_pr_branch_drift, sync_local_pr_branches, LocalPrBranchActionKind,
+        LocalPrBranchTarget,
+    };
     use crate::config::LocalPrBranchSyncPolicy;
     use crate::execution::ExecutionMode;
     use crate::test_support::{commit_file, git, init_repo, lock_cwd, DirGuard};
@@ -400,6 +446,37 @@ mod tests {
 
         assert_eq!(actions[0].action, LocalPrBranchActionKind::Created);
         assert!(branch_tip(&repo, "dank-spr/alpha").is_none());
+    }
+
+    #[test]
+    fn drift_planning_reports_only_reconcilable_or_blocked_branches() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let current_tip = rev_parse(&repo, "HEAD");
+        git(
+            &repo,
+            ["branch", "dank-spr/current", &current_tip].as_slice(),
+        );
+        git(&repo, ["branch", "dank-spr/stale", &current_tip].as_slice());
+        let target_tip = commit_file(&repo, "alpha.txt", "alpha\n", "feat: alpha");
+
+        let actions = plan_local_pr_branch_drift(
+            LocalPrBranchSyncPolicy::CreateOrUpdate,
+            &[
+                target("dank-spr/missing", &target_tip),
+                target("dank-spr/current", &current_tip),
+                target("dank-spr/stale", &target_tip),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].branch, "dank-spr/missing");
+        assert_eq!(actions[0].action, LocalPrBranchActionKind::Created);
+        assert_eq!(actions[1].branch, "dank-spr/stale");
+        assert_eq!(actions[1].action, LocalPrBranchActionKind::Updated);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
         crate::cli::Cmd::Restack { .. }
         | crate::cli::Cmd::Absorb { .. }
         | crate::cli::Cmd::Resume { .. }
+        | crate::cli::Cmd::SyncLocalBranches
         | crate::cli::Cmd::FixPr { .. } => false,
         crate::cli::Cmd::ResolveStack { target } => target
             .as_deref()
@@ -271,8 +272,14 @@ fn read_only_pr_list_output(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy,
 ) -> std::result::Result<crate::read_only_output::ReadOnlyOutput, crate::json_output::ErrorOutput> {
-    match crate::commands::collect_pr_list_data_for_json(base, prefix, ignore_tag) {
+    match crate::commands::collect_pr_list_data_for_json(
+        base,
+        prefix,
+        ignore_tag,
+        local_pr_branch_policy,
+    ) {
         Ok(data) => Ok(crate::read_only_output::pr_list(command, data)),
         Err(crate::commands::ReadOnlyQueryError::SyntheticBranchNameCollision(collision)) => Err(
             crate::json_output::ErrorOutput::synthetic_branch_name_collision(command, &collision),
@@ -288,8 +295,14 @@ fn read_only_commit_list_output(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
+    local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy,
 ) -> std::result::Result<crate::read_only_output::ReadOnlyOutput, crate::json_output::ErrorOutput> {
-    match crate::commands::collect_commit_list_data_for_json(base, prefix, ignore_tag) {
+    match crate::commands::collect_commit_list_data_for_json(
+        base,
+        prefix,
+        ignore_tag,
+        local_pr_branch_policy,
+    ) {
         Ok(data) => Ok(crate::read_only_output::commit_list(command, data)),
         Err(crate::commands::ReadOnlyQueryError::SyntheticBranchNameCollision(collision)) => Err(
             crate::json_output::ErrorOutput::synthetic_branch_name_collision(command, &collision),
@@ -646,10 +659,13 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 &base,
                 &prefix,
                 &ignore_tag,
-                pr_description_mode,
-                list_order,
-                selection,
-                execution_mode,
+                crate::commands::PrepExecutionOptions {
+                    pr_description_mode,
+                    list_order,
+                    local_pr_branch_policy,
+                    selection,
+                    execution_mode,
+                },
             )?;
             if output_format == crate::cli::OutputFormat::Json {
                 Ok(CommandOutput::Maintenance(Box::new(
@@ -668,6 +684,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         &base,
                         &prefix,
                         &ignore_tag,
+                        local_pr_branch_policy,
                     ) {
                         Ok(output) => Ok(CommandOutput::ReadOnly(output)),
                         Err(output) => Ok(CommandOutput::Error(output)),
@@ -677,6 +694,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         &base,
                         &prefix,
                         &ignore_tag,
+                        local_pr_branch_policy,
                     ) {
                         Ok(output) => Ok(CommandOutput::ReadOnly(output)),
                         Err(output) => Ok(CommandOutput::Error(output)),
@@ -684,14 +702,19 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 }
             } else {
                 match what {
-                    crate::cli::ListWhat::Pr => {
-                        crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?
-                    }
+                    crate::cli::ListWhat::Pr => crate::commands::list_prs_display(
+                        &base,
+                        &prefix,
+                        &ignore_tag,
+                        list_order,
+                        local_pr_branch_policy,
+                    )?,
                     crate::cli::ListWhat::Commit => crate::commands::list_commits_display(
                         &base,
                         &prefix,
                         &ignore_tag,
                         list_order,
+                        local_pr_branch_policy,
                     )?,
                 }
                 Ok(CommandOutput::None)
@@ -704,12 +727,45 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &base,
                     &prefix,
                     &ignore_tag,
+                    local_pr_branch_policy,
                 ) {
                     Ok(output) => Ok(CommandOutput::ReadOnly(output)),
                     Err(output) => Ok(CommandOutput::Error(output)),
                 }
             } else {
-                crate::commands::list_prs_display(&base, &prefix, &ignore_tag, list_order)?;
+                crate::commands::list_prs_display(
+                    &base,
+                    &prefix,
+                    &ignore_tag,
+                    list_order,
+                    local_pr_branch_policy,
+                )?;
+                Ok(CommandOutput::None)
+            }
+        }
+        crate::cli::Cmd::SyncLocalBranches => {
+            let local_pr_branch_actions = sync_local_pr_branches_for_current_stack(
+                local_pr_branch_policy,
+                ExecutionMode::Apply,
+                &base,
+                &prefix,
+                &ignore_tag,
+            )?;
+            if output_format == crate::cli::OutputFormat::Json {
+                Ok(CommandOutput::Maintenance(Box::new(
+                    crate::maintenance_output::local_pr_branch_sync_summary(
+                        crate::maintenance_output::LocalPrBranchSyncSummaryData {
+                            repo: crate::maintenance_output::LocalPrBranchSyncRepoContext {
+                                base,
+                                prefix,
+                                ignore_tag,
+                            },
+                            policy: local_pr_branch_policy,
+                            local_pr_branch_actions,
+                        },
+                    ),
+                )))
+            } else {
                 Ok(CommandOutput::None)
             }
         }
@@ -1065,6 +1121,9 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
             crate::cli::ListWhat::Commit => crate::machine_output::MachineCommand::ListCommit,
         },
         crate::cli::Cmd::Status => crate::machine_output::MachineCommand::Status,
+        crate::cli::Cmd::SyncLocalBranches => {
+            crate::machine_output::MachineCommand::SyncLocalBranches
+        }
         crate::cli::Cmd::RelinkPrs { .. } => crate::machine_output::MachineCommand::RelinkPrs,
         crate::cli::Cmd::Cleanup { .. } => crate::machine_output::MachineCommand::Cleanup,
     }
@@ -1237,6 +1296,11 @@ mod tests {
     #[test]
     fn status_requires_github_cli() {
         assert!(command_requires_gh(&crate::cli::Cmd::Status));
+    }
+
+    #[test]
+    fn sync_local_branches_stays_local_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::SyncLocalBranches));
     }
 
     #[test]
@@ -1414,6 +1478,20 @@ mod tests {
         ];
 
         assert_eq!(json_command_for_raw_args(&args), JsonCommand::Status);
+    }
+
+    #[test]
+    fn json_command_for_raw_args_detects_sync_local_branches() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("sync-local-branches"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(
+            json_command_for_raw_args(&args),
+            JsonCommand::SyncLocalBranches
+        );
     }
 
     #[test]
@@ -1686,6 +1764,63 @@ mod tests {
     }
 
     #[test]
+    fn run_cli_prep_json_propagates_local_branch_sync_policy() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let origin_url = format!("file://{}", dir.path().join("origin.git").display());
+        git(
+            &repo,
+            ["remote", "set-url", "origin", origin_url.as_str()].as_slice(),
+        );
+        let log_path = repo.join("gh.log");
+        let script = prep_json_gh_script(&log_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "--until",
+            "1",
+            "prep",
+            "--dry-run",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Maintenance(output) => match output.data {
+                MaintenancePayload::Prep { data } => {
+                    let update = data
+                        .update
+                        .expect("prep should include nested update summary");
+                    assert_eq!(
+                        update.options.local_pr_branches,
+                        crate::config::LocalPrBranchSyncPolicy::CreateOrUpdate
+                    );
+                    assert_eq!(update.local_pr_branch_actions.len(), 1);
+                    assert_eq!(
+                        update.local_pr_branch_actions[0].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Created
+                    );
+                }
+                other => panic!("unexpected maintenance payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
     fn run_cli_restack_preview_json_returns_preview_payload() {
         let _lock = lock_cwd();
         let _restore = CurrentDirGuard::capture();
@@ -1854,6 +1989,131 @@ mod tests {
             }
             other => panic!("unexpected command output: {:?}", other),
         }
+    }
+
+    #[test]
+    fn run_cli_list_pr_json_reports_local_branch_drift_without_mutating_refs() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_local_stack_repo();
+        let alpha_tip = rev_parse(repo.path(), "HEAD~2");
+        git(
+            repo.path(),
+            ["branch", "dank-spr/alpha", &alpha_tip].as_slice(),
+        );
+        let log_path = repo.path().join("gh.log");
+        let open_json_path = repo.path().join("gh-open.json");
+        let status_json_path = repo.path().join("gh-status.json");
+        fs::write(
+            &open_json_path,
+            "{\"data\":{\"repository\":{\"pr0\":{\"nodes\":[]},\"pr1\":{\"nodes\":[]}}}}",
+        )
+        .unwrap();
+        fs::write(&status_json_path, "{\"data\":{\"repository\":{}}}").unwrap();
+        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "list",
+            "--json",
+            "pr",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::ReadOnly(output) => match output.data {
+                ReadOnlyPayload::PrList { data } => {
+                    assert_eq!(data.local_pr_branch_drift.len(), 2);
+                    assert_eq!(data.local_pr_branch_drift[0].branch, "dank-spr/alpha");
+                    assert_eq!(
+                        data.local_pr_branch_drift[0].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                    );
+                    assert_eq!(data.local_pr_branch_drift[1].branch, "dank-spr/beta");
+                    assert_eq!(
+                        data.local_pr_branch_drift[1].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Created
+                    );
+                }
+                other => panic!("unexpected read-only payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+
+        assert_eq!(rev_parse(repo.path(), "dank-spr/alpha"), alpha_tip);
+        assert!(!local_branch_exists(repo.path(), "dank-spr/beta"));
+    }
+
+    #[test]
+    fn run_cli_sync_local_branches_json_reconciles_current_stack() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_local_stack_repo();
+        let alpha_tip = rev_parse(repo.path(), "HEAD~2");
+        git(
+            repo.path(),
+            ["branch", "dank-spr/alpha", &alpha_tip].as_slice(),
+        );
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "sync-local-branches",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Maintenance(output) => {
+                assert_eq!(output.command, JsonCommand::SyncLocalBranches);
+                match output.data {
+                    MaintenancePayload::LocalPrBranchSync { data } => {
+                        assert_eq!(
+                            data.policy,
+                            crate::config::LocalPrBranchSyncPolicy::CreateOrUpdate
+                        );
+                        assert_eq!(data.local_pr_branch_actions.len(), 2);
+                        assert_eq!(
+                            data.local_pr_branch_actions[0].action,
+                            crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                        );
+                        assert_eq!(
+                            data.local_pr_branch_actions[1].action,
+                            crate::local_pr_branches::LocalPrBranchActionKind::Created
+                        );
+                    }
+                    other => panic!("unexpected maintenance payload: {:?}", other),
+                }
+            }
+            other => panic!("unexpected command output: {:?}", other),
+        }
+
+        assert_eq!(
+            rev_parse(repo.path(), "dank-spr/alpha"),
+            rev_parse(repo.path(), "HEAD~1")
+        );
+        assert_eq!(
+            rev_parse(repo.path(), "dank-spr/beta"),
+            rev_parse(repo.path(), "HEAD")
+        );
     }
 
     #[test]

--- a/src/maintenance_output.rs
+++ b/src/maintenance_output.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::config::PrDescriptionMode;
+use crate::config::{LocalPrBranchSyncPolicy, PrDescriptionMode};
 use crate::json_output::JsonCommand;
 use crate::summary_output::SummaryOutput;
 use crate::update_output::UpdateSummaryData;
@@ -21,6 +21,10 @@ pub enum MaintenancePayload {
     Cleanup {
         #[serde(flatten)]
         data: Box<CleanupSummaryData>,
+    },
+    LocalPrBranchSync {
+        #[serde(flatten)]
+        data: Box<LocalPrBranchSyncSummaryData>,
     },
 }
 
@@ -157,6 +161,20 @@ pub struct CleanupSummaryData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LocalPrBranchSyncSummaryData {
+    pub repo: LocalPrBranchSyncRepoContext,
+    pub policy: LocalPrBranchSyncPolicy,
+    pub local_pr_branch_actions: Vec<crate::local_pr_branches::LocalPrBranchAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LocalPrBranchSyncRepoContext {
+    pub base: String,
+    pub prefix: String,
+    pub ignore_tag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CleanupRepoContext {
     pub prefix: String,
 }
@@ -197,6 +215,15 @@ pub fn cleanup_summary(data: CleanupSummaryData) -> MaintenanceOutput {
     SummaryOutput::new(
         JsonCommand::Cleanup,
         MaintenancePayload::Cleanup {
+            data: Box::new(data),
+        },
+    )
+}
+
+pub fn local_pr_branch_sync_summary(data: LocalPrBranchSyncSummaryData) -> MaintenanceOutput {
+    SummaryOutput::new(
+        JsonCommand::SyncLocalBranches,
+        MaintenancePayload::LocalPrBranchSync {
             data: Box::new(data),
         },
     )

--- a/src/read_only_output.rs
+++ b/src/read_only_output.rs
@@ -64,6 +64,7 @@ mod tests {
                         },
                     },
                 }],
+                local_pr_branch_drift: Vec::new(),
             },
         );
 
@@ -93,6 +94,7 @@ mod tests {
                         subject: "feat: alpha".to_string(),
                     }],
                 }],
+                local_pr_branch_drift: Vec::new(),
             },
         );
 
@@ -116,6 +118,7 @@ mod tests {
                                 subject: "feat: alpha".to_string(),
                             }],
                         }],
+                        local_pr_branch_drift: Vec::new(),
                     },
                 },
             )


### PR DESCRIPTION
Add an explicit local-branch sync path and surface drift in read-only output so local PR branches can be repaired after manual Git surgery without publishing or rewriting the stack.

# Problem Solved

SPR can keep per-PR branches aligned during normal writes, but manual rebases or reorders can leave those local branches stale afterward. This adds one repair command plus drift reporting so operators can see and fix that state directly.

# Mental model

Read-only commands report the branch actions a repair would need. `spr sync-local-branches` applies the configured policy locally, and normal update/prep paths continue to use the same sync machinery after successful writes.

# Tests

Validation covers read-only drift reporting, explicit reconciliation, JSON output, checked-out branch protection, and prep/update propagation of the local branch policy.

- `cargo test`

<!-- spr-stack:start -->
**Stack**:
-   #136
-   #135
-   #134
-   #133
- ➡ #132

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->