### PR TITLE
prep: squash selected suffixes from one group upward

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,8 @@ Default follow-up behavior:
 
 Prepare PRs for landing per-PR - squashes each PR's commits into a single commit.
 
-- Uses global `--until <N|0|label|pr:<label>>` / `--exact <I|label|pr:<label>>`
+- Uses global `--until <N|0|label|pr:<label>>`, global `--exact <I|label|pr:<label>>`,
+  or local `--from <N|label|pr:<label>>`; these selectors are mutually exclusive
 - Before rewriting or pushing, `spr prep` validates that no two live PR groups
   derive synthetic branch names that collide under case-insensitive
   comparison. If they do, it halts before the local squash or follow-on
@@ -647,6 +648,11 @@ Prepare PRs for landing per-PR - squashes each PR's commits into a single commit
 Behavior:
 
 - Rewrites local history to ensure selected PRs become single-commit groups
+- Squashes each selected PR group independently; it does not combine commits
+  across PR-group boundaries. For ordinary non-empty groups, that preserves the
+  selected PRs' net diffs relative to their parent groups.
+- Empty selected groups keep the existing `skipped_empty` behavior when their
+  tip tree already matches the parent tree.
 - Pushes branches (respects `--dry-run`)
 - Adds a warning to the next PR not included in the push
 - When `local_pr_branches` is enabled, the nested update path also synchronizes local synthetic PR
@@ -759,6 +765,9 @@ spr prep --until beta
 
 # Prep exactly the stable gamma group
 spr prep --exact gamma
+
+# Prep the stable gamma group and every group above it
+spr prep --from gamma
 
 # Prep the first 3 PRs from the bottom
 spr prep --until 3

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ pub enum Extent {
 pub enum PrepSelection {
     Until(crate::selectors::InclusiveSelector),
     Exact(crate::selectors::GroupSelector),
+    From(crate::selectors::GroupSelector),
     All,
 }
 
@@ -176,7 +177,11 @@ pub enum Cmd {
 
     /// Prepare PRs for landing (e.g., squash) and halt early on case-colliding synthetic branch names
     Prep {
-        // selection is provided via global --until/--exact flags
+        /// Prepare this PR group and every group above it
+        #[arg(long, value_name = "N|label|pr:<label>")]
+        from: Option<crate::selectors::GroupSelector>,
+
+        // Additional selection is provided via global --until/--exact flags.
         #[command(flatten)]
         dry_run: DryRunArgs,
     },
@@ -356,6 +361,19 @@ mod tests {
 
         match cli.cmd {
             Cmd::Absorb {
+                from: Some(crate::selectors::GroupSelector::Stable(handle)),
+                ..
+            } => assert_eq!(handle.tag, "beta"),
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn prep_from_selector_parses() {
+        let cli = Cli::try_parse_from(["spr", "prep", "--from", "pr:beta"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Prep {
                 from: Some(crate::selectors::GroupSelector::Stable(handle)),
                 ..
             } => assert_eq!(handle.tag, "beta"),

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -42,6 +42,10 @@ fn resolve_prep_window(
             let ordinal = resolve_group_ordinal(groups, selector)?;
             Ok((ordinal - 1, ordinal))
         }
+        crate::cli::PrepSelection::From(selector) => {
+            let ordinal = resolve_group_ordinal(groups, selector)?;
+            Ok((ordinal - 1, groups.len()))
+        }
     }
 }
 
@@ -51,6 +55,7 @@ fn selector_text(selector: &GroupSelector) -> String {
 
 fn resolved_selection(
     selection: &crate::cli::PrepSelection,
+    start_idx: usize,
     end_idx_exclusive: usize,
 ) -> ResolvedPrepSelection {
     match selection {
@@ -65,6 +70,10 @@ fn resolved_selection(
         crate::cli::PrepSelection::Exact(selector) => ResolvedPrepSelection::Exact {
             selector: selector_text(selector),
             local_pr_number: end_idx_exclusive,
+        },
+        crate::cli::PrepSelection::From(selector) => ResolvedPrepSelection::From {
+            selector: selector_text(selector),
+            first_local_pr_number: start_idx + 1,
         },
     }
 }
@@ -95,6 +104,7 @@ fn limit_and_next_idx(
                 ResolvedUpdateLimit::ByPr { count },
             ))
         }
+        crate::cli::PrepSelection::From(_) => Ok((None, None, ResolvedUpdateLimit::All)),
     }
 }
 
@@ -218,7 +228,7 @@ pub fn prep_squash(
     }
     let branch_identities = group_branch_identities(&groups, prefix)?;
     let (start_idx, end_idx_exclusive) = resolve_prep_window(&groups, &selection)?;
-    let resolved_selection = resolved_selection(&selection, end_idx_exclusive);
+    let resolved_selection = resolved_selection(&selection, start_idx, end_idx_exclusive);
 
     let mut parent_sha = if start_idx == 0 {
         merge_base.clone()
@@ -537,6 +547,16 @@ mod tests {
         }));
 
         assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (1, 2));
+    }
+
+    #[test]
+    fn prep_from_stable_handle_resolves_suffix_window() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let selection = PrepSelection::From(GroupSelector::Stable(StableHandle {
+            tag: "beta".to_string(),
+        }));
+
+        assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (1, 3));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,22 +638,25 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 local_pr_branch_actions,
             )?))
         }
-        crate::cli::Cmd::Prep { dry_run } => {
+        crate::cli::Cmd::Prep { from, dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
-            if cli.until.is_some() && cli.exact.is_some() {
-                return Err(anyhow::anyhow!("--until conflicts with --exact"));
-            }
-            let selection = if let Some(n) = cli.until {
-                if n == crate::selectors::InclusiveSelector::All {
-                    crate::cli::PrepSelection::All
-                } else {
-                    crate::cli::PrepSelection::Until(n)
+            let selection = match (cli.until, cli.exact, from) {
+                (Some(_), Some(_), _) | (Some(_), _, Some(_)) | (_, Some(_), Some(_)) => {
+                    return Err(anyhow::anyhow!(
+                        "--until, --exact, and --from are mutually exclusive"
+                    ));
                 }
-            } else if let Some(i) = cli.exact {
-                crate::cli::PrepSelection::Exact(i)
-            } else {
-                crate::cli::PrepSelection::All
+                (Some(n), None, None) => {
+                    if n == crate::selectors::InclusiveSelector::All {
+                        crate::cli::PrepSelection::All
+                    } else {
+                        crate::cli::PrepSelection::Until(n)
+                    }
+                }
+                (None, Some(i), None) => crate::cli::PrepSelection::Exact(i),
+                (None, None, Some(selector)) => crate::cli::PrepSelection::From(selector),
+                (None, None, None) => crate::cli::PrepSelection::All,
             };
             let summary = crate::commands::prep_squash(
                 &base,
@@ -1760,6 +1763,95 @@ mod tests {
                 }
             }
             other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_cli_prep_from_json_returns_suffix_summary() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let origin_url = format!("file://{}", dir.path().join("origin.git").display());
+        git(
+            &repo,
+            ["remote", "set-url", "origin", origin_url.as_str()].as_slice(),
+        );
+        let log_path = repo.join("gh.log");
+        let script = prep_json_gh_script(&log_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "prep",
+            "--from",
+            "pr:beta",
+            "--dry-run",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Maintenance(output) => match output.data {
+                MaintenancePayload::Prep { data } => {
+                    assert_eq!(
+                        data.selection,
+                        ResolvedPrepSelection::From {
+                            selector: "pr:beta".to_string(),
+                            first_local_pr_number: 2,
+                        }
+                    );
+                    assert_eq!(data.selected_groups.len(), 1);
+                    assert_eq!(data.selected_groups[0].stable_handle, "pr:beta");
+                    assert!(data.next_child.is_none());
+                    let update = data
+                        .update
+                        .expect("prep should include nested update summary");
+                    assert_eq!(update.extent, ResolvedUpdateLimit::All);
+                    assert_eq!(update.groups.len(), 2);
+                    assert_eq!(update.groups[0].stable_handle, "pr:alpha");
+                    assert_eq!(update.groups[1].stable_handle, "pr:beta");
+                }
+                other => panic!("unexpected maintenance payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn run_cli_prep_rejects_mixed_selectors() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let cases = [
+            vec![
+                "spr", "--base", "main", "--until", "1", "--exact", "1", "prep",
+            ],
+            vec![
+                "spr", "--base", "main", "--until", "1", "prep", "--from", "pr:beta",
+            ],
+            vec![
+                "spr", "--base", "main", "--exact", "1", "prep", "--from", "pr:beta",
+            ],
+        ];
+
+        for case in cases {
+            let cli = crate::cli::Cli::try_parse_from(case).unwrap();
+            let err = run_cli(cli, OutputFormat::Human).unwrap_err();
+
+            assert_eq!(
+                err.to_string(),
+                "--until, --exact, and --from are mutually exclusive"
+            );
         }
     }
 

--- a/src/maintenance_output.rs
+++ b/src/maintenance_output.rs
@@ -66,6 +66,10 @@ pub enum ResolvedPrepSelection {
         selector: String,
         local_pr_number: usize,
     },
+    From {
+        selector: String,
+        first_local_pr_number: usize,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
Add `spr prep --from` so operators can prepare one selected PR group and every group above it without touching lower groups. The new selector reuses the existing prep machinery while preserving each selected group as its own one-commit PR.

# Tests

Validation covers suffix selection, mixed-selector rejection, and JSON summaries for the selected suffix path.

- `cargo test`

<!-- spr-stack:start -->
**Stack**:
-   #137
-   #136
-   #135
-   #134
- ➡ #133

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->