### PR TITLE
spr: preserve exact branch names for PR groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cargo install --path .
 Quick start
 -----------
 
-1. Create commits with `pr:<tag>` markers to define PR groups, bottom → top. Use `pr:ignore` to skip commits until the next `pr:<tag>`. Example:
+1. Create commits with `pr:<tag>` or `branch:<branch-name>` markers to define PR groups, bottom → top. Use `pr:ignore` to skip commits until the next group marker. Example:
 
 ```bash
 git commit -m "feat: parser groundwork pr:alpha"
@@ -31,8 +31,8 @@ git commit -m "wip: spike cleanup"
 git commit -m "feat: new API pr:beta" -m "Body explaining the change"
 ```
 
-Ignored blocks are local-only. If an ignored block sits below later `pr:<tag>`
-groups, `spr update` warns and leaves those later groups local-only instead of
+Ignored blocks are local-only. If an ignored block sits below later group
+markers, `spr update` warns and leaves those later groups local-only instead of
 publishing PRs whose GitHub diffs would include the ignored commits.
 
 2. Configure defaults (optional) in `.spr_multicommit_cfg.yml` (see below), then:
@@ -57,15 +57,16 @@ spr list commit
 spr update
 ```
 
-`pr:<tag>` is the stable handle for a PR group, and `<tag>` must start with an
-ASCII letter. Commands that target groups accept either a bare label like
-`beta` or the explicit `pr:beta` form. `LPR #N` is only the current local
-position in the outstanding stack and may renumber after lower groups land or
-are removed. For example, `spr land flatten --until beta` and `spr move beta
---after gamma` both target stable PR-group labels. Stable handles remain
-exact-case. Synthetic branch-name conflict checks are separate and fold case on
-the full derived branch name.
-Any command that derives synthetic branch names from the live stack may halt
+Each PR group has exactly one marker. `pr:<tag>` derives `prefix + tag`, while
+`branch:<branch-name>` preserves that exact Git branch name. `pr:` labels must
+start with an ASCII letter; `branch:` payloads use Git branch-name validation.
+Commands that target groups accept explicit selectors such as `pr:beta` or
+`branch:feature/login`, plus bare selectors such as `beta` only when exactly one
+current-stack group matches. `LPR #N` is only the current local position in the
+outstanding stack and may renumber after lower groups land or are removed.
+Concrete branch-name conflict checks are separate and fold case on the resolved
+branch name.
+Any command that derives concrete branch names from the live stack may halt
 before doing command-specific work if two outstanding groups would collide
 under that case-insensitive branch-name comparison.
 
@@ -93,7 +94,7 @@ prefix: mattskl-spr/
 land: flatten
 
 # Tag used to ignore commits between PR groups
-# Commit with pr:ignore_tag starts ignore mode until the next pr:<tag>
+# Commit with pr:ignore_tag starts ignore mode until the next group marker
 # Must start with an ASCII letter
 ignore_tag: ignore
 
@@ -108,7 +109,7 @@ pr_description_mode: overwrite | stack_only
 # one of: "recent_on_bottom" (default) or "recent_on_top"
 list_order: recent_on_bottom
 
-# Optional local synchronization for branches named like `prefix + <tag>`.
+# Optional local synchronization for each group's resolved concrete branch.
 # - `off` (default): do not create or move local per-PR branches
 # - `update-existing`: move matching local branches that already exist
 # - `create-or-update`: create missing matching local branches and move existing ones
@@ -149,8 +150,8 @@ Global flags
 - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
 - `--local-pr-branches <off|update-existing|create-or-update>`: override local per-PR branch synchronization for this run
-- `--until <N|0|label|pr:<label>>`: target range used by `prep` and `land` (`0` means all)
-- `--exact <I|label|pr:<label>>`: used by `prep` to select exactly one PR group
+- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: target range used by `prep` and `land` (`0` means all)
+- `--exact <I|name|pr:<label>|branch:<branch-name>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
 
 Example:
@@ -178,28 +179,28 @@ Key options:
 - `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
 - `--json`: write exactly one update summary object to stdout
 - Extent (optional subcommand):
-  - `pr --to <N|label|pr:<label>>`: canonical selector for limiting updates to the first N PRs from the bottom
+  - `pr --to <N|name|pr:<label>|branch:<branch-name>>`: canonical selector for limiting updates to the first N PRs from the bottom
   - `pr --n <N>`: legacy numeric-only form
   - `pr <N>`: backward-compatible positional numeric form
   - `commits --n <N>`: limit to first N commits (untested)
 
 Behavior:
 
-- Parses `pr:<tag>` markers from `merge-base(base, from)..from` (commits between `pr:ignore` and the next `pr:<tag>` are ignored)
+- Parses group markers from `merge-base(base, from)..from` (commits between `pr:ignore` and the next group marker are ignored)
 - Creates/updates per-PR branches and GitHub PRs
 - Warns and skips any PR groups above an ignored block, because GitHub would include the ignored commits in those higher PRs
 - When a PR is first created, `spr` always seeds it from the bottom commit in that PR group:
   the PR title comes from the first line of that commit message, and the PR description comes
   from the rest of that same commit message, regardless of `pr_description_mode`
-- Before creating a PR for a branch head without an open PR, checks whether the same synthetic
+- Before creating a PR for a branch head without an open PR, checks whether the same concrete
   branch name, including case-only variants, had a recently merged or closed PR and halts within
   `branch_reuse_guard_days`
-- Refuses to operate when two live PR groups would derive synthetic branch names that differ only
+- Refuses to operate when two live PR groups would derive concrete branch names that differ only
   by case, because those names are unsafe on case-insensitive filesystems
 - Updates PR bodies with a visualized stack block and correct `baseRefName`
   - When `pr_description_mode` is `stack_only`, only the stack block (between markers) is updated; the rest of the body is preserved
   - May temporarily set existing PR bases to the repo base while pushing, then re-chain them to match the local stack
-- When `local_pr_branches` is enabled, synchronizes local branches named exactly like the synthetic PR branches after the update succeeds. `update-existing` only moves existing local branches; `create-or-update` also creates missing ones.
+- When `local_pr_branches` is enabled, synchronizes local branches named exactly like each group's resolved concrete branch after the update succeeds. `update-existing` only moves existing local branches; `create-or-update` also creates missing ones.
 
 ### spr restack
 
@@ -210,17 +211,17 @@ up, prefer `spr drop-merged-prefix`.
 
 Options:
 
-- `--after <N|0|bottom|top|last|all|label|pr:<label>>`: keep groups through this selector in place, then rebase only the groups above it onto `--base`
+- `--after <N|0|bottom|top|last|all|name|pr:<label>|branch:<branch-name>>`: keep groups through this selector in place, then rebase only the groups above it onto `--base`
   - `0` or `bottom`: restack all groups (moves everything after merge-base)
   - `top` or `last` or `all`: skip all PRs; ignored commits (pr:ignore blocks) are preserved, so the branch may remain ahead of base
-  - `label` or `pr:<label>`: keep that stable group and everything below it in place even if local PR numbers renumber
+  - bare name, `pr:<label>`, or `branch:<branch-name>`: keep that group and everything below it in place even if local PR numbers renumber
 - `--safe`: create a local backup tag at current `HEAD` before rebasing
 - `--preview`: print the resolved high-level plan and stop before fetch, backup tags, temp worktrees, resume files, cherry-picks, branch resets, metadata writes, pushes, or GitHub calls
 - `--json`: with `--preview`, write exactly one preview object to stdout
 
 Behavior:
 
-- Computes PR groups from `merge-base(base, HEAD)..HEAD` using `pr:<tag>` markers (oldest → newest; ignore blocks are preserved but excluded from grouping)
+- Computes PR groups from `merge-base(base, HEAD)..HEAD` using group markers (oldest → newest; ignore blocks are preserved but excluded from grouping)
 - `spr restack --after ... --preview` uses local refs only and reports that remote freshness, replay conflicts, tests, hooks, GitHub mergeability, and update/push results have not been validated
 - Normal human `spr restack --after ...` prints the same high-level plan immediately before it starts the rewrite phase
 - Drops the first N groups, then rebuilds the remaining commits onto `--base`
@@ -230,7 +231,7 @@ Behavior:
 - Uses the existing temp-worktree cherry-pick executor when the plan is not one contiguous suffix,
   or when the fast rebase conflicts and can be aborted cleanly.
 - Updates the current branch to the rebuilt tip
-- When `local_pr_branches` is enabled, synchronizes local synthetic PR branches to the final rewritten group tips after a successful rewrite.
+- When `local_pr_branches` is enabled, synchronizes local resolved PR branches to the final rewritten group tips after a successful rewrite.
 - With `--safe`, a backup tag named like `backup/restack/<current-branch>-<short-sha>` is created first
 - Conflict handling is controlled by `restack_conflict` in config.
 - Before rewriting the checked-out branch, `spr restack` follows the `dirty_worktree` config.
@@ -266,7 +267,7 @@ Behavior:
 - With `--safe`, creates a local backup tag named like `backup/drop-merged-prefix/<current-branch>-<short-sha>` before moving the branch
 - Does not merge, close, retarget, comment on, push, or otherwise mutate GitHub PRs
 - Does not run `spr update`; run it afterwards to publish the remaining open PR branch updates
-- When `local_pr_branches` is enabled, synchronizes local synthetic PR branches for the remaining stack after the local rewrite succeeds.
+- When `local_pr_branches` is enabled, synchronizes local resolved PR branches for the remaining stack after the local rewrite succeeds.
 
 ### spr absorb
 
@@ -275,10 +276,10 @@ Absorb commits appended to canonical local per-PR branches back into the checked
 Behavior:
 
 - If you append commits to the end of a local PR branch such as `user-spr/alpha`, `spr absorb` rebuilds the local stack so the new commits become part of the matching PR group while preserving PR-group order
-- Inspects only exact local branches named `prefix + tag`
+- Inspects only each group's exact resolved local branch
 - Skips missing branches, branches whose rewritten-equivalent prefix still descends from the same stack merge-base and ends at the same pre-tail tree as the current stack, and branches that are behind the current stack
-- Refuses to operate when two live PR groups would derive synthetic branch names that differ only by case
-- Refuses to guess through divergence, source branches that incorporated later stack commits, merge commits, or absorbed commits that contain `pr:<tag>` markers
+- Refuses to operate when two live PR groups would derive concrete branch names that differ only by case
+- Refuses to guess through divergence, source branches that incorporated later stack commits, merge commits, or absorbed commits that contain group markers
 - By default, also blocks copied later stack commits whose original replay would otherwise become empty or ambiguous
 - `--allow-replayed-duplicates` overrides that copied-commit blocker for safe cases by absorbing the copied commit and keeping its later non-seed replay in the rebuilt stack
 - Rebuilds the current stack from its existing `merge-base(base, HEAD)` rather than restacking onto the latest base tip
@@ -287,9 +288,9 @@ Behavior:
 - Before rewriting the checked-out branch, `spr absorb` follows the `dirty_worktree` config.
 - On cherry-pick conflict, `spr absorb` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`
 - Does not update GitHub; inspect the rewritten stack first, then run `spr update`
-- When `local_pr_branches` is enabled, synchronizes local synthetic PR branches to the absorbed stack's final group tips after the local rewrite succeeds. A branch checked out in any worktree is reported as blocked and is not moved.
-- `--from <N|label|pr:<label>>` constrains absorb to one explicit selected-and-higher suffix.
-- `--query-changed-branches --json` reports the stack branch plus every synthetic PR branch whose logical tip would change if the absorb rewrite ran, without creating backup tags, temp worktrees, or rewrite side effects. When paired with `--from`, it reports the full selected suffix even when only some branches currently have absorbable tails, so callers can query and apply one stable transaction boundary.
+- When `local_pr_branches` is enabled, synchronizes local resolved PR branches to the absorbed stack's final group tips after the local rewrite succeeds. A branch checked out in any worktree is reported as blocked and is not moved.
+- `--from <N|name|pr:<label>|branch:<branch-name>>` constrains absorb to one explicit selected-and-higher suffix.
+- `--query-changed-branches --json` reports the stack branch plus every resolved PR branch whose logical tip would change if the absorb rewrite ran, without creating backup tags, temp worktrees, or rewrite side effects. When paired with `--from`, it reports the full selected suffix even when only some branches currently have absorbable tails, so callers can query and apply one stable transaction boundary.
 
 Typical workflow:
 
@@ -353,7 +354,7 @@ spr resolve-stack --json https://github.com/org/repo/pull/123
 
 ### spr sync-local-branches
 
-Reconcile local synthetic PR branches with the checked-out stack without publishing or rewriting
+Reconcile local resolved PR branches with the checked-out stack without publishing or rewriting
 the stack itself.
 
 Behavior:
@@ -504,7 +505,7 @@ Operator rules:
 
 ### spr list pr
 
-Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top, but the output now shows both the current `LPR #N` and the stable `pr:<label>` handle for each group.
+Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top, but the output now shows both the current `LPR #N` and each group's explicit selector.
 
 Aliases:
 
@@ -523,12 +524,12 @@ Example summary line:
 ```
 
 Before listing, `spr list pr` validates that no two live PR groups derive
-synthetic branch names that collide under case-insensitive comparison. If they
+concrete branch names that collide under case-insensitive comparison. If they
 do, it halts before loading GitHub PR state.
 
 `spr list --json pr` emits one read-only JSON object instead of human-formatted lines.
 The payload always uses canonical bottom-up group order, includes remote PR metadata plus explicit
-CI/review state when available, and reports case-colliding synthetic branch failures as a typed
+CI/review state when available, and reports case-colliding concrete branch failures as a typed
 `synthetic_branch_name_collision` error payload.
 
 ### spr status
@@ -539,7 +540,7 @@ Aliases:
 
 Alias for `spr list pr`.
 
-`spr status` runs the same early synthetic branch-collision validation as
+`spr status` runs the same early concrete branch-collision validation as
 `spr list pr` before printing anything.
 
 `spr status --json` emits the same read-only payload shape as `spr list --json pr`, but keeps the
@@ -547,10 +548,10 @@ top-level command identity as `status`.
 
 ### spr list commit
 
-Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top, and each group header also shows its stable `pr:<label>` handle.
+Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top, and each group header also shows its explicit selector.
 
 Before listing, `spr list commit` validates that no two live PR groups derive
-synthetic branch names that collide under case-insensitive comparison. If they
+concrete branch names that collide under case-insensitive comparison. If they
 do, it halts before loading GitHub PR state.
 
 `spr list --json commit` emits one read-only JSON object instead of human-formatted lines.
@@ -570,7 +571,7 @@ current bottom PR has auto-merge enabled before allowing a rewrite that would
 move another PR below it.
 
 Before planning the move, `spr move` validates that no two live PR groups
-derive synthetic branch names that collide under case-insensitive comparison.
+derive concrete branch names that collide under case-insensitive comparison.
 If they do, it halts before the GitHub auto-merge lookup or any rewrite
 planning.
 
@@ -580,8 +581,8 @@ Aliases:
 
 - `spr move A --after C`: move PR at position A to come after PR C (C ∈ [0..N])
 - `spr move A..B --after C`: move PRs A..B to come after PR C (requires A < B and C ∉ [A..B]; C ∈ [0..N])
-- `spr move beta --after gamma`: move a stable group handle without caring what its current local PR number is
-- `spr move beta..gamma --after delta`: stable-handle range form
+- `spr move beta --after gamma`: move a bare selector without caring what its current local PR number is
+- `spr move beta..gamma --after delta`: bare-selector range form
   - `--after bottom` is the same as `--after 0`
   - `--after top` is the same as `--after N`
 - `--safe`: create a local backup tag at current `HEAD` before rewriting
@@ -597,11 +598,11 @@ Land PRs using either flatten or per-pr strategy.
 
 Shared options (global):
 
-- `--until <N|0|label|pr:<label>>`: land bottom-up through this local position or stable handle (`0` means all)
+- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: land bottom-up through this local position or selector (`0` means all)
 - `--no-restack`: do not automatically restack after landing
 
 Before any GitHub land work, `spr land` validates that no two live PR groups
-derive synthetic branch names that collide under case-insensitive comparison.
+derive concrete branch names that collide under case-insensitive comparison.
 If they do, it halts before resolving the PR segment to land.
 
 Safety checks:
@@ -638,10 +639,11 @@ Default follow-up behavior:
 
 Prepare PRs for landing per-PR - squashes each PR's commits into a single commit.
 
-- Uses global `--until <N|0|label|pr:<label>>`, global `--exact <I|label|pr:<label>>`,
-  or local `--from <N|label|pr:<label>>`; these selectors are mutually exclusive
+- Uses global `--until <N|0|name|pr:<label>|branch:<branch-name>>`, global
+  `--exact <I|name|pr:<label>|branch:<branch-name>>`, or local
+  `--from <N|name|pr:<label>|branch:<branch-name>>`; these selectors are mutually exclusive
 - Before rewriting or pushing, `spr prep` validates that no two live PR groups
-  derive synthetic branch names that collide under case-insensitive
+  derive concrete branch names that collide under case-insensitive
   comparison. If they do, it halts before the local squash or follow-on
   `spr update`.
 
@@ -655,7 +657,7 @@ Behavior:
   tip tree already matches the parent tree.
 - Pushes branches (respects `--dry-run`)
 - Adds a warning to the next PR not included in the push
-- When `local_pr_branches` is enabled, the nested update path also synchronizes local synthetic PR
+- When `local_pr_branches` is enabled, the nested update path also synchronizes local resolved PR
   branches after the prepared rewrite succeeds.
 - `--json` writes the typed prep summary instead of human log lines
 - In `--dry-run`, prep still computes the hypothetical rewritten commit chain so the JSON summary
@@ -663,7 +665,7 @@ Behavior:
 
 ### spr fix-pr
 
-Move the tail M commits (top of stack) to the tail of a PR group selected by local PR number or stable handle.
+Move the tail M commits (top of stack) to the tail of a PR group selected by local PR number or selector.
 
 Aliases:
 
@@ -727,7 +729,7 @@ Behavior:
 - Computes the expected bottom → top chain from local commits and updates each PR’s base to match.
 - Skips PRs that are already correct; warns for missing PRs.
 - Before comparing local and remote connectivity, `spr relink-prs` validates
-  that no two live PR groups derive synthetic branch names that collide under
+  that no two live PR groups derive concrete branch names that collide under
   case-insensitive comparison. If they do, it halts before any GitHub edit.
 - `--json` writes the typed relink summary instead of human log lines
 

--- a/src/branch_names.rs
+++ b/src/branch_names.rs
@@ -1,22 +1,17 @@
-//! Shared synthetic branch-name derivation and conflict checks.
+//! Shared group branch-name derivation and conflict checks.
 //!
-//! `spr` stores exact-case `pr:<tag>` handles in commit history, but most
-//! commands also derive synthetic branch names such as `dank-spr/alpha` by
-//! concatenating the configured prefix and the stored tag. On
-//! case-insensitive filesystems, two exact handles can still collide once they
-//! become branch names, so branch-conflict decisions must use a canonicalized
-//! comparison key instead of raw string equality.
+//! `pr:<label>` groups derive branch names by concatenating the configured
+//! prefix and label, while `branch:<branch-name>` groups use their exact branch
+//! name. On case-insensitive filesystems, two exact marker identities can still
+//! collide once they become concrete branch names, so conflict decisions use a
+//! canonicalized comparison key instead of raw string equality.
 
 use anyhow::Result;
 use std::collections::HashMap;
 
 use crate::parsing::Group;
 
-/// Canonical comparison key for synthetic branch-name conflicts.
-///
-/// The stored `pr:<tag>` grammar is ASCII-only, so ASCII lowercasing is enough
-/// to catch the case-only collisions this rollout targets without changing the
-/// user-visible exact tag spelling.
+/// Canonical comparison key for concrete branch-name conflicts.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CanonicalBranchConflictKey(String);
 
@@ -26,33 +21,32 @@ impl CanonicalBranchConflictKey {
     }
 }
 
-/// Exact derived branch name plus the canonical key used only for comparisons.
+/// Exact concrete branch name plus the canonical key used only for comparisons.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SyntheticBranchIdentity {
+pub struct GroupBranchIdentity {
     pub exact: String,
     pub conflict_key: CanonicalBranchConflictKey,
 }
 
-/// One live PR group whose synthetic branch name participates in a collision.
+/// One live PR group whose concrete branch name participates in a collision.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SyntheticBranchCollisionEntry {
-    pub stable_handle: String,
+pub struct GroupBranchCollisionEntry {
+    pub selector: String,
     pub head_branch: String,
 }
 
-/// Two live PR groups whose derived synthetic branch names collide under case-folding.
+/// Two live PR groups whose concrete branch names collide under case-folding.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SyntheticBranchNameCollision {
-    pub first: SyntheticBranchCollisionEntry,
-    pub second: SyntheticBranchCollisionEntry,
+pub struct GroupBranchNameCollision {
+    pub first: GroupBranchCollisionEntry,
+    pub second: GroupBranchCollisionEntry,
 }
 
-impl SyntheticBranchIdentity {
-    pub fn new(prefix: &str, tag: &str) -> Self {
-        let exact = format!("{prefix}{tag}");
-        let conflict_key = CanonicalBranchConflictKey::new(&exact);
+impl GroupBranchIdentity {
+    pub fn new(branch_name: String) -> Self {
+        let conflict_key = CanonicalBranchConflictKey::new(&branch_name);
         Self {
-            exact,
+            exact: branch_name,
             conflict_key,
         }
     }
@@ -62,46 +56,41 @@ pub fn canonical_branch_conflict_key(branch_name: &str) -> CanonicalBranchConfli
     CanonicalBranchConflictKey::new(branch_name)
 }
 
-pub fn synthetic_branch_identity(prefix: &str, tag: &str) -> SyntheticBranchIdentity {
-    SyntheticBranchIdentity::new(prefix, tag)
+pub fn group_branch_name(prefix: &str, group: &Group) -> String {
+    group.concrete_branch_name(prefix)
 }
 
-pub fn synthetic_branch_name(prefix: &str, tag: &str) -> String {
-    synthetic_branch_identity(prefix, tag).exact
-}
-
-impl std::fmt::Display for SyntheticBranchNameCollision {
+impl std::fmt::Display for GroupBranchNameCollision {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Refusing to operate on this stack because {} and {} derive conflicting synthetic branch names (`{}` and `{}`) under case-insensitive comparison. Stable handles remain exact-case, but these branch names are not safe to treat as distinct on a case-insensitive filesystem.",
-            self.first.stable_handle,
-            self.second.stable_handle,
+            "Refusing to operate on this stack because {} and {} derive conflicting branch names (`{}` and `{}`) under case-insensitive comparison. Group selectors remain exact-case, but these branch names are not safe to treat as distinct on a case-insensitive filesystem.",
+            self.first.selector,
+            self.second.selector,
             self.first.head_branch,
             self.second.head_branch
         )
     }
 }
 
-impl std::error::Error for SyntheticBranchNameCollision {}
+impl std::error::Error for GroupBranchNameCollision {}
 
-/// Return the first case-folding synthetic-branch collision in `groups`, if any.
-pub fn find_synthetic_branch_name_collision(
+/// Return the first case-folding concrete-branch collision in `groups`, if any.
+pub fn find_group_branch_name_collision(
     groups: &[Group],
     prefix: &str,
-) -> Option<SyntheticBranchNameCollision> {
-    let mut seen: HashMap<CanonicalBranchConflictKey, SyntheticBranchCollisionEntry> =
-        HashMap::new();
+) -> Option<GroupBranchNameCollision> {
+    let mut seen: HashMap<CanonicalBranchConflictKey, GroupBranchCollisionEntry> = HashMap::new();
     for group in groups {
-        let head_branch = synthetic_branch_name(prefix, &group.tag);
-        let stable_handle = format!("pr:{}", group.tag);
+        let head_branch = group_branch_name(prefix, group);
+        let selector = group.selector_text();
         let conflict_key = canonical_branch_conflict_key(&head_branch);
-        let entry = SyntheticBranchCollisionEntry {
-            stable_handle,
+        let entry = GroupBranchCollisionEntry {
+            selector,
             head_branch,
         };
         if let Some(previous) = seen.get(&conflict_key) {
-            return Some(SyntheticBranchNameCollision {
+            return Some(GroupBranchNameCollision {
                 first: previous.clone(),
                 second: entry,
             });
@@ -112,21 +101,14 @@ pub fn find_synthetic_branch_name_collision(
     None
 }
 
-/// Derive synthetic branch identities for `groups` and reject canonical collisions.
-///
-/// The returned vector preserves the input order. On collision, the error names
-/// both exact tags and both exact branch spellings so the user can fix history
-/// without guessing which pair caused the problem.
-pub fn group_branch_identities(
-    groups: &[Group],
-    prefix: &str,
-) -> Result<Vec<SyntheticBranchIdentity>> {
-    if let Some(collision) = find_synthetic_branch_name_collision(groups, prefix) {
+/// Derive concrete branch identities for `groups` and reject canonical collisions.
+pub fn group_branch_identities(groups: &[Group], prefix: &str) -> Result<Vec<GroupBranchIdentity>> {
+    if let Some(collision) = find_group_branch_name_collision(groups, prefix) {
         Err(collision.into())
     } else {
         Ok(groups
             .iter()
-            .map(|group| synthetic_branch_identity(prefix, &group.tag))
+            .map(|group| GroupBranchIdentity::new(group_branch_name(prefix, group)))
             .collect())
     }
 }
@@ -134,26 +116,48 @@ pub fn group_branch_identities(
 #[cfg(test)]
 mod tests {
     use super::{
-        canonical_branch_conflict_key, find_synthetic_branch_name_collision,
-        group_branch_identities, synthetic_branch_identity,
+        canonical_branch_conflict_key, find_group_branch_name_collision, group_branch_identities,
+        GroupBranchIdentity,
     };
+    use crate::group_markers::GroupMarker;
     use crate::parsing::Group;
 
-    fn group(tag: &str) -> Group {
+    fn pr_group(label: &str) -> Group {
         Group {
-            tag: tag.to_string(),
-            subjects: vec![format!("feat: {tag}")],
-            commits: vec![format!("{tag}1")],
-            first_message: Some(format!("feat: {tag}\n\npr:{tag}")),
+            marker: GroupMarker::PrLabel(label.to_string()),
+            subjects: vec![format!("feat: {label}")],
+            commits: vec![format!("{label}1")],
+            first_message: Some(format!("feat: {label}\n\npr:{label}")),
+            ignored_after: Vec::new(),
+        }
+    }
+
+    fn branch_group(branch_name: &str) -> Group {
+        Group {
+            marker: GroupMarker::BranchName(branch_name.to_string()),
+            subjects: vec![format!("feat: {branch_name}")],
+            commits: vec![format!("{branch_name}1")],
+            first_message: Some(format!("feat: {branch_name}\n\nbranch:{branch_name}")),
             ignored_after: Vec::new(),
         }
     }
 
     #[test]
-    fn synthetic_branch_identity_preserves_exact_branch_name() {
-        let identity = synthetic_branch_identity("dank-spr/", "Alpha");
+    fn branch_identity_preserves_exact_branch_name() {
+        let identity = GroupBranchIdentity::new(
+            GroupMarker::PrLabel("Alpha".to_string()).concrete_branch_name("dank-spr/"),
+        );
 
         assert_eq!(identity.exact, "dank-spr/Alpha");
+    }
+
+    #[test]
+    fn branch_identity_uses_exact_explicit_branch_name() {
+        let identity = GroupBranchIdentity::new(
+            GroupMarker::BranchName("feature/login".to_string()).concrete_branch_name("dank-spr/"),
+        );
+
+        assert_eq!(identity.exact, "feature/login");
     }
 
     #[test]
@@ -173,17 +177,9 @@ mod tests {
     }
 
     #[test]
-    fn group_branch_identities_keep_prefix_in_collision_domain() {
-        let alpha = canonical_branch_conflict_key("dank-spr/alpha");
-        let other = canonical_branch_conflict_key("other-spr/alpha");
-
-        assert_ne!(alpha, other);
-    }
-
-    #[test]
     fn group_branch_identities_reject_case_only_collision() {
-        let err =
-            group_branch_identities(&[group("alpha"), group("Alpha")], "dank-spr/").unwrap_err();
+        let err = group_branch_identities(&[pr_group("alpha"), pr_group("Alpha")], "dank-spr/")
+            .unwrap_err();
 
         assert!(err.to_string().contains("pr:alpha and pr:Alpha"));
         assert!(err.to_string().contains("dank-spr/alpha"));
@@ -191,14 +187,25 @@ mod tests {
     }
 
     #[test]
-    fn find_synthetic_branch_name_collision_returns_typed_entries() {
+    fn group_branch_identities_reject_explicit_collision() {
+        let err = group_branch_identities(
+            &[pr_group("beta"), branch_group("dank-spr/beta")],
+            "dank-spr/",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("pr:beta and branch:dank-spr/beta"));
+    }
+
+    #[test]
+    fn find_group_branch_name_collision_returns_typed_entries() {
         let collision =
-            find_synthetic_branch_name_collision(&[group("alpha"), group("Alpha")], "dank-spr/")
+            find_group_branch_name_collision(&[pr_group("alpha"), pr_group("Alpha")], "dank-spr/")
                 .unwrap();
 
-        assert_eq!(collision.first.stable_handle, "pr:alpha");
+        assert_eq!(collision.first.selector, "pr:alpha");
         assert_eq!(collision.first.head_branch, "dank-spr/alpha");
-        assert_eq!(collision.second.stable_handle, "pr:Alpha");
+        assert_eq!(collision.second.selector, "pr:Alpha");
         assert_eq!(collision.second.head_branch, "dank-spr/Alpha");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,8 +7,8 @@ use crate::execution::ExecutionMode;
 pub enum Extent {
     /// Update the first N PRs (bottom-up)
     Pr {
-        /// Limit updates through this local PR number or stable handle
-        #[arg(long, value_name = "N|label|pr:<label>", conflicts_with_all = ["n", "legacy_n"])]
+        /// Limit updates through this local PR number or group selector
+        #[arg(long, value_name = "N|name|pr:<label>|branch:<branch-name>", conflicts_with_all = ["n", "legacy_n"])]
         to: Option<crate::selectors::GroupSelector>,
         /// Legacy numeric-only limit
         #[arg(long, value_name = "N", conflicts_with_all = ["to", "legacy_n"])]
@@ -73,10 +73,10 @@ impl From<DryRunArgs> for ExecutionMode {
 
 #[derive(Subcommand, Debug, Clone, Copy)]
 pub enum ListWhat {
-    /// List PRs in the stack (halts early if live groups derive case-colliding synthetic branch names)
+    /// List PRs in the stack (halts early if live groups derive case-colliding concrete branch names)
     #[command(alias = "p")]
     Pr,
-    /// List commits in the stack (halts early if live groups derive case-colliding synthetic branch names)
+    /// List commits in the stack (halts early if live groups derive case-colliding concrete branch names)
     #[command(alias = "c")]
     Commit,
 }
@@ -107,7 +107,7 @@ pub enum Cmd {
         pr_description_mode: Option<crate::config::PrDescriptionMode>,
 
         /// Bypass the recent branch-name reuse guard and allow creating a new PR even when the
-        /// same synthetic branch name, including case-only variants, had a recently closed or
+        /// same concrete branch name, including case-only variants, had a recently closed or
         /// merged PR.
         #[arg(long)]
         allow_branch_reuse: bool,
@@ -126,7 +126,10 @@ pub enum Cmd {
     )]
     Restack {
         /// Keep groups through this selector in place and rebuild only the groups above it
-        #[arg(long, value_name = "N|0|bottom|top|last|all|label|pr:<label>")]
+        #[arg(
+            long,
+            value_name = "N|0|bottom|top|last|all|name|pr:<label>|branch:<branch-name>"
+        )]
         after: crate::selectors::AfterSelector,
 
         /// Create a local backup tag at current HEAD before rebasing
@@ -156,11 +159,11 @@ pub enum Cmd {
 
     /// Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch
     #[command(
-        long_about = "Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.\n\nIf you append commits to the end of a local PR branch such as `user-spr/alpha`, run `spr absorb` while the stack branch is checked out. `spr` rebuilds the local stack so the new commits become part of the matching PR group. The PR-group order stays the same.\n\nThis command is local-only: it rewrites the current stack branch, creates a backup tag, and does not update GitHub. After checking the result, run `spr update`.\n\nOnly exact local branches named `prefix + tag` are considered. If one of those branches still points at rewritten-equivalent stack commits, `spr absorb` accepts that prefix only when the branch still descends from the same stack merge-base and the matched pre-tail commit ends at the same tree as the canonical stack prefix. A no-op rewritten match is reported as `skip (rewritten-equivalent prefix)`, and only commits appended above that proven prefix are absorbed. `spr absorb` also refuses to operate when two live PR groups would derive synthetic branch names that differ only by case.\n\nUse `--from <N|label|pr:<label>>` to constrain absorb to one PR group and every group above it. For example, `spr absorb --from pr:beta` considers only the `pr:beta..top` suffix and leaves unrelated lower-group branch tails out of scope.\n\nExample:\n- The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`.\n- Check out `user-spr/alpha` and append 2 commits.\n- Check out the stack branch.\n- Run `spr absorb`.\n- Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same.\n- Then run `spr update`.\n\nOn cherry-pick conflict, `spr absorb` leaves the temp rewrite worktree in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and run the printed resume command.\n\nAdvanced:\n- By default, absorb blocks copied later commits when replaying the stack would become empty or ambiguous.\n- `--allow-replayed-duplicates` allows an earlier copied non-seed follow-up commit to coexist with its later replayed copy by keeping both commits in the rewritten stack."
+        long_about = "Absorb commits appended to canonical local per-PR branches back into the checked-out stack branch.\n\nIf you append commits to the end of a local PR branch such as `user-spr/alpha`, run `spr absorb` while the stack branch is checked out. `spr` rebuilds the local stack so the new commits become part of the matching PR group. The PR-group order stays the same.\n\nThis command is local-only: it rewrites the current stack branch, creates a backup tag, and does not update GitHub. After checking the result, run `spr update`.\n\nOnly each group's exact resolved local branch is considered. If one of those branches still points at rewritten-equivalent stack commits, `spr absorb` accepts that prefix only when the branch still descends from the same stack merge-base and the matched pre-tail commit ends at the same tree as the canonical stack prefix. A no-op rewritten match is reported as `skip (rewritten-equivalent prefix)`, and only commits appended above that proven prefix are absorbed. `spr absorb` also refuses to operate when two live PR groups would derive concrete branch names that differ only by case.\n\nUse `--from <N|name|pr:<label>|branch:<branch-name>>` to constrain absorb to one PR group and every group above it. For example, `spr absorb --from pr:beta` considers only the `pr:beta..top` suffix and leaves unrelated lower-group branch tails out of scope.\n\nExample:\n- The current stack has three PR groups: `pr:alpha`, `pr:beta`, and `pr:gamma`.\n- Check out `user-spr/alpha` and append 2 commits.\n- Check out the stack branch.\n- Run `spr absorb`.\n- Result: the 2 new commits are folded into the `pr:alpha` group, and the PR-group order stays the same.\n- Then run `spr update`.\n\nOn cherry-pick conflict, `spr absorb` leaves the temp rewrite worktree in place, writes a resume file under the repository common Git directory, and prints `spr resume <path>`. Resolve conflicts in that temp worktree, stage the resolution, and run the printed resume command.\n\nAdvanced:\n- By default, absorb blocks copied later commits when replaying the stack would become empty or ambiguous.\n- `--allow-replayed-duplicates` allows an earlier copied non-seed follow-up commit to coexist with its later replayed copy by keeping both commits in the rewritten stack."
     )]
     Absorb {
         /// Absorb only this PR group and every group above it
-        #[arg(long, value_name = "N|label|pr:<label>")]
+        #[arg(long, value_name = "N|name|pr:<label>|branch:<branch-name>")]
         from: Option<crate::selectors::GroupSelector>,
 
         /// Allow replayed duplicates and keep both copies when the later replay is non-seed
@@ -175,10 +178,10 @@ pub enum Cmd {
         dry_run: DryRunArgs,
     },
 
-    /// Prepare PRs for landing (e.g., squash) and halt early on case-colliding synthetic branch names
+    /// Prepare PRs for landing (e.g., squash) and halt early on case-colliding concrete branch names
     Prep {
         /// Prepare this PR group and every group above it
-        #[arg(long, value_name = "N|label|pr:<label>")]
+        #[arg(long, value_name = "N|name|pr:<label>|branch:<branch-name>")]
         from: Option<crate::selectors::GroupSelector>,
 
         // Additional selection is provided via global --until/--exact flags.
@@ -196,14 +199,14 @@ pub enum Cmd {
         path: PathBuf,
     },
 
-    /// List entities and halt early on case-colliding synthetic branch names
+    /// List entities and halt early on case-colliding concrete branch names
     #[command(alias = "ls")]
     List {
         #[command(subcommand)]
         what: ListWhat,
     },
 
-    /// Status overview (alias for `list pr`) with the same early synthetic branch-collision guard
+    /// Status overview (alias for `list pr`) with the same early concrete branch-collision guard
     #[command(alias = "stat")]
     Status,
 
@@ -219,7 +222,7 @@ pub enum Cmd {
         target: Option<String>,
     },
 
-    /// Land PRs (merge variants) and halt early on case-colliding synthetic branch names
+    /// Land PRs (merge variants) and halt early on case-colliding concrete branch names
     Land {
         // Target PR index is provided via global --until. For `flatten`, 0 means the top PR. For `per-pr`, 0 means all
         #[command(subcommand)]
@@ -234,7 +237,7 @@ pub enum Cmd {
         dry_run: DryRunArgs,
     },
 
-    /// Relink PR stack to match local commit stack and halt early on case-colliding synthetic branch names
+    /// Relink PR stack to match local commit stack and halt early on case-colliding concrete branch names
     RelinkPrs {
         #[command(flatten)]
         dry_run: DryRunArgs,
@@ -250,7 +253,7 @@ pub enum Cmd {
     /// Move the last M commits (top of stack) to the tail of a selected PR group
     #[command(visible_alias = "fix")]
     FixPr {
-        /// Target local PR number or stable handle
+        /// Target local PR number or group selector
         target: crate::selectors::GroupSelector,
         /// Number of top commits to move to the selected PR group's tail
         #[arg(short = 't', long = "tail", default_value_t = 1)]
@@ -262,13 +265,16 @@ pub enum Cmd {
         dry_run: DryRunArgs,
     },
 
-    /// Reorder local PR groups by moving one or a range to come after a target PR, halting early on case-colliding synthetic branch names
+    /// Reorder local PR groups by moving one or a range to come after a target PR, halting early on case-colliding concrete branch names
     #[command(alias = "mv")]
     Move {
-        /// Position or range to move: `A`, `A..B`, `label`, `pr:<label>`, `a..b`, or `pr:<a>..pr:<b>`
+        /// Position or range to move: ordinal, bare selector, explicit selector, or selector range
         range: crate::selectors::GroupRangeSelector,
-        /// Target PR position to come after: number, stable handle, or one of bottom/top/last/all
-        #[arg(long, value_name = "C|bottom|top|last|all|label|pr:<label>")]
+        /// Target PR position to come after: number, group selector, or one of bottom/top/last/all
+        #[arg(
+            long,
+            value_name = "C|bottom|top|last|all|name|pr:<label>|branch:<branch-name>"
+        )]
         after: crate::selectors::AfterSelector,
         /// Create a local backup tag at current HEAD before rewriting
         #[arg(long)]
@@ -305,14 +311,22 @@ pub struct Cli {
     /// Global branch prefix for per-PR branches
     #[arg(long, global = true)]
     pub prefix: Option<String>,
-    /// Sync local per-PR branches named like synthetic PR branches
+    /// Sync local per-PR branches named like each group's resolved concrete branch
     #[arg(long, global = true, value_enum)]
     pub local_pr_branches: Option<crate::config::LocalPrBranchSyncPolicy>,
-    /// Global until (used by prep/land). Accepts 0, a local PR number, or a stable handle
-    #[arg(long, global = true, value_name = "N|0|label|pr:<label>")]
+    /// Global until (used by prep/land). Accepts 0, a local PR number, or a group selector
+    #[arg(
+        long,
+        global = true,
+        value_name = "N|0|name|pr:<label>|branch:<branch-name>"
+    )]
     pub until: Option<crate::selectors::InclusiveSelector>,
-    /// Global exact (used by prep). Accepts a local PR number or a stable handle
-    #[arg(long, global = true, value_name = "I|label|pr:<label>")]
+    /// Global exact (used by prep). Accepts a local PR number or a group selector
+    #[arg(
+        long,
+        global = true,
+        value_name = "I|name|pr:<label>|branch:<branch-name>"
+    )]
     pub exact: Option<crate::selectors::GroupSelector>,
     #[command(flatten)]
     pub output: OutputArgs,
@@ -361,9 +375,12 @@ mod tests {
 
         match cli.cmd {
             Cmd::Absorb {
-                from: Some(crate::selectors::GroupSelector::Stable(handle)),
+                from:
+                    Some(crate::selectors::GroupSelector::Explicit(
+                        crate::selectors::ExplicitGroupSelector::PrLabel(label),
+                    )),
                 ..
-            } => assert_eq!(handle.tag, "beta"),
+            } => assert_eq!(label, "beta"),
             other => panic!("unexpected command: {:?}", other),
         }
     }
@@ -374,9 +391,12 @@ mod tests {
 
         match cli.cmd {
             Cmd::Prep {
-                from: Some(crate::selectors::GroupSelector::Stable(handle)),
+                from:
+                    Some(crate::selectors::GroupSelector::Explicit(
+                        crate::selectors::ExplicitGroupSelector::PrLabel(label),
+                    )),
                 ..
-            } => assert_eq!(handle.tag, "beta"),
+            } => assert_eq!(label, "beta"),
             other => panic!("unexpected command: {:?}", other),
         }
     }

--- a/src/commands/absorb.rs
+++ b/src/commands/absorb.rs
@@ -1,7 +1,7 @@
 //! Absorb append-only local per-PR branch tails back into the current stack.
 //!
-//! `spr absorb` inspects the current local stack, looks for exact local source
-//! branches named `prefix + tag`, and classifies each one as absorbable,
+//! `spr absorb` inspects the current local stack, looks for each group's exact
+//! canonical local branch, and classifies it as absorbable,
 //! skippable, or blocking. When one or more groups have append-only local
 //! branch tails, the command rebuilds the checked-out stack branch from its
 //! current merge-base and inserts those tails immediately after their owning
@@ -14,7 +14,7 @@ use anyhow::{anyhow, Result};
 use std::collections::{HashMap, HashSet};
 use tracing::info;
 
-use crate::branch_names::{group_branch_identities, synthetic_branch_name};
+use crate::branch_names::{group_branch_identities, group_branch_name};
 use crate::commands::common::{self, CherryPickEmptyPolicy, CherryPickOp};
 use crate::commands::rewrite_resume::{
     self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteSession,
@@ -32,11 +32,11 @@ use crate::selectors::{resolve_group_index, GroupSelector};
 /// Rebuilds the current stack branch by folding append-only local per-PR branch
 /// tails back into their owning PR groups.
 ///
-/// The exact source branch rule is intentional: only the local branch named
-/// `prefix + tag` is considered for each group. Missing branches and branches
+/// The exact source branch rule is intentional: only the local branch resolved
+/// from the group's seed marker is considered for each group. Missing branches and branches
 /// that are unchanged or behind the stack are no-op states. Divergence, source
 /// branches that incorporated later stack commits, merge commits, and embedded
-/// `pr:<tag>` markers in absorbed tails are blocking errors. A local branch
+/// group markers in absorbed tails are blocking errors. A local branch
 /// whose canonical stack prefix was rewritten to patch-equivalent commits is
 /// still acceptable when that rewritten prefix descends from the same stack
 /// merge-base and reaches the same tree at the matched pre-tail endpoint.
@@ -86,7 +86,7 @@ pub fn absorb_branch_tails(
 /// Returns the local branch names the current absorb transaction may move.
 ///
 /// A tail inserted into an earlier group rewrites that group and every later
-/// group in the stack, even if optional local synthetic-branch synchronization
+/// group in the stack, even if optional local resolved-branch synchronization
 /// is disabled for the actual command. Untargeted queries return the realized
 /// changed suffix. Targeted queries return the requested suffix so callers can
 /// protect the whole transaction boundary before running apply mode.
@@ -124,7 +124,7 @@ fn changed_branches_for_plan(prefix: &str, plan: &RewritePlan) -> Result<Vec<Str
     changed_branches.extend(
         plan.groups[first_changed_group..]
             .iter()
-            .map(|group| synthetic_branch_name(prefix, &group.group.tag)),
+            .map(|group| group_branch_name(prefix, &group.group)),
     );
     Ok(changed_branches)
 }
@@ -265,10 +265,7 @@ impl SourceBranchRecord {
     fn summary_line(&self) -> String {
         match &self.classification {
             AbsorbClassification::Skip(reason) => {
-                format!(
-                    "pr:{} <- {} : skip ({})",
-                    self.tag, self.branch_name, reason
-                )
+                format!("{} <- {} : skip ({})", self.tag, self.branch_name, reason)
             }
             AbsorbClassification::Absorbable(tail) => {
                 let kept_text = if tail.kept_later_duplicate_replays.is_empty() {
@@ -280,7 +277,7 @@ impl SourceBranchRecord {
                     )
                 };
                 format!(
-                    "pr:{} <- {} : absorb {}{}",
+                    "{} <- {} : absorb {}{}",
                     self.tag,
                     self.branch_name,
                     commit_count_text(tail.commits.len()),
@@ -288,10 +285,7 @@ impl SourceBranchRecord {
                 )
             }
             AbsorbClassification::Blocked(reason) => {
-                format!(
-                    "pr:{} <- {} : block ({})",
-                    self.tag, self.branch_name, reason
-                )
+                format!("{} <- {} : block ({})", self.tag, self.branch_name, reason)
             }
         }
     }
@@ -431,7 +425,7 @@ impl std::fmt::Display for AbsorbBlocker {
                 owner_commit,
             } => write!(
                 f,
-                "absorbed tail commit {} duplicates later replayed pr:{} commit {}",
+                "absorbed tail commit {} duplicates later replayed {} commit {}",
                 short_sha(commit),
                 owner_tag,
                 short_sha(owner_commit)
@@ -442,7 +436,7 @@ impl std::fmt::Display for AbsorbBlocker {
                 owner_commit,
             } => write!(
                 f,
-                "absorbed tail commit {} duplicates later pr:{} seed commit {}; --allow-replayed-duplicates only applies to later non-seed commits, so this still blocks",
+                "absorbed tail commit {} duplicates later {} seed commit {}; --allow-replayed-duplicates only applies to later non-seed commits, so this still blocks",
                 short_sha(commit),
                 owner_tag,
                 short_sha(owner_commit)
@@ -514,13 +508,13 @@ fn build_out_of_scope_group_rewrite_plan(
     group: Group,
     prefix: &str,
 ) -> Result<PreliminaryGroupRewritePlan> {
-    let tag = group.tag.clone();
-    let branch_name = synthetic_branch_name(prefix, &group.tag);
+    let tag = group.selector_text();
+    let branch_name = group_branch_name(prefix, &group);
     let group_tip = group
         .commits
         .last()
         .cloned()
-        .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+        .ok_or_else(|| anyhow!("Group {} has no commits", group.selector_text()))?;
     Ok(PreliminaryGroupRewritePlan {
         group,
         source: PreliminarySourceBranchRecord {
@@ -579,13 +573,13 @@ fn classify_source_branch_preliminary(
     stack_merge_base: &str,
     stack_head: &str,
 ) -> Result<PreliminarySourceBranchRecord> {
-    let branch_name = synthetic_branch_name(prefix, &group.tag);
+    let branch_name = group_branch_name(prefix, group);
     let stack_prefix = build_stack_prefix(group, stack_merge_base)?;
     let group_tip = stack_prefix
         .commits
         .last()
         .cloned()
-        .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+        .ok_or_else(|| anyhow!("Group {} has no commits", group.selector_text()))?;
     let source_tip = git_local_branch_tip(&branch_name)?;
     let classification = if let Some(source_tip) = source_tip.as_deref() {
         if source_tip == group_tip {
@@ -620,7 +614,7 @@ fn classify_source_branch_preliminary(
         ))
     };
     Ok(PreliminarySourceBranchRecord {
-        tag: group.tag.clone(),
+        tag: group.selector_text(),
         branch_name,
         group_tip,
         source_tip,
@@ -638,7 +632,7 @@ fn finalize_source_branch_record(
         PreliminaryAbsorbClassification::NeedsTailValidation { commits } => {
             let later_owned_patches = later_owned_patches.ok_or_else(|| {
                 anyhow!(
-                    "Missing later-owned patch map for absorb candidate pr:{}",
+                    "Missing later-owned patch map for absorb candidate {}",
                     source.tag
                 )
             })?;
@@ -659,12 +653,17 @@ fn build_stack_prefix(group: &Group, stack_merge_base: &str) -> Result<StackPref
         .commits
         .last()
         .cloned()
-        .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+        .ok_or_else(|| anyhow!("Group {} has no commits", group.selector_text()))?;
     let commits = git_rev_list_range(stack_merge_base, &group_tip)?;
     let group_start_index = commits
         .len()
         .checked_sub(group.commits.len())
-        .ok_or_else(|| anyhow!("Group {} stack prefix is shorter than the group", group.tag))?;
+        .ok_or_else(|| {
+            anyhow!(
+                "Group {} stack prefix is shorter than the group",
+                group.selector_text()
+            )
+        })?;
     Ok(StackPrefix {
         commits,
         group_start_index,
@@ -794,7 +793,7 @@ fn classify_absorbed_tail(
             ));
         }
         let message = git_commit_message(sha)?;
-        if crate::pr_labels::contains_candidate_marker(&message) {
+        if !crate::group_markers::candidate_group_markers(&message).is_empty() {
             return Ok(AbsorbClassification::Blocked(
                 AbsorbBlocker::TailHasStackMarker {
                     commit: sha.clone(),
@@ -901,7 +900,7 @@ fn build_later_owned_patch_maps(
             record_later_replayed_commits(
                 &mut later_owned_patches,
                 &group.group.ignored_after,
-                &group.group.tag,
+                &group.group.selector_text(),
                 &patch_ids_by_commit,
                 LaterReplayedCommitKind::IgnoredAfter,
             );
@@ -915,7 +914,7 @@ fn build_later_owned_patch_maps(
             record_later_replayed_commits(
                 &mut later_owned_patches,
                 &group.group.commits,
-                &group.group.tag,
+                &group.group.selector_text(),
                 &patch_ids_by_commit,
                 LaterReplayedCommitKind::GroupFollowUp,
             );
@@ -1138,8 +1137,8 @@ fn emit_rewrite_plan(plan: &RewritePlan) {
             format!(" + keep {}", commit_count_text(kept_replays))
         };
         info!(
-            "  pr:{}: replay {}{}{}{}",
-            group.group.tag,
+            "  {}: replay {}{}{}{}",
+            group.group.selector_text(),
             commit_count_text(group.group.commits.len()),
             absorbed_text,
             ignored_text,
@@ -1179,7 +1178,7 @@ mod tests {
     use crate::config::DirtyWorktreePolicy;
     use crate::execution::ExecutionMode;
     use crate::parsing::{derive_local_groups_with_ignored, Group};
-    use crate::selectors::{GroupSelector, StableHandle};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
     use std::env;
     use std::fs;
@@ -1294,7 +1293,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("pr:alpha and pr:Alpha derive conflicting synthetic branch names"),
+                .contains("pr:alpha and pr:Alpha derive conflicting branch names"),
             "unexpected error: {err}"
         );
     }
@@ -1801,7 +1800,7 @@ mod tests {
                 owner_commit,
                 ..
             }) => {
-                assert_eq!(owner_tag, "beta");
+                assert_eq!(owner_tag, "pr:beta");
                 assert_eq!(owner_commit, repo.beta_tip.unwrap());
             }
             other => panic!("unexpected classification: {:?}", other),
@@ -1824,7 +1823,7 @@ mod tests {
             AbsorbClassification::Absorbable(tail) => {
                 assert_eq!(tail.commits.len(), 1);
                 assert_eq!(tail.kept_later_duplicate_replays.len(), 1);
-                assert_eq!(tail.kept_later_duplicate_replays[0].tag, "beta");
+                assert_eq!(tail.kept_later_duplicate_replays[0].tag, "pr:beta");
                 assert_eq!(
                     tail.kept_later_duplicate_replays[0].sha,
                     repo.beta_tip.unwrap()
@@ -1891,14 +1890,14 @@ mod tests {
     ) -> GroupRewritePlan {
         GroupRewritePlan {
             group: Group {
-                tag: tag.to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
                 subjects: Vec::new(),
                 commits: commits.iter().map(|sha| sha.to_string()).collect(),
                 first_message: None,
                 ignored_after: ignored_after.iter().map(|sha| sha.to_string()).collect(),
             },
             source: SourceBranchRecord {
-                tag: tag.to_string(),
+                tag: format!("pr:{tag}"),
                 branch_name: format!("dank-spr/{tag}"),
                 group_tip: commits.last().unwrap().to_string(),
                 source_tip: Some(
@@ -1951,7 +1950,7 @@ mod tests {
     #[test]
     fn rewritten_equivalent_prefix_skip_reason_has_distinct_summary_text() {
         let record = SourceBranchRecord {
-            tag: "alpha".to_string(),
+            tag: "pr:alpha".to_string(),
             branch_name: "dank-spr/alpha".to_string(),
             group_tip: "alpha-2".to_string(),
             source_tip: Some("alpha-rewrite-2".to_string()),
@@ -2207,7 +2206,7 @@ mod tests {
         assert_eq!(
             groups
                 .iter()
-                .map(|group| group.tag.as_str())
+                .map(Group::bare_selector_text)
                 .collect::<Vec<_>>(),
             vec!["alpha", "beta", "gamma"]
         );
@@ -2316,7 +2315,7 @@ mod tests {
         assert_eq!(
             groups
                 .iter()
-                .map(|group| group.tag.as_str())
+                .map(Group::bare_selector_text)
                 .collect::<Vec<_>>(),
             vec!["alpha", "beta", "gamma"]
         );
@@ -2631,9 +2630,7 @@ mod tests {
         );
         git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
 
-        let from = GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        });
+        let from = GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("beta".to_string()));
         let _guard = DirGuard::change_to(&repo.repo);
         let changed_branches = query_absorb_changed_branches(
             &repo.base_branch,
@@ -2682,9 +2679,7 @@ mod tests {
         );
         git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
 
-        let from = GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        });
+        let from = GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("beta".to_string()));
         {
             let _guard = DirGuard::change_to(&repo.repo);
             absorb_branch_tails(
@@ -2720,9 +2715,7 @@ mod tests {
         let _keep_dir_alive = repo.dir.path();
         git(&repo.repo, ["checkout", &repo.stack_branch].as_slice());
 
-        let from = GroupSelector::Stable(StableHandle {
-            tag: "missing".to_string(),
-        });
+        let from = GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("missing".to_string()));
         let _guard = DirGuard::change_to(&repo.repo);
         let err = query_absorb_changed_branches(
             &repo.base_branch,
@@ -2735,7 +2728,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("No outstanding PR group matches stable handle `pr:missing`."),
+                .contains("No outstanding PR group matches selector `pr:missing`."),
             "unexpected error: {err}"
         );
     }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -715,7 +715,7 @@ impl CherryPickOp {
 /// Build expected (head, base) chain bottom→top from local groups.
 ///
 /// This validates that the current stack does not derive case-colliding
-/// synthetic branch names before returning any branch chain.
+/// concrete branch names before returning any branch chain.
 pub fn build_head_base_chain(
     base: &str,
     groups: &[Group],
@@ -730,17 +730,19 @@ pub fn build_head_base_chain(
     Ok(expected)
 }
 
-pub fn stable_handle_text(tag: &str) -> String {
-    format!("pr:{tag}")
+pub fn group_selector_text(group: &Group) -> String {
+    group.selector_text()
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_temp_worktree, create_backup_tag, create_temp_worktree,
+        build_head_base_chain, cleanup_temp_worktree, create_backup_tag, create_temp_worktree,
         get_current_branch_and_short,
     };
     use crate::execution::ExecutionMode;
+    use crate::group_markers::GroupMarker;
+    use crate::parsing::Group;
     use crate::test_support::{lock_cwd, DirGuard};
     use std::fs;
     use std::path::Path;
@@ -773,6 +775,36 @@ mod tests {
         git(repo, ["add", "."].as_slice());
         git(repo, ["commit", "-m", "init"].as_slice());
         dir
+    }
+
+    fn group(marker: GroupMarker) -> Group {
+        Group {
+            marker,
+            subjects: Vec::new(),
+            commits: vec!["sha".to_string()],
+            first_message: None,
+            ignored_after: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn build_head_base_chain_uses_resolved_concrete_branch_names() {
+        let groups = vec![
+            group(GroupMarker::BranchName("feature/login".to_string())),
+            group(GroupMarker::PrLabel("beta".to_string())),
+            group(GroupMarker::BranchName("release/docs".to_string())),
+        ];
+
+        let chain = build_head_base_chain("main", &groups, "dank-spr/").unwrap();
+
+        assert_eq!(
+            chain,
+            vec![
+                ("feature/login".to_string(), "main".to_string()),
+                ("dank-spr/beta".to_string(), "feature/login".to_string()),
+                ("release/docs".to_string(), "dank-spr/beta".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/commands/drop_merged_prefix.rs
+++ b/src/commands/drop_merged_prefix.rs
@@ -24,7 +24,7 @@ use crate::stack_metadata::RefreshMetadataContext;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct MergedPrefixCandidate {
-    tag: String,
+    selector: String,
     head: String,
     pr_number: u64,
     local_tip: String,
@@ -65,7 +65,7 @@ fn select_bottom_merged_prefix(
 ) -> Result<Vec<MergedPrefixCandidate>> {
     if groups.len() != heads.len() {
         bail!(
-            "internal error: {} local groups but {} synthetic branch heads",
+            "internal error: {} local groups but {} resolved branch heads",
             groups.len(),
             heads.len()
         );
@@ -78,10 +78,13 @@ fn select_bottom_merged_prefix(
         if let Some(remote_pr) = remote_pr {
             if remote_pr.state == PrState::Merged {
                 let local_tip = group.commits.last().cloned().ok_or_else(|| {
-                    anyhow!("local PR group pr:{} has no local commits", group.tag)
+                    anyhow!(
+                        "local PR group {} has no local commits",
+                        group.selector_text()
+                    )
                 })?;
                 selected.push(MergedPrefixCandidate {
-                    tag: group.tag.clone(),
+                    selector: group.selector_text(),
                     head: head.clone(),
                     pr_number: remote_pr.number,
                     local_tip,
@@ -162,7 +165,7 @@ fn log_drop_plan(plan: &DropMergedPrefixPlan, execution_mode: ExecutionMode, bas
     let handles = plan
         .dropped
         .iter()
-        .map(|candidate| format!("pr:{} (#{})", candidate.tag, candidate.pr_number))
+        .map(|candidate| format!("{} (#{})", candidate.selector, candidate.pr_number))
         .collect::<Vec<_>>()
         .join(", ");
     let mode = if execution_mode == ExecutionMode::DryRun {
@@ -336,7 +339,7 @@ mod tests {
 
     fn group(tag: &str, commits: &[&str]) -> Group {
         Group {
-            tag: tag.to_string(),
+            marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
             subjects: vec![format!("feat: {tag}")],
             commits: commits.iter().map(|commit| (*commit).to_string()).collect(),
             first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -361,7 +364,7 @@ mod tests {
         local_tip: &str,
     ) -> MergedPrefixCandidate {
         MergedPrefixCandidate {
-            tag: tag.to_string(),
+            selector: format!("pr:{tag}"),
             head: head.to_string(),
             pr_number,
             local_tip: local_tip.to_string(),

--- a/src/commands/fix_pr.rs
+++ b/src/commands/fix_pr.rs
@@ -85,17 +85,17 @@ pub fn fix_pr_tail(
     let m = tail_count.min(all_commits.len());
     let top_commits: Vec<String> = all_commits.split_off(all_commits.len() - m);
 
-    // Validate: moved commits must NOT contain pr:<tag> markers
+    // Validate: moved commits must NOT contain group markers.
     let mut offenders: Vec<String> = vec![];
     for sha in &top_commits {
         let msg = git_ro(["log", "-n", "1", "--format=%B", sha].as_slice())?;
-        if crate::pr_labels::contains_candidate_marker(&msg) {
+        if !crate::group_markers::candidate_group_markers(&msg).is_empty() {
             offenders.push(sha.clone());
         }
     }
     if !offenders.is_empty() {
         bail!(
-            "Selected tail commit(s) contain pr:<tag> markers; cannot move commits that start or belong to PR groups: {}",
+            "Selected tail commit(s) contain group markers; cannot move commits that start or belong to PR groups: {}",
             offenders
                 .iter()
                 .map(|s| s.chars().take(8).collect::<String>())
@@ -207,7 +207,7 @@ mod tests {
     use crate::config::DirtyWorktreePolicy;
     use crate::execution::ExecutionMode;
     use crate::parsing::Group;
-    use crate::selectors::{GroupSelector, StableHandle};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector};
     use crate::test_support::{lock_cwd, DirGuard};
     use std::fs;
     use std::path::Path;
@@ -225,7 +225,7 @@ mod tests {
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
             .map(|tag| Group {
-                tag: tag.to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
                 subjects: vec![format!("feat: {tag}")],
                 commits: vec![format!("{tag}1")],
                 first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -237,9 +237,7 @@ mod tests {
     #[test]
     fn fix_pr_resolves_stable_handle_to_current_local_ordinal() {
         let groups = groups(&["alpha", "beta", "gamma"]);
-        let target = GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        });
+        let target = GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("beta".to_string()));
 
         assert_eq!(resolve_fix_pr_target(&groups, &target).unwrap(), 2);
     }

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -22,7 +22,7 @@ fn resolve_land_take_count(
 
 fn resolve_landed_pr_segment<'a>(
     groups: &[crate::parsing::Group],
-    branch_identities: &[crate::branch_names::SyntheticBranchIdentity],
+    branch_identities: &[crate::branch_names::GroupBranchIdentity],
     prs_by_head: &HashMap<
         crate::branch_names::CanonicalBranchConflictKey,
         &'a crate::github::PrInfo,
@@ -38,7 +38,7 @@ fn resolve_landed_pr_segment<'a>(
         } else {
             bail!(
                 "No open PR found for local group '{}' (branch '{}')",
-                g.tag,
+                g.selector_text(),
                 head_branch
             );
         }
@@ -288,14 +288,14 @@ mod tests {
     use crate::execution::ExecutionMode;
     use crate::github::PrInfo;
     use crate::parsing::Group;
-    use crate::selectors::{GroupSelector, InclusiveSelector, StableHandle};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector, InclusiveSelector};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
     use std::collections::HashMap;
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
             .map(|tag| Group {
-                tag: tag.to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
                 subjects: vec![format!("feat: {tag}")],
                 commits: vec![format!("{tag}1")],
                 first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -315,9 +315,9 @@ mod tests {
     #[test]
     fn land_until_resolves_stable_handle_as_inclusive_prefix() {
         let groups = groups(&["alpha", "beta", "gamma"]);
-        let until = InclusiveSelector::Group(GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        }));
+        let until = InclusiveSelector::Group(GroupSelector::Explicit(
+            ExplicitGroupSelector::PrLabel("beta".to_string()),
+        ));
 
         assert_eq!(resolve_land_take_count(&groups, &until).unwrap(), 2);
     }
@@ -370,7 +370,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "No open PR found for local group 'sigma' (branch 'skilltest/sigma')"
+            "No open PR found for local group 'pr:sigma' (branch 'skilltest/sigma')"
         );
     }
 
@@ -394,7 +394,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("pr:alpha and pr:Alpha derive conflicting synthetic branch names"),
+                .contains("pr:alpha and pr:Alpha derive conflicting branch names"),
             "unexpected error: {err}"
         );
     }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use tracing::info;
 
 use crate::branch_names::{
-    canonical_branch_conflict_key, find_synthetic_branch_name_collision, group_branch_identities,
-    CanonicalBranchConflictKey, SyntheticBranchIdentity, SyntheticBranchNameCollision,
+    canonical_branch_conflict_key, find_group_branch_name_collision, group_branch_identities,
+    CanonicalBranchConflictKey, GroupBranchIdentity, GroupBranchNameCollision,
 };
 use crate::config::{ListOrder, LocalPrBranchSyncPolicy};
 use crate::github::{
@@ -27,7 +27,7 @@ use crate::parsing::{derive_local_groups, Group};
 
 #[derive(Debug)]
 pub enum ReadOnlyQueryError {
-    SyntheticBranchNameCollision(SyntheticBranchNameCollision),
+    SyntheticBranchNameCollision(GroupBranchNameCollision),
     Internal(anyhow::Error),
 }
 
@@ -235,10 +235,10 @@ fn derive_groups_and_identities(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
-) -> std::result::Result<(Vec<Group>, Vec<SyntheticBranchIdentity>), ReadOnlyQueryError> {
+) -> std::result::Result<(Vec<Group>, Vec<GroupBranchIdentity>), ReadOnlyQueryError> {
     let (_merge_base, groups) =
         derive_local_groups(base, ignore_tag).map_err(ReadOnlyQueryError::Internal)?;
-    if let Some(collision) = find_synthetic_branch_name_collision(&groups, prefix) {
+    if let Some(collision) = find_group_branch_name_collision(&groups, prefix) {
         Err(ReadOnlyQueryError::SyntheticBranchNameCollision(collision))
     } else {
         let identities =
@@ -248,7 +248,7 @@ fn derive_groups_and_identities(
 }
 
 fn fetch_remote_pr_metadata(
-    branch_identities: &[SyntheticBranchIdentity],
+    branch_identities: &[GroupBranchIdentity],
 ) -> Result<HashMap<CanonicalBranchConflictKey, RemotePrMetadata>> {
     let heads: Vec<String> = branch_identities
         .iter()
@@ -290,7 +290,7 @@ fn build_remote_pr_metadata(
 
 fn build_pr_list_data(
     groups: &[Group],
-    branch_identities: &[SyntheticBranchIdentity],
+    branch_identities: &[GroupBranchIdentity],
     remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
     local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 ) -> PrListData {
@@ -301,7 +301,7 @@ fn build_pr_list_data(
             let identity = &branch_identities[group_idx];
             PrGroupData {
                 local_pr_number: group_idx + 1,
-                stable_handle: crate::commands::common::stable_handle_text(&group.tag),
+                stable_handle: crate::commands::common::group_selector_text(group),
                 head_branch: identity.exact.clone(),
                 first_commit_sha: group.commits.first().cloned().unwrap_or_default(),
                 commit_count: group.commits.len(),
@@ -324,7 +324,7 @@ fn build_pr_list_data(
 
 fn build_commit_list_data(
     groups: &[Group],
-    branch_identities: &[SyntheticBranchIdentity],
+    branch_identities: &[GroupBranchIdentity],
     remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
     local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
 ) -> CommitListData {
@@ -355,7 +355,7 @@ fn build_commit_list_data(
                 .collect();
             CommitGroupData {
                 local_pr_number: group_idx + 1,
-                stable_handle: crate::commands::common::stable_handle_text(&group.tag),
+                stable_handle: crate::commands::common::group_selector_text(group),
                 head_branch: identity.exact.clone(),
                 remote: remote_by_head
                     .get(&identity.conflict_key)
@@ -681,7 +681,20 @@ mod tests {
 
     fn group(tag: &str, commits: &[(&str, &str)]) -> Group {
         Group {
-            tag: tag.to_string(),
+            marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
+            subjects: commits
+                .iter()
+                .map(|(_, subject)| (*subject).to_string())
+                .collect(),
+            commits: commits.iter().map(|(sha, _)| (*sha).to_string()).collect(),
+            first_message: None,
+            ignored_after: Vec::new(),
+        }
+    }
+
+    fn branch_group(branch_name: &str, commits: &[(&str, &str)]) -> Group {
+        Group {
+            marker: crate::group_markers::GroupMarker::BranchName(branch_name.to_string()),
             subjects: commits
                 .iter()
                 .map(|(_, subject)| (*subject).to_string())
@@ -699,8 +712,8 @@ mod tests {
             group("beta", &[("bbbbbbbb1", "feat: beta")]),
         ];
         let branch_identities = vec![
-            SyntheticBranchIdentity::new("dank-spr/", "alpha"),
-            SyntheticBranchIdentity::new("dank-spr/", "beta"),
+            GroupBranchIdentity::new("dank-spr/alpha".to_string()),
+            GroupBranchIdentity::new("dank-spr/beta".to_string()),
         ];
         let remote_by_head = HashMap::from([(
             canonical_branch_conflict_key("dank-spr/beta"),
@@ -730,6 +743,25 @@ mod tests {
             RemotePrState::RemoteWithCiReview { url, .. }
                 if url == "https://github.com/o/r/pull/17"
         ));
+    }
+
+    #[test]
+    fn build_pr_list_data_renders_explicit_branch_selectors_and_heads() {
+        let groups = vec![
+            branch_group("feature/login", &[("aaaaaaaa1", "feat: login")]),
+            group("beta", &[("bbbbbbbb1", "feat: beta")]),
+        ];
+        let branch_identities = vec![
+            GroupBranchIdentity::new("feature/login".to_string()),
+            GroupBranchIdentity::new("dank-spr/beta".to_string()),
+        ];
+
+        let data = build_pr_list_data(&groups, &branch_identities, &HashMap::new(), Vec::new());
+
+        assert_eq!(data.groups[0].stable_handle, "branch:feature/login");
+        assert_eq!(data.groups[0].head_branch, "feature/login");
+        assert_eq!(data.groups[1].stable_handle, "pr:beta");
+        assert_eq!(data.groups[1].head_branch, "dank-spr/beta");
     }
 
     #[test]
@@ -790,8 +822,8 @@ mod tests {
             group("beta", &[("bbbbbbbb1", "feat: beta one")]),
         ];
         let branch_identities = vec![
-            SyntheticBranchIdentity::new("dank-spr/", "alpha"),
-            SyntheticBranchIdentity::new("dank-spr/", "beta"),
+            GroupBranchIdentity::new("dank-spr/alpha".to_string()),
+            GroupBranchIdentity::new("dank-spr/beta".to_string()),
         ];
         let remote_by_head = HashMap::from([(
             canonical_branch_conflict_key("dank-spr/alpha"),
@@ -969,8 +1001,8 @@ mod tests {
 
         match err {
             ReadOnlyQueryError::SyntheticBranchNameCollision(collision) => {
-                assert_eq!(collision.first.stable_handle, "pr:alpha");
-                assert_eq!(collision.second.stable_handle, "pr:Alpha");
+                assert_eq!(collision.first.selector, "pr:alpha");
+                assert_eq!(collision.second.selector, "pr:Alpha");
             }
             other => panic!("unexpected error: {:?}", other),
         }

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Result};
 use tracing::info;
 
-use crate::branch_names::{group_branch_identities, synthetic_branch_name};
+use crate::branch_names::{group_branch_identities, group_branch_name};
 use crate::commands::common;
 use crate::commands::common::CherryPickOp;
 use crate::commands::rewrite_resume::{
@@ -97,14 +97,14 @@ fn enforce_bottom_pr_automerge_guard(
 ) -> Result<()> {
     if changes_stack_bottom(new_order) {
         let bottom_group = &groups[0];
-        let bottom_head = synthetic_branch_name(prefix, &bottom_group.tag);
+        let bottom_head = group_branch_name(prefix, bottom_group);
         if let Some(bottom_pr) = get_open_pr_automerge_for_head(&bottom_head)? {
             if should_block_for_bottom_pr_automerge(bottom_pr.auto_merge_enabled, new_order) {
                 Err(anyhow!(
-                    "Refusing to change the stack bottom because {} (#{} / pr:{}) has auto-merge enabled. Disable auto-merge on that bottom PR before moving any PR below it.",
+                    "Refusing to change the stack bottom because {} (#{} / {}) has auto-merge enabled. Disable auto-merge on that bottom PR before moving any PR below it.",
                     bottom_head,
                     bottom_pr.number,
-                    bottom_group.tag
+                    bottom_group.selector_text()
                 ))
             } else {
                 Ok(())
@@ -280,7 +280,9 @@ mod tests {
     use crate::config::DirtyWorktreePolicy;
     use crate::execution::ExecutionMode;
     use crate::parsing::Group;
-    use crate::selectors::{AfterSelector, GroupRangeSelector, GroupSelector, StableHandle};
+    use crate::selectors::{
+        AfterSelector, ExplicitGroupSelector, GroupRangeSelector, GroupSelector,
+    };
     use crate::test_support::{commit_file, git, lock_cwd, log_subjects, write_file, DirGuard};
     use std::env;
     use std::fs;
@@ -314,7 +316,7 @@ mod tests {
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
             .map(|tag| Group {
-                tag: tag.to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
                 subjects: vec![format!("feat: {tag}")],
                 commits: vec![format!("{tag}1")],
                 first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -327,16 +329,12 @@ mod tests {
     fn move_range_and_after_resolve_from_stable_handles() {
         let groups = groups(&["alpha", "beta", "gamma"]);
         let range = GroupRangeSelector::Inclusive {
-            start: GroupSelector::Stable(StableHandle {
-                tag: "beta".to_string(),
-            }),
-            end: GroupSelector::Stable(StableHandle {
-                tag: "gamma".to_string(),
-            }),
+            start: GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("beta".to_string())),
+            end: GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("gamma".to_string())),
         };
-        let after = AfterSelector::Group(GroupSelector::Stable(StableHandle {
-            tag: "alpha".to_string(),
-        }));
+        let after = AfterSelector::Group(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+            "alpha".to_string(),
+        )));
 
         assert_eq!(
             resolve_move_targets(&groups, &range, &after).unwrap(),

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -247,7 +247,7 @@ pub fn prep_squash(
             let tip = group
                 .commits
                 .last()
-                .ok_or_else(|| anyhow!("Empty group {}", group.tag))?;
+                .ok_or_else(|| anyhow!("Empty group {}", group.selector_text()))?;
             args.push(format!("{}^{{tree}}", tip));
         }
         let ref_args: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -311,7 +311,7 @@ pub fn prep_squash(
                 parent_sha = new_commit.clone();
                 selected_groups.push(PreparedGroupData {
                     local_pr_number: start_idx + offset + 1,
-                    stable_handle: crate::commands::common::stable_handle_text(&group.tag),
+                    stable_handle: crate::commands::common::group_selector_text(group),
                     source_commit_count: group.commits.len(),
                     action,
                     target_sha: Some(new_commit),
@@ -319,7 +319,7 @@ pub fn prep_squash(
             } else {
                 selected_groups.push(PreparedGroupData {
                     local_pr_number: start_idx + offset + 1,
-                    stable_handle: crate::commands::common::stable_handle_text(&group.tag),
+                    stable_handle: crate::commands::common::group_selector_text(group),
                     source_commit_count: group.commits.len(),
                     action: PreparedGroupAction::SkippedEmpty,
                     target_sha: None,
@@ -453,8 +453,8 @@ pub fn prep_squash(
                     };
                     Some(PrepNextChildData {
                         local_pr_number: next_idx + 1,
-                        stable_handle: crate::commands::common::stable_handle_text(
-                            &groups[next_idx].tag,
+                        stable_handle: crate::commands::common::group_selector_text(
+                            &groups[next_idx],
                         ),
                         head_branch: next_branch,
                         remote_pr_number: Some(pr.number),
@@ -463,9 +463,7 @@ pub fn prep_squash(
                 }
                 None => Some(PrepNextChildData {
                     local_pr_number: next_idx + 1,
-                    stable_handle: crate::commands::common::stable_handle_text(
-                        &groups[next_idx].tag,
-                    ),
+                    stable_handle: crate::commands::common::group_selector_text(&groups[next_idx]),
                     head_branch: next_branch,
                     remote_pr_number: None,
                     action: PrepNextChildAction::MissingOpenPr,
@@ -512,13 +510,13 @@ mod tests {
     use crate::execution::ExecutionMode;
     use crate::maintenance_output::{PreparedGroupAction, ResolvedPrepSelection};
     use crate::parsing::Group;
-    use crate::selectors::{GroupSelector, InclusiveSelector, StableHandle};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector, InclusiveSelector};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
 
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
             .map(|tag| Group {
-                tag: tag.to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
                 subjects: vec![format!("feat: {tag}")],
                 commits: vec![format!("{tag}1")],
                 first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -530,10 +528,8 @@ mod tests {
     #[test]
     fn prep_until_stable_handle_resolves_inclusive_window() {
         let groups = groups(&["alpha", "beta", "gamma"]);
-        let selection = PrepSelection::Until(InclusiveSelector::Group(GroupSelector::Stable(
-            StableHandle {
-                tag: "beta".to_string(),
-            },
+        let selection = PrepSelection::Until(InclusiveSelector::Group(GroupSelector::Explicit(
+            ExplicitGroupSelector::PrLabel("beta".to_string()),
         )));
 
         assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (0, 2));
@@ -542,9 +538,9 @@ mod tests {
     #[test]
     fn prep_exact_stable_handle_resolves_single_group_window() {
         let groups = groups(&["alpha", "beta", "gamma"]);
-        let selection = PrepSelection::Exact(GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        }));
+        let selection = PrepSelection::Exact(GroupSelector::Explicit(
+            ExplicitGroupSelector::PrLabel("beta".to_string()),
+        ));
 
         assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (1, 2));
     }
@@ -552,9 +548,9 @@ mod tests {
     #[test]
     fn prep_from_stable_handle_resolves_suffix_window() {
         let groups = groups(&["alpha", "beta", "gamma"]);
-        let selection = PrepSelection::From(GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        }));
+        let selection = PrepSelection::From(GroupSelector::Explicit(
+            ExplicitGroupSelector::PrLabel("beta".to_string()),
+        ));
 
         assert_eq!(resolve_prep_window(&groups, &selection).unwrap(), (1, 3));
     }
@@ -616,7 +612,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("pr:alpha and pr:Alpha derive conflicting synthetic branch names"),
+                .contains("pr:alpha and pr:Alpha derive conflicting branch names"),
             "unexpected error: {err}"
         );
     }

--- a/src/commands/relink_prs.rs
+++ b/src/commands/relink_prs.rs
@@ -75,7 +75,7 @@ pub fn relink_prs(
         .map(
             |(group_idx, (head_branch, expected_base_ref))| RelinkExpectedBaseData {
                 local_pr_number: group_idx + 1,
-                stable_handle: common::stable_handle_text(&groups[group_idx].tag),
+                stable_handle: common::group_selector_text(&groups[group_idx]),
                 head_branch: head_branch.clone(),
                 expected_base_ref: expected_base_ref.clone(),
             },

--- a/src/commands/restack.rs
+++ b/src/commands/restack.rs
@@ -208,7 +208,7 @@ fn resolve_restack_after_count(groups: &[Group], after: &AfterSelector) -> Resul
 
 fn group_preview(group: &Group) -> RestackPreviewGroup {
     RestackPreviewGroup {
-        stable_handle: format!("pr:{}", group.tag),
+        stable_handle: group.selector_text(),
         commit_count: group.commits.len(),
         ignored_after_count: group.ignored_after.len(),
     }
@@ -725,7 +725,7 @@ mod tests {
     use crate::execution::ExecutionMode;
     use crate::parsing::Group;
     use crate::restack_output::RestackExecutorPlan;
-    use crate::selectors::{AfterSelector, GroupSelector, StableHandle};
+    use crate::selectors::{AfterSelector, ExplicitGroupSelector, GroupSelector};
     use crate::test_support::{commit_file, git, lock_cwd, write_file, DirGuard};
     use std::env;
     use std::fs;
@@ -743,7 +743,7 @@ mod tests {
     fn groups(tags: &[&str]) -> Vec<Group> {
         tags.iter()
             .map(|tag| Group {
-                tag: tag.to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
                 subjects: vec![format!("feat: {tag}")],
                 commits: vec![format!("{tag}1")],
                 first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -755,9 +755,9 @@ mod tests {
     #[test]
     fn restack_after_stable_handle_keeps_that_group_and_lower_groups() {
         let groups = groups(&["alpha", "beta", "gamma"]);
-        let after = AfterSelector::Group(GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        }));
+        let after = AfterSelector::Group(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+            "beta".to_string(),
+        )));
 
         assert_eq!(resolve_restack_after_count(&groups, &after).unwrap(), 2);
     }
@@ -766,14 +766,14 @@ mod tests {
     fn kept_ignored_segments_preserve_group_boundaries() {
         let groups = vec![
             Group {
-                tag: "alpha".to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel("alpha".to_string()),
                 subjects: vec!["feat: alpha".to_string()],
                 commits: vec!["a1".to_string()],
                 first_message: Some("feat: alpha pr:alpha".to_string()),
                 ignored_after: vec!["i1".to_string(), "i2".to_string()],
             },
             Group {
-                tag: "beta".to_string(),
+                marker: crate::group_markers::GroupMarker::PrLabel("beta".to_string()),
                 subjects: vec!["feat: beta".to_string()],
                 commits: vec!["b1".to_string()],
                 first_message: Some("feat: beta pr:beta".to_string()),
@@ -839,14 +839,14 @@ mod tests {
         assert_eq!(
             plan.dropped_groups
                 .iter()
-                .map(|group| group.tag.as_str())
+                .map(Group::bare_selector_text)
                 .collect::<Vec<_>>(),
             vec!["alpha", "beta"]
         );
         assert_eq!(
             plan.remaining_groups
                 .iter()
-                .map(|group| group.tag.as_str())
+                .map(Group::bare_selector_text)
                 .collect::<Vec<_>>(),
             vec!["gamma"]
         );
@@ -1051,9 +1051,9 @@ mod tests {
 
         let preview = preview_restack_after(
             &metadata_context(),
-            &AfterSelector::Group(GroupSelector::Stable(StableHandle {
-                tag: "alpha".to_string(),
-            })),
+            &AfterSelector::Group(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+                "alpha".to_string(),
+            ))),
             true,
         )
         .unwrap();

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -491,7 +491,7 @@ fn build_from_groups_internal(
             .commits
             .last()
             .cloned()
-            .ok_or_else(|| anyhow!("Group {} has no commits", group.tag))?;
+            .ok_or_else(|| anyhow!("Group {} has no commits", group.selector_text()))?;
         let kind = if remote_head.as_deref() == Some(target_sha.as_str()) {
             PushKind::Skip
         } else if let Some(ref remote_sha) = remote_head {
@@ -883,7 +883,7 @@ fn build_from_groups_internal(
         .enumerate()
         .map(
             |(group_idx, planned_push)| crate::local_pr_branches::LocalPrBranchTarget {
-                stable_handle: common::stable_handle_text(&groups[group_idx].tag),
+                stable_handle: common::group_selector_text(&groups[group_idx]),
                 branch_name: planned_push.branch.clone(),
                 tip: planned_push.target_sha.clone(),
             },
@@ -903,7 +903,7 @@ fn build_from_groups_internal(
         .map(
             |(group_idx, ((group, identity), planned_push))| UpdateGroupData {
                 local_pr_number: group_idx + 1,
-                stable_handle: common::stable_handle_text(&group.tag),
+                stable_handle: common::group_selector_text(group),
                 head_branch: identity.exact.clone(),
                 base_ref: desired_base_by_head
                     .get(&identity.exact)
@@ -1133,7 +1133,7 @@ mod tests {
 
     fn group(tag: &str) -> Group {
         Group {
-            tag: tag.to_string(),
+            marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
             subjects: vec![format!("feat: {tag}")],
             commits: vec![format!("{tag}1")],
             first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -1199,7 +1199,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("pr:alpha and pr:Alpha derive conflicting synthetic branch names"),
+                .contains("pr:alpha and pr:Alpha derive conflicting branch names"),
             "unexpected error: {err}"
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,19 +35,14 @@ pub enum LocalPrBranchSyncPolicy {
 /// Behavior when `spr restack` encounters a cherry-pick conflict.
 ///
 /// This is YAML-deserializable and avoids stringly-typed policy handling.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum RestackConflictPolicy {
     /// Abort and clean up temp restack state.
     Rollback,
     /// Suspend, leave the temp worktree in place, and resume with `spr resume`.
+    #[default]
     Halt,
-}
-
-impl Default for RestackConflictPolicy {
-    fn default() -> Self {
-        Self::Halt
-    }
 }
 
 /// Behavior when a branch-rewriting command sees local changes.
@@ -55,7 +50,7 @@ impl Default for RestackConflictPolicy {
 /// This applies to commands that rebuild the checked-out branch and then move
 /// it to a rewritten tip, such as `spr restack`, `spr move`, `spr fix-pr`, and
 /// `spr absorb`.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DirtyWorktreePolicy {
     /// Preserve the historical behavior: proceed and let the rewrite replace
@@ -65,13 +60,8 @@ pub enum DirtyWorktreePolicy {
     /// reapply them with `git stash apply --index`.
     Stash,
     /// Refuse to rewrite until the worktree is clean.
+    #[default]
     Halt,
-}
-
-impl Default for DirtyWorktreePolicy {
-    fn default() -> Self {
-        Self::Halt
-    }
 }
 
 /// Output ordering for list-style displays.

--- a/src/git.rs
+++ b/src/git.rs
@@ -194,6 +194,24 @@ pub fn normalize_branch_name(name: &str) -> String {
     out.to_string()
 }
 
+/// Validate one branch name using Git's own refname rules.
+pub fn validate_branch_name(branch_name: &str) -> Result<()> {
+    let out = Command::new("git")
+        .args(["check-ref-format", "--branch", branch_name])
+        .output()
+        .with_context(|| "failed to spawn git check-ref-format")?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        if stderr.is_empty() {
+            bail!("invalid branch name `{branch_name}`")
+        } else {
+            bail!("invalid branch name `{branch_name}`: {stderr}")
+        }
+    }
+}
+
 pub fn repo_root() -> Result<Option<String>> {
     match git_ro(["rev-parse", "--show-toplevel"].as_slice()) {
         Ok(path) => Ok(Some(path.trim().to_string())),

--- a/src/group_markers.rs
+++ b/src/group_markers.rs
@@ -1,0 +1,206 @@
+//! Shared parsing and rendering for PR-group seed markers.
+//!
+//! A seed commit identifies exactly one group either with `pr:<label>` or with
+//! `branch:<branch-name>`. `pr:` labels keep the historical compact grammar,
+//! while `branch:` names are validated through Git because real refname rules
+//! are wider than the label grammar.
+
+use anyhow::{bail, Result};
+use regex::{Captures, Regex};
+use std::sync::OnceLock;
+
+const CANDIDATE_MARKER_PATTERN: &str = r"(?i)(^|[^A-Za-z0-9_])(pr|branch):(\S*)";
+
+static CANDIDATE_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
+
+/// The exact one-of marker stored on a PR-group seed commit.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum GroupMarker {
+    PrLabel(String),
+    BranchName(String),
+}
+
+impl GroupMarker {
+    pub fn explicit_selector_text(&self) -> String {
+        match self {
+            Self::PrLabel(label) => format!("pr:{label}"),
+            Self::BranchName(branch_name) => format!("branch:{branch_name}"),
+        }
+    }
+
+    pub fn bare_selector_text(&self) -> &str {
+        match self {
+            Self::PrLabel(label) => label,
+            Self::BranchName(branch_name) => branch_name,
+        }
+    }
+
+    pub fn concrete_branch_name(&self, prefix: &str) -> String {
+        match self {
+            Self::PrLabel(label) => format!("{prefix}{label}"),
+            Self::BranchName(branch_name) => branch_name.clone(),
+        }
+    }
+
+    pub fn is_ignore_pr_label(&self, ignore_tag: &str) -> bool {
+        matches!(self, Self::PrLabel(label) if label == ignore_tag)
+    }
+}
+
+impl std::fmt::Display for GroupMarker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.explicit_selector_text())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CandidateGroupMarker {
+    pub kind: CandidateGroupMarkerKind,
+    pub payload: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateGroupMarkerKind {
+    Pr,
+    Branch,
+}
+
+impl CandidateGroupMarker {
+    pub fn display_text(&self) -> String {
+        match self.kind {
+            CandidateGroupMarkerKind::Pr => format!("pr:{}", self.payload),
+            CandidateGroupMarkerKind::Branch => format!("branch:{}", self.payload),
+        }
+    }
+
+    pub fn validate(self) -> Result<GroupMarker> {
+        match self.kind {
+            CandidateGroupMarkerKind::Pr => {
+                if let Err(err) = crate::pr_labels::validate_label(&self.payload) {
+                    bail!("invalid PR tag `pr:{}`: {err}", self.payload);
+                }
+                Ok(GroupMarker::PrLabel(self.payload))
+            }
+            CandidateGroupMarkerKind::Branch => {
+                crate::git::validate_branch_name(&self.payload)?;
+                Ok(GroupMarker::BranchName(self.payload))
+            }
+        }
+    }
+}
+
+fn candidate_marker_regex() -> &'static Regex {
+    CANDIDATE_MARKER_REGEX.get_or_init(|| {
+        Regex::new(CANDIDATE_MARKER_PATTERN).expect("candidate group marker regex should compile")
+    })
+}
+
+fn marker_kind(capture: &Captures<'_>) -> CandidateGroupMarkerKind {
+    let raw = capture
+        .get(2)
+        .expect("marker regex should capture marker kind")
+        .as_str();
+    if raw.eq_ignore_ascii_case("pr") {
+        CandidateGroupMarkerKind::Pr
+    } else {
+        CandidateGroupMarkerKind::Branch
+    }
+}
+
+fn marker_payload<'a>(capture: &'a Captures<'a>) -> &'a str {
+    capture
+        .get(3)
+        .expect("marker regex should capture marker payload")
+        .as_str()
+}
+
+/// Returns every `pr:` or `branch:` token candidate from `text`.
+pub fn candidate_group_markers(text: &str) -> Vec<CandidateGroupMarker> {
+    candidate_marker_regex()
+        .captures_iter(text)
+        .map(|capture| CandidateGroupMarker {
+            kind: marker_kind(&capture),
+            payload: marker_payload(&capture).to_string(),
+        })
+        .collect()
+}
+
+/// Returns the first valid group marker found in `text`, if any.
+pub fn first_valid_group_marker(text: &str) -> Option<GroupMarker> {
+    candidate_group_markers(text)
+        .into_iter()
+        .find_map(|candidate| candidate.validate().ok())
+}
+
+/// Removes valid group markers from `text` without partially stripping malformed tokens.
+pub fn strip_valid_group_markers(text: &str) -> String {
+    candidate_marker_regex()
+        .replace_all(text, |capture: &Captures<'_>| {
+            let candidate = CandidateGroupMarker {
+                kind: marker_kind(capture),
+                payload: marker_payload(capture).to_string(),
+            };
+            if candidate.validate().is_ok() {
+                let prefix = capture.get(1).map_or("", |value| value.as_str());
+                prefix.to_string()
+            } else {
+                capture
+                    .get(0)
+                    .expect("whole marker match should exist")
+                    .as_str()
+                    .to_string()
+            }
+        })
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        candidate_group_markers, first_valid_group_marker, strip_valid_group_markers,
+        CandidateGroupMarkerKind, GroupMarker,
+    };
+
+    #[test]
+    fn candidate_markers_capture_pr_and_branch_tokens() {
+        let markers = candidate_group_markers(
+            "feat: alpha pr:alpha\nfeat: login branch:feature/login branch:",
+        );
+
+        assert_eq!(markers.len(), 3);
+        assert_eq!(markers[0].kind, CandidateGroupMarkerKind::Pr);
+        assert_eq!(markers[0].payload, "alpha");
+        assert_eq!(markers[1].kind, CandidateGroupMarkerKind::Branch);
+        assert_eq!(markers[1].payload, "feature/login");
+        assert_eq!(markers[2].kind, CandidateGroupMarkerKind::Branch);
+        assert_eq!(markers[2].payload, "");
+    }
+
+    #[test]
+    fn first_valid_group_marker_accepts_real_branch_names() {
+        assert_eq!(
+            first_valid_group_marker("feat: login branch:feature/login"),
+            Some(GroupMarker::BranchName("feature/login".to_string()))
+        );
+    }
+
+    #[test]
+    fn strip_valid_group_markers_removes_both_valid_forms() {
+        assert_eq!(
+            strip_valid_group_markers("feat: login branch:feature/login"),
+            "feat: login "
+        );
+        assert_eq!(
+            strip_valid_group_markers("feat: alpha pr:alpha"),
+            "feat: alpha "
+        );
+    }
+
+    #[test]
+    fn strip_valid_group_markers_preserves_invalid_branch_tokens() {
+        assert_eq!(
+            strip_valid_group_markers("feat: bad branch:bad..name"),
+            "feat: bad branch:bad..name"
+        );
+    }
+}

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -179,18 +179,18 @@ impl ErrorOutput {
 
     pub fn synthetic_branch_name_collision(
         command: JsonCommand,
-        collision: &crate::branch_names::SyntheticBranchNameCollision,
+        collision: &crate::branch_names::GroupBranchNameCollision,
     ) -> Self {
         Self::new(
             command,
             JsonError::SyntheticBranchNameCollision {
                 conflicting_groups: vec![
                     CollisionGroup {
-                        stable_handle: collision.first.stable_handle.clone(),
+                        stable_handle: collision.first.selector.clone(),
                         head_branch: collision.first.head_branch.clone(),
                     },
                     CollisionGroup {
-                        stable_handle: collision.second.stable_handle.clone(),
+                        stable_handle: collision.second.selector.clone(),
                         head_branch: collision.second.head_branch.clone(),
                     },
                 ],

--- a/src/local_pr_branches.rs
+++ b/src/local_pr_branches.rs
@@ -1,15 +1,15 @@
 //! Optional synchronization for local per-PR branches.
 //!
-//! The synthetic branch name for a PR group is `prefix + tag`. Remote updates
-//! already use those names, and this module optionally keeps matching local
-//! branches pointed at the same group tips.
+//! Each group's canonical branch name is resolved from its seed marker. Remote
+//! updates already use those names, and this module optionally keeps matching
+//! local branches pointed at the same group tips.
 
 use anyhow::{Context, Result};
 use serde::Serialize;
 use std::collections::HashSet;
 use tracing::info;
 
-use crate::branch_names::synthetic_branch_name;
+use crate::branch_names::group_branch_name;
 use crate::config::LocalPrBranchSyncPolicy;
 use crate::execution::ExecutionMode;
 use crate::git::{git_is_ancestor, git_local_branch_tip, git_ro, git_rw};
@@ -53,14 +53,13 @@ pub fn targets_from_groups(prefix: &str, groups: &[Group]) -> Result<Vec<LocalPr
     groups
         .iter()
         .map(|group| {
-            let tip = group
-                .commits
-                .last()
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Group {} has no commits", group.tag))?;
+            let tip =
+                group.commits.last().cloned().ok_or_else(|| {
+                    anyhow::anyhow!("Group {} has no commits", group.selector_text())
+                })?;
             Ok(LocalPrBranchTarget {
-                stable_handle: crate::commands::common::stable_handle_text(&group.tag),
-                branch_name: synthetic_branch_name(prefix, &group.tag),
+                stable_handle: crate::commands::common::group_selector_text(group),
+                branch_name: group_branch_name(prefix, group),
                 tip,
             })
         })
@@ -310,11 +309,13 @@ fn short_sha(sha: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::{
-        plan_local_pr_branch_drift, sync_local_pr_branches, LocalPrBranchActionKind,
-        LocalPrBranchTarget,
+        plan_local_pr_branch_drift, sync_local_pr_branches, targets_from_groups,
+        LocalPrBranchActionKind, LocalPrBranchTarget,
     };
     use crate::config::LocalPrBranchSyncPolicy;
     use crate::execution::ExecutionMode;
+    use crate::group_markers::GroupMarker;
+    use crate::parsing::Group;
     use crate::test_support::{commit_file, git, init_repo, lock_cwd, DirGuard};
     use std::path::Path;
 
@@ -348,6 +349,33 @@ mod tests {
             branch_name: branch_name.to_string(),
             tip: tip.to_string(),
         }
+    }
+
+    #[test]
+    fn targets_from_groups_manage_resolved_branch_names_for_both_marker_kinds() {
+        let groups = vec![
+            Group {
+                marker: GroupMarker::BranchName("feature/login".to_string()),
+                subjects: Vec::new(),
+                commits: vec!["a1".to_string()],
+                first_message: None,
+                ignored_after: Vec::new(),
+            },
+            Group {
+                marker: GroupMarker::PrLabel("beta".to_string()),
+                subjects: Vec::new(),
+                commits: vec!["b1".to_string()],
+                first_message: None,
+                ignored_after: Vec::new(),
+            },
+        ];
+
+        let targets = targets_from_groups("dank-spr/", &groups).unwrap();
+
+        assert_eq!(targets[0].stable_handle, "branch:feature/login");
+        assert_eq!(targets[0].branch_name, "feature/login");
+        assert_eq!(targets[1].stable_handle, "pr:beta");
+        assert_eq!(targets[1].branch_name, "dank-spr/beta");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod execution;
 mod format;
 mod git;
 mod github;
+mod group_markers;
 mod json_output;
 mod limit;
 mod local_pr_branches;
@@ -1145,7 +1146,7 @@ mod tests {
     };
     use crate::parsing::{derive_local_groups_with_ignored, Group};
     use crate::read_only_output::ReadOnlyPayload;
-    use crate::selectors::{GroupSelector, StableHandle};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector};
     use crate::test_support::{
         commit_file, git, init_case_conflicting_stack_repo, init_repo as init_stack_repo, lock_cwd,
         write_file, DirGuard,
@@ -1218,7 +1219,7 @@ mod tests {
 
     fn group(tag: &str) -> Group {
         Group {
-            tag: tag.to_string(),
+            marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
             subjects: vec![format!("feat: {tag}")],
             commits: vec![format!("{tag}1")],
             first_message: Some(format!("feat: {tag} pr:{tag}")),
@@ -1231,9 +1232,9 @@ mod tests {
         let groups = vec![group("alpha")];
         let result = resolve_update_pr_limit(
             &groups,
-            Some(GroupSelector::Stable(StableHandle {
-                tag: "alpha".to_string(),
-            })),
+            Some(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+                "alpha".to_string(),
+            ))),
             Some(1),
             None,
         );
@@ -1253,9 +1254,9 @@ mod tests {
         let groups = vec![group("alpha")];
         let result = resolve_update_pr_limit(
             &groups,
-            Some(GroupSelector::Stable(StableHandle {
-                tag: "beta".to_string(),
-            })),
+            Some(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+                "beta".to_string(),
+            ))),
             None,
             None,
         );
@@ -1266,7 +1267,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("No outstanding PR group matches stable handle `pr:beta`"),
+                .contains("No outstanding PR group matches selector `pr:beta`"),
             "unexpected error: {err}"
         );
     }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,68 +1,85 @@
-//! Parse `pr:<tag>` commit markers into PR groups and attach ignore blocks.
+//! Parse group markers into PR groups and attach ignore blocks.
 //!
 //! The parser treats `pr:ignore` (or a configured ignore tag) as a local-only block:
 //! ignored commits are preserved in local history, but they are not part of any PR
 //! grouping and are attached to the preceding group for rewrite operations.
 
 use crate::git::git_ro;
+use crate::group_markers::{candidate_group_markers, first_valid_group_marker, GroupMarker};
 use anyhow::{bail, Result};
 use std::collections::HashSet;
 use tracing::warn;
 
-/// A PR group derived from `pr:<tag>` markers in commit messages.
+/// A PR group derived from seed markers in commit messages.
 ///
 /// Groups are ordered oldest→newest, and each group owns the commits that will
 /// become its branch tip. Ignore blocks are preserved and attached to the group
 /// they follow so rewrite operations can keep local-only work.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Group {
-    /// The tag value from `pr:<tag>`.
-    pub tag: String,
+    /// The exact one-of marker from the group's seed commit.
+    pub marker: GroupMarker,
     /// Subjects for commits in this group, oldest→newest.
     pub subjects: Vec<String>,
     /// Commit SHAs for the group, oldest→newest.
     pub commits: Vec<String>, // SHAs oldest→newest
     /// Full commit message for the first commit in the group.
     pub first_message: Option<String>,
-    /// Commits that follow this group in an ignore block (pr:ignore_tag .. next pr:<tag>).
+    /// Commits that follow this group in an ignore block (pr:ignore_tag .. next group marker).
     pub ignored_after: Vec<String>,
 }
 
 impl Group {
+    pub fn selector_text(&self) -> String {
+        self.marker.explicit_selector_text()
+    }
+
+    pub fn bare_selector_text(&self) -> &str {
+        self.marker.bare_selector_text()
+    }
+
+    pub fn concrete_branch_name(&self, prefix: &str) -> String {
+        self.marker.concrete_branch_name(prefix)
+    }
+
     pub fn pr_title(&self) -> Result<String> {
         if let Some(s) = self.subjects.first() {
-            let t = crate::pr_labels::strip_valid_markers(s).trim().to_string();
+            let t = crate::group_markers::strip_valid_group_markers(s)
+                .trim()
+                .to_string();
             if !t.is_empty() {
                 return Ok(t);
             }
         }
-        Ok(self.tag.clone())
+        Ok(self.bare_selector_text().to_string())
     }
     pub fn squash_commit_message(&self) -> Result<String> {
         if let Some(full) = &self.first_message {
-            // Validate the first commit contains the expected pr:<tag> marker
-            if let Some(found) = crate::pr_labels::first_valid_marker_label(full) {
-                if !found.eq_ignore_ascii_case(&self.tag) {
+            if let Some(found) = first_valid_group_marker(full) {
+                if found != self.marker {
                     bail!(
-                        "First commit tag mismatch for group `{}`: expected `pr:{}`, found `pr:{}`",
-                        self.tag,
-                        self.tag,
+                        "First commit marker mismatch for group `{}`: expected `{}`, found `{}`",
+                        self.selector_text(),
+                        self.selector_text(),
                         found
                     );
                 }
             } else {
                 bail!(
-                    "First commit is missing required `pr:{}` tag for group `{}`.",
-                    self.tag,
-                    self.tag
+                    "First commit is missing required `{}` marker for group `{}`.",
+                    self.selector_text(),
+                    self.selector_text()
                 );
             }
             return Ok(full.trim_end().to_string());
         }
-        bail!("First commit message missing for group `{}`", self.tag)
+        bail!(
+            "First commit message missing for group `{}`",
+            self.selector_text()
+        )
     }
     pub fn pr_body(&self) -> Result<String> {
-        // Use only the body (drop the subject/title line); remove pr:<tag> markers
+        // Use only the body (drop the subject/title line); remove group markers.
         let base_body = if let Some(full) = &self.first_message {
             let mut it = full.lines();
             let _ = it.next();
@@ -70,7 +87,7 @@ impl Group {
         } else {
             String::new()
         };
-        let cleaned = crate::pr_labels::strip_valid_markers(&base_body)
+        let cleaned = crate::group_markers::strip_valid_group_markers(&base_body)
             .trim()
             .to_string();
         let sep = if cleaned.is_empty() { "" } else { "\n\n" };
@@ -80,7 +97,7 @@ impl Group {
         ))
     }
 
-    /// Body derived from the first commit message (without the title line) and with pr:<tag> markers removed.
+    /// Body derived from the first commit message (without the title line) and with group markers removed.
     /// Does not include any stack markers. Trimmed.
     pub fn pr_body_base(&self) -> Result<String> {
         let base_body = if let Some(full) = &self.first_message {
@@ -90,35 +107,36 @@ impl Group {
         } else {
             String::new()
         };
-        Ok(crate::pr_labels::strip_valid_markers(&base_body)
+        Ok(crate::group_markers::strip_valid_group_markers(&base_body)
             .trim()
             .to_string())
     }
 }
 
 #[derive(Debug)]
-struct DuplicateGroupTagError {
-    tag: String,
+struct DuplicateGroupMarkerError {
+    marker: String,
 }
 
-impl std::fmt::Display for DuplicateGroupTagError {
+impl std::fmt::Display for DuplicateGroupMarkerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Duplicate outstanding PR group tag `pr:{}`. `pr:<label>` starts a PR group, must remain unique within the outstanding stack, and is now used as a stable handle.",
-            self.tag
+            "Duplicate outstanding PR group marker `{}`. Each live group marker must remain unique within the outstanding stack.",
+            self.marker
         )
     }
 }
 
-impl std::error::Error for DuplicateGroupTagError {}
+impl std::error::Error for DuplicateGroupMarkerError {}
 
-fn ensure_unique_group_tags(groups: &[Group]) -> Result<()> {
-    let mut seen: HashSet<&str> = HashSet::new();
+fn ensure_unique_group_markers(groups: &[Group]) -> Result<()> {
+    let mut seen: HashSet<String> = HashSet::new();
     for group in groups {
-        if !seen.insert(group.tag.as_str()) {
-            return Err(DuplicateGroupTagError {
-                tag: group.tag.clone(),
+        let selector_text = group.selector_text();
+        if !seen.insert(selector_text.clone()) {
+            return Err(DuplicateGroupMarkerError {
+                marker: selector_text,
             }
             .into());
         }
@@ -129,16 +147,16 @@ fn ensure_unique_group_tags(groups: &[Group]) -> Result<()> {
 /// Parse a reversed git log stream into PR groups, honoring an ignore tag.
 ///
 /// The input must be the raw output of `git log --format=%H%x00%B%x1e --reverse <range>`.
-/// Commits with a single `pr:<tag>` marker start a new group, and untagged commits
+/// Commits with a single group marker start a new group, and untagged commits
 /// are appended to the current group once one exists.
 ///
 /// If a commit's tag matches `ignore_tag` (case-sensitive), the current group is
 /// finalized and the parser enters ignore mode; commits are skipped until the next
-/// non-ignore `pr:<tag>` marker is seen.
+/// non-ignore group marker is seen.
 ///
 /// # Errors
 ///
-/// Returns an error if any commit message contains more than one `pr:<tag>` marker.
+/// Returns an error if any commit message contains more than one group marker.
 pub fn parse_groups(raw: &str, ignore_tag: &str) -> Result<Vec<Group>> {
     let (_leading_ignored, groups) = parse_groups_with_ignored(raw, ignore_tag)?;
     Ok(groups)
@@ -152,7 +170,7 @@ pub fn parse_groups(raw: &str, ignore_tag: &str) -> Result<Vec<Group>> {
 ///
 /// # Errors
 ///
-/// Returns an error if any commit message contains more than one `pr:<tag>` marker.
+/// Returns an error if any commit message contains more than one group marker.
 pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<String>, Vec<Group>)> {
     let mut groups: Vec<Group> = vec![];
     let mut current: Option<Group> = None;
@@ -190,16 +208,19 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
         let message = parts.next().unwrap_or_default().to_string();
         let subj = message.lines().next().unwrap_or_default().to_string();
 
-        let tags = crate::pr_labels::candidate_marker_labels(&message);
-        if tags.len() > 1 {
-            bail!("Multiple pr:<tag> markers found in commit {sha}");
+        let markers = candidate_group_markers(&message);
+        if markers.len() > 1 {
+            bail!("Multiple group markers found in commit {sha}");
         }
 
-        if let Some(tag) = tags.first() {
-            if let Err(err) = crate::pr_labels::validate_label(tag) {
-                bail!("Commit {sha} has invalid PR tag `pr:{tag}`: {err}");
-            }
-            if tag == ignore_tag {
+        if let Some(candidate_marker) = markers.into_iter().next() {
+            let marker = candidate_marker.clone().validate().map_err(|err| {
+                anyhow::anyhow!(
+                    "Commit {sha} has invalid group marker `{}`: {err:#}",
+                    candidate_marker.display_text()
+                )
+            })?;
+            if marker.is_ignore_pr_label(ignore_tag) {
                 flush_current(&mut current, &mut groups);
                 ignoring = true;
                 ignored_block.push(sha);
@@ -211,7 +232,7 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
             }
             flush_current(&mut current, &mut groups);
             current = Some(Group {
-                tag: tag.clone(),
+                marker,
                 subjects: vec![subj.clone()],
                 commits: vec![sha],
                 first_message: Some(message.clone()),
@@ -223,20 +244,20 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
             g.subjects.push(subj);
             g.commits.push(sha);
         } else {
-            warn!("Untagged commit before first pr:<tag>; ignored");
+            warn!("Untagged commit before first group marker; ignored");
         }
     }
     flush_current(&mut current, &mut groups);
     if ignoring {
         flush_ignored(&mut ignored_block, &mut groups, &mut leading_ignored);
     }
-    ensure_unique_group_tags(&groups)?;
+    ensure_unique_group_markers(&groups)?;
     Ok((leading_ignored, groups))
 }
 
 /// Split parsed groups into the publishable update prefix and the local-only suffix.
 ///
-/// Once an ignored block appears, later `pr:<tag>` groups stay local-only because
+/// Once an ignored block appears, later groups stay local-only because
 /// publishing them would include the ignored commits in GitHub diffs. The returned
 /// handle list is already formatted for user-facing warnings.
 pub fn split_groups_for_update(
@@ -257,7 +278,7 @@ pub fn split_groups_for_update(
     let skipped_handles: Vec<String> = groups
         .iter()
         .skip(first_local_only_group_idx)
-        .map(|group| format!("pr:{}", group.tag))
+        .map(Group::selector_text)
         .collect();
     let pushable_groups: Vec<Group> = groups
         .into_iter()
@@ -299,7 +320,7 @@ pub fn derive_local_groups(base: &str, ignore_tag: &str) -> Result<(String, Vec<
 /// Derive PR groups and leading ignored commits from `merge-base(base, to)..to`.
 ///
 /// Leading ignored commits come from an ignore block that appears before the first
-/// `pr:<tag>` marker and are preserved ahead of the stack during rewrite operations.
+/// group marker and are preserved ahead of the stack during rewrite operations.
 ///
 /// # Errors
 ///
@@ -365,12 +386,35 @@ mod tests {
         ]);
         let groups = parse_groups(&raw, "skip").expect("parse_groups ok");
         assert_eq!(groups.len(), 3);
-        assert_eq!(groups[0].tag, "alpha");
+        assert_eq!(groups[0].bare_selector_text(), "alpha");
         assert_eq!(groups[0].commits, vec!["a1", "a2"]);
-        assert_eq!(groups[1].tag, "ignore");
+        assert_eq!(groups[1].bare_selector_text(), "ignore");
         assert_eq!(groups[1].commits, vec!["i1", "i2"]);
-        assert_eq!(groups[2].tag, "beta");
+        assert_eq!(groups[2].bare_selector_text(), "beta");
         assert_eq!(groups[2].commits, vec!["b1"]);
+    }
+
+    #[test]
+    fn parse_groups_accepts_mixed_pr_and_branch_markers() {
+        let raw = make_log(&[
+            ("a1", "feat: login start branch:feature/login"),
+            ("b1", "feat: beta start pr:beta"),
+            ("c1", "feat: docs start branch:release/docs"),
+        ]);
+
+        let groups = parse_groups(&raw, "ignore").expect("parse_groups ok");
+
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| group.selector_text())
+                .collect::<Vec<_>>(),
+            vec![
+                "branch:feature/login".to_string(),
+                "pr:beta".to_string(),
+                "branch:release/docs".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -387,19 +431,19 @@ mod tests {
             parse_groups_with_ignored(&raw, "ignore").expect("parse_groups_with_ignored ok");
         assert!(leading.is_empty());
         assert_eq!(groups.len(), 2);
-        assert_eq!(groups[0].tag, "alpha");
+        assert_eq!(groups[0].bare_selector_text(), "alpha");
         assert_eq!(groups[0].commits, vec!["a1", "a2"]);
         assert_eq!(groups[0].ignored_after, vec!["i1", "i2"]);
-        assert_eq!(groups[1].tag, "beta");
+        assert_eq!(groups[1].bare_selector_text(), "beta");
         assert_eq!(groups[1].commits, vec!["b1", "b2"]);
         assert!(groups[1].ignored_after.is_empty());
 
         // Superset check: the wrapper should drop ignored commits but preserve grouping.
         let groups_via_wrapper = parse_groups(&raw, "ignore").expect("parse_groups ok");
         assert_eq!(groups_via_wrapper.len(), 2);
-        assert_eq!(groups_via_wrapper[0].tag, "alpha");
+        assert_eq!(groups_via_wrapper[0].bare_selector_text(), "alpha");
         assert_eq!(groups_via_wrapper[0].commits, vec!["a1", "a2"]);
-        assert_eq!(groups_via_wrapper[1].tag, "beta");
+        assert_eq!(groups_via_wrapper[1].bare_selector_text(), "beta");
         assert_eq!(groups_via_wrapper[1].commits, vec!["b1", "b2"]);
     }
 
@@ -414,7 +458,7 @@ mod tests {
             parse_groups_with_ignored(&raw, "ignore").expect("parse_groups_with_ignored ok");
         assert_eq!(leading, vec!["i1", "i2"]);
         assert_eq!(groups.len(), 1);
-        assert_eq!(groups[0].tag, "alpha");
+        assert_eq!(groups[0].bare_selector_text(), "alpha");
         assert!(groups[0].ignored_after.is_empty());
     }
 
@@ -434,7 +478,7 @@ mod tests {
         assert_eq!(
             pushable
                 .iter()
-                .map(|group| group.tag.as_str())
+                .map(|group| group.bare_selector_text())
                 .collect::<Vec<_>>(),
             vec!["alpha", "beta"]
         );
@@ -460,7 +504,7 @@ mod tests {
         assert_eq!(
             pushable
                 .iter()
-                .map(|group| group.tag.as_str())
+                .map(|group| group.bare_selector_text())
                 .collect::<Vec<_>>(),
             vec!["alpha"]
         );
@@ -493,9 +537,9 @@ mod tests {
         ]);
         let groups = parse_groups(&raw, "ignore").expect("parse_groups ok");
         assert_eq!(groups.len(), 3);
-        assert_eq!(groups[0].tag, "alpha");
-        assert_eq!(groups[1].tag, "IGNORE");
-        assert_eq!(groups[2].tag, "beta");
+        assert_eq!(groups[0].bare_selector_text(), "alpha");
+        assert_eq!(groups[1].bare_selector_text(), "IGNORE");
+        assert_eq!(groups[2].bare_selector_text(), "beta");
     }
 
     #[test]
@@ -509,8 +553,21 @@ mod tests {
         let err = parse_groups(&raw, "ignore").unwrap_err();
         let message = format!("{err:#}");
         assert!(
-            message.contains("Duplicate outstanding PR group tag `pr:alpha`"),
+            message.contains("Duplicate outstanding PR group marker `pr:alpha`"),
             "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_groups_rejects_multiple_marker_kinds_on_one_seed() {
+        let raw = make_log(&[("a1", "feat: invalid pr:alpha branch:feature/login")]);
+
+        let err = parse_groups(&raw, "ignore").unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Multiple group markers found in commit a1"),
+            "unexpected error: {err:#}"
         );
     }
 
@@ -521,7 +578,7 @@ mod tests {
         let err = parse_groups(&raw, "ignore").unwrap_err();
         let message = format!("{err:#}");
         assert!(
-            message.contains("Commit a1 has invalid PR tag `pr:1alpha`"),
+            message.contains("Commit a1 has invalid group marker `pr:1alpha`"),
             "unexpected error: {message}"
         );
         assert!(
@@ -539,13 +596,13 @@ mod tests {
 
         let groups = parse_groups(&raw, "ignore").unwrap();
         assert_eq!(groups.len(), 2);
-        assert_eq!(groups[0].tag, "alpha-");
+        assert_eq!(groups[0].bare_selector_text(), "alpha-");
         assert_eq!(groups[0].pr_title().unwrap(), "feat: alpha start");
         assert_eq!(
             groups[0].squash_commit_message().unwrap(),
             "feat: alpha start pr:alpha-"
         );
-        assert_eq!(groups[1].tag, "beta.");
+        assert_eq!(groups[1].bare_selector_text(), "beta.");
         assert_eq!(groups[1].pr_title().unwrap(), "feat: beta start");
     }
 
@@ -556,7 +613,7 @@ mod tests {
         let err = parse_groups(&raw, "ignore").unwrap_err();
         let message = format!("{err:#}");
         assert!(
-            message.contains("Commit a1 has invalid PR tag `pr:alpha!oops`"),
+            message.contains("Commit a1 has invalid group marker `pr:alpha!oops`"),
             "unexpected error: {message}"
         );
         assert!(
@@ -574,7 +631,7 @@ mod tests {
         let err = parse_groups(&raw, "ignore").unwrap_err();
         let message = format!("{err:#}");
         assert!(
-            message.contains("Commit a1 has invalid PR tag `pr:`"),
+            message.contains("Commit a1 has invalid group marker `pr:`"),
             "unexpected error: {message}"
         );
         assert!(

--- a/src/pr_labels.rs
+++ b/src/pr_labels.rs
@@ -4,15 +4,6 @@
 //! stable selector inputs. They must start with an ASCII letter and may then
 //! use ASCII letters, digits, `.`, `_`, or `-`.
 
-use regex::{Captures, Regex};
-use std::sync::OnceLock;
-
-const VALID_MARKER_PATTERN: &str = r"(?i)(^|[^A-Za-z0-9_])pr:([A-Za-z][A-Za-z0-9._\-]*)($|\s)";
-const CANDIDATE_MARKER_PATTERN: &str = r"(?i)(^|[^A-Za-z0-9_])pr:(\S*)";
-
-static VALID_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
-static CANDIDATE_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
-
 /// A validation failure for a PR-group label.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LabelValidationError {
@@ -34,58 +25,6 @@ impl std::fmt::Display for LabelValidationError {
 
 impl std::error::Error for LabelValidationError {}
 
-/// Returns the regex for valid `pr:<label>` markers in commit messages.
-fn valid_marker_regex() -> &'static Regex {
-    VALID_MARKER_REGEX.get_or_init(|| {
-        Regex::new(VALID_MARKER_PATTERN).expect("valid PR label regex should compile")
-    })
-}
-
-/// Returns the regex used to find candidate `pr:<tag>` markers before validation.
-fn candidate_marker_regex() -> &'static Regex {
-    CANDIDATE_MARKER_REGEX.get_or_init(|| {
-        Regex::new(CANDIDATE_MARKER_PATTERN).expect("candidate PR label regex should compile")
-    })
-}
-
-fn marker_label<'a>(capture: &'a Captures<'a>) -> &'a str {
-    capture
-        .get(2)
-        .expect("marker regex should capture the label token")
-        .as_str()
-}
-
-/// Returns every `pr:<token>` candidate from `text` using the shared marker tokenizer.
-pub fn candidate_marker_labels(text: &str) -> Vec<String> {
-    candidate_marker_regex()
-        .captures_iter(text)
-        .map(|capture| marker_label(&capture).to_string())
-        .collect()
-}
-
-/// Returns the first valid label found in `text`, if any.
-pub fn first_valid_marker_label(text: &str) -> Option<String> {
-    valid_marker_regex()
-        .captures(text)
-        .map(|capture| marker_label(&capture).to_string())
-}
-
-/// Reports whether `text` contains any `pr:<token>` candidate.
-pub fn contains_candidate_marker(text: &str) -> bool {
-    candidate_marker_regex().is_match(text)
-}
-
-/// Removes valid `pr:<label>` markers from `text` without partially stripping malformed tokens.
-pub fn strip_valid_markers(text: &str) -> String {
-    valid_marker_regex()
-        .replace_all(text, |capture: &Captures<'_>| {
-            let prefix = capture.get(1).map_or("", |value| value.as_str());
-            let suffix = capture.get(3).map_or("", |value| value.as_str());
-            format!("{prefix}{suffix}")
-        })
-        .to_string()
-}
-
 /// Validates one PR-group label against the shared commit-marker and selector grammar.
 pub fn validate_label(label: &str) -> std::result::Result<(), LabelValidationError> {
     let mut chars = label.chars();
@@ -104,43 +43,7 @@ pub fn validate_label(label: &str) -> std::result::Result<(), LabelValidationErr
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        candidate_marker_labels, first_valid_marker_label, strip_valid_markers, validate_label,
-        LabelValidationError,
-    };
-
-    #[test]
-    fn candidate_markers_capture_full_tokens_until_whitespace() {
-        assert_eq!(
-            candidate_marker_labels("feat: alpha pr:alpha!oops more\npr:beta-\npr:"),
-            vec![
-                "alpha!oops".to_string(),
-                "beta-".to_string(),
-                "".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn first_valid_marker_label_accepts_trailing_dash_and_dot() {
-        assert_eq!(
-            first_valid_marker_label("feat: alpha pr:alpha-"),
-            Some("alpha-".to_string())
-        );
-        assert_eq!(
-            first_valid_marker_label("feat: beta pr:beta."),
-            Some("beta.".to_string())
-        );
-    }
-
-    #[test]
-    fn strip_valid_markers_does_not_partially_strip_invalid_tokens() {
-        assert_eq!(strip_valid_markers("feat: alpha pr:alpha-"), "feat: alpha ");
-        assert_eq!(
-            strip_valid_markers("feat: alpha pr:alpha!oops"),
-            "feat: alpha pr:alpha!oops"
-        );
-    }
+    use super::{validate_label, LabelValidationError};
 
     #[test]
     fn validate_label_rejects_empty_string() {

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -1,28 +1,39 @@
 //! Typed parsing and resolution for PR-group selectors.
 //!
-//! These types separate user-facing selector syntax from the current local PR
-//! numbering. Command entrypoints parse into these enums once, then resolve
-//! them against the current `Vec<Group>` to recover the numeric boundary or
-//! local ordinal that existing command logic already understands. Stable-label
-//! selectors accept either bare labels or the explicit `pr:<label>` form, while
-//! digits-only inputs remain local PR ordinals.
+//! Explicit selectors use either `pr:<label>` or `branch:<branch-name>`.
+//! Bare selectors are convenience syntax only: they resolve when exactly one
+//! current-stack group has the matching bare marker payload.
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
 
+use crate::group_markers::GroupMarker;
 use crate::parsing::Group;
 
-/// An immutable `pr:<label>` handle that refers to one outstanding PR group.
+/// An explicit selector that refers to one outstanding PR group.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StableHandle {
-    pub tag: String,
+pub enum ExplicitGroupSelector {
+    PrLabel(String),
+    BranchName(String),
 }
 
-impl Display for StableHandle {
+impl ExplicitGroupSelector {
+    fn marker(&self) -> GroupMarker {
+        match self {
+            Self::PrLabel(label) => GroupMarker::PrLabel(label.clone()),
+            Self::BranchName(branch_name) => GroupMarker::BranchName(branch_name.clone()),
+        }
+    }
+}
+
+impl Display for ExplicitGroupSelector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "pr:{}", self.tag)
+        match self {
+            Self::PrLabel(label) => write!(f, "pr:{label}"),
+            Self::BranchName(branch_name) => write!(f, "branch:{branch_name}"),
+        }
     }
 }
 
@@ -30,14 +41,16 @@ impl Display for StableHandle {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupSelector {
     LocalPr(usize),
-    Stable(StableHandle),
+    Explicit(ExplicitGroupSelector),
+    Bare(String),
 }
 
 impl Display for GroupSelector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::LocalPr(n) => write!(f, "LPR #{}", n),
-            Self::Stable(handle) => write!(f, "{handle}"),
+            Self::LocalPr(n) => write!(f, "LPR #{n}"),
+            Self::Explicit(selector) => write!(f, "{selector}"),
+            Self::Bare(value) => write!(f, "{value}"),
         }
     }
 }
@@ -77,11 +90,12 @@ pub enum GroupRangeSelector {
     },
 }
 
-fn has_pr_prefix(input: &str) -> bool {
-    if let Some(prefix) = input.get(..3) {
-        prefix.eq_ignore_ascii_case("pr:")
+fn strip_ascii_prefix<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
+    let head = input.get(..prefix.len())?;
+    if head.eq_ignore_ascii_case(prefix) {
+        input.get(prefix.len()..)
     } else {
-        false
+        None
     }
 }
 
@@ -89,38 +103,39 @@ fn is_digits_only(input: &str) -> bool {
     !input.is_empty() && input.chars().all(|ch| ch.is_ascii_digit())
 }
 
-fn parse_handle(input: &str) -> std::result::Result<StableHandle, String> {
-    let trimmed = input.trim();
-    let tag = if has_pr_prefix(trimmed) {
-        if let Some(tag) = trimmed.get(3..) {
-            if tag.is_empty() {
-                return Err(format!(
-                    "stable selector `{trimmed}` is missing the label after `pr:`"
-                ));
-            } else {
-                tag
-            }
-        } else {
-            return Err(format!(
-                "stable selector `{trimmed}` is missing the label after `pr:`"
-            ));
-        }
-    } else {
-        trimmed
-    };
-
-    if let Err(err) = crate::pr_labels::validate_label(tag) {
+fn parse_pr_label(input: &str, whole: &str) -> std::result::Result<String, String> {
+    if input.is_empty() {
+        Err(format!(
+            "explicit selector `{whole}` is missing the label after `pr:`"
+        ))
+    } else if let Err(err) = crate::pr_labels::validate_label(input) {
         match err {
             crate::pr_labels::LabelValidationError::MustStartWithLetter => Err(format!(
-                "stable selector `{trimmed}` must start with an ASCII letter"
+                "explicit selector `{whole}` must start with an ASCII letter after `pr:`"
             )),
             crate::pr_labels::LabelValidationError::InvalidCharacters => Err(format!(
-                "stable selector `{trimmed}` must use only ASCII letters, digits, `.`, `_`, or `-` after the first letter"
+                "explicit selector `{whole}` must use only ASCII letters, digits, `.`, `_`, or `-` after the first letter"
             )),
         }
     } else {
-        Ok(StableHandle {
-            tag: tag.to_string(),
+        Ok(input.to_string())
+    }
+}
+
+fn parse_branch_name(input: &str, whole: &str) -> std::result::Result<String, String> {
+    crate::git::validate_branch_name(input)
+        .map(|()| input.to_string())
+        .map_err(|err| format!("explicit selector `{whole}` has invalid branch name: {err:#}"))
+}
+
+fn parse_explicit_selector(
+    input: &str,
+) -> Option<std::result::Result<ExplicitGroupSelector, String>> {
+    if let Some(label) = strip_ascii_prefix(input, "pr:") {
+        Some(parse_pr_label(label, input).map(ExplicitGroupSelector::PrLabel))
+    } else {
+        strip_ascii_prefix(input, "branch:").map(|branch_name| {
+            parse_branch_name(branch_name, input).map(ExplicitGroupSelector::BranchName)
         })
     }
 }
@@ -144,8 +159,10 @@ impl FromStr for GroupSelector {
         let trimmed = input.trim();
         if is_digits_only(trimmed) {
             parse_local_pr(trimmed).map(Self::LocalPr)
+        } else if let Some(selector) = parse_explicit_selector(trimmed) {
+            selector.map(Self::Explicit)
         } else {
-            parse_handle(trimmed).map(Self::Stable)
+            Ok(Self::Bare(trimmed.to_string()))
         }
     }
 }
@@ -157,7 +174,7 @@ impl FromStr for InclusiveSelector {
         let trimmed = input.trim();
         if is_digits_only(trimmed) {
             let parsed = trimmed.parse::<usize>().map_err(|_| {
-                format!("`{trimmed}` must be 0, a local PR number, a label, or `pr:<label>`")
+                format!("`{trimmed}` must be 0, a local PR number, or a group selector")
             })?;
             if parsed == 0 {
                 Ok(Self::All)
@@ -165,9 +182,7 @@ impl FromStr for InclusiveSelector {
                 Ok(Self::Group(GroupSelector::LocalPr(parsed)))
             }
         } else {
-            parse_handle(trimmed)
-                .map(GroupSelector::Stable)
-                .map(Self::Group)
+            trimmed.parse::<GroupSelector>().map(Self::Group)
         }
     }
 }
@@ -181,7 +196,7 @@ impl FromStr for AfterSelector {
         if is_digits_only(trimmed) {
             let parsed = trimmed.parse::<usize>().map_err(|_| {
                 format!(
-                    "`{trimmed}` must be 0, a local PR number, `bottom`, `top`, `last`, `all`, a label, or `pr:<label>`"
+                    "`{trimmed}` must be 0, a local PR number, `bottom`, `top`, `last`, `all`, or a group selector"
                 )
             })?;
             if parsed == 0 {
@@ -194,9 +209,7 @@ impl FromStr for AfterSelector {
         } else if lowered == "top" || lowered == "last" || lowered == "all" {
             Ok(Self::Top)
         } else {
-            parse_handle(trimmed)
-                .map(GroupSelector::Stable)
-                .map(Self::Group)
+            trimmed.parse::<GroupSelector>().map(Self::Group)
         }
     }
 }
@@ -216,6 +229,14 @@ impl FromStr for GroupRangeSelector {
     }
 }
 
+fn matching_bare_groups<'a>(groups: &'a [Group], bare: &str) -> Vec<(usize, &'a Group)> {
+    groups
+        .iter()
+        .enumerate()
+        .filter(|(_, group)| group.bare_selector_text() == bare)
+        .collect()
+}
+
 /// Resolve a selector to a 0-based index into the current local stack.
 pub fn resolve_group_index(groups: &[Group], selector: &GroupSelector) -> Result<usize> {
     match selector {
@@ -232,10 +253,29 @@ pub fn resolve_group_index(groups: &[Group], selector: &GroupSelector) -> Result
                 )
             }
         }
-        GroupSelector::Stable(handle) => groups
-            .iter()
-            .position(|group| group.tag == handle.tag)
-            .ok_or_else(|| anyhow!("No outstanding PR group matches stable handle `{handle}`.")),
+        GroupSelector::Explicit(explicit) => {
+            let marker = explicit.marker();
+            groups
+                .iter()
+                .position(|group| group.marker == marker)
+                .ok_or_else(|| anyhow!("No outstanding PR group matches selector `{explicit}`."))
+        }
+        GroupSelector::Bare(bare) => match matching_bare_groups(groups, bare).as_slice() {
+            [] => Err(anyhow!(
+                "No outstanding PR group matches bare selector `{bare}`."
+            )),
+            [(index, _)] => Ok(*index),
+            matches => {
+                let explicit = matches
+                    .iter()
+                    .map(|(_, group)| format!("`{}`", group.selector_text()))
+                    .collect::<Vec<_>>()
+                    .join(" and ");
+                Err(anyhow!(
+                    "Bare selector `{bare}` is ambiguous in the current stack: it matches {explicit}. Use an explicit selector."
+                ))
+            }
+        },
     }
 }
 
@@ -283,41 +323,54 @@ pub fn resolve_group_range(
 mod tests {
     use super::{
         resolve_after_count, resolve_group_index, resolve_group_range, resolve_inclusive_count,
-        AfterSelector, GroupRangeSelector, GroupSelector, InclusiveSelector, StableHandle,
+        AfterSelector, ExplicitGroupSelector, GroupRangeSelector, GroupSelector, InclusiveSelector,
     };
+    use crate::group_markers::GroupMarker;
     use crate::parsing::Group;
 
-    fn group(tag: &str) -> Group {
+    fn pr_group(label: &str) -> Group {
         Group {
-            tag: tag.to_string(),
-            subjects: vec![format!("feat: {tag}")],
-            commits: vec![format!("{tag}1")],
-            first_message: Some(format!("feat: {tag} pr:{tag}")),
+            marker: GroupMarker::PrLabel(label.to_string()),
+            subjects: vec![format!("feat: {label}")],
+            commits: vec![format!("{label}1")],
+            first_message: Some(format!("feat: {label} pr:{label}")),
             ignored_after: Vec::new(),
         }
     }
 
-    fn groups(tags: &[&str]) -> Vec<Group> {
-        tags.iter().map(|tag| group(tag)).collect()
+    fn branch_group(branch_name: &str) -> Group {
+        Group {
+            marker: GroupMarker::BranchName(branch_name.to_string()),
+            subjects: vec![format!("feat: {branch_name}")],
+            commits: vec![format!("{branch_name}1")],
+            first_message: Some(format!("feat: {branch_name} branch:{branch_name}")),
+            ignored_after: Vec::new(),
+        }
+    }
+
+    fn pr_groups(labels: &[&str]) -> Vec<Group> {
+        labels.iter().map(|label| pr_group(label)).collect()
     }
 
     #[test]
-    fn group_selector_parses_numeric_and_stable_forms() {
+    fn group_selector_parses_numeric_explicit_and_bare_forms() {
         assert_eq!(
             "2".parse::<GroupSelector>().unwrap(),
             GroupSelector::LocalPr(2)
         );
         assert_eq!(
             "PR:Beta".parse::<GroupSelector>().unwrap(),
-            GroupSelector::Stable(StableHandle {
-                tag: "Beta".to_string()
-            })
+            GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("Beta".to_string()))
+        );
+        assert_eq!(
+            "branch:feature/login".parse::<GroupSelector>().unwrap(),
+            GroupSelector::Explicit(ExplicitGroupSelector::BranchName(
+                "feature/login".to_string()
+            ))
         );
         assert_eq!(
             "beta".parse::<GroupSelector>().unwrap(),
-            GroupSelector::Stable(StableHandle {
-                tag: "beta".to_string()
-            })
+            GroupSelector::Bare("beta".to_string())
         );
     }
 
@@ -329,14 +382,12 @@ mod tests {
         );
         assert_eq!(
             "beta".parse::<InclusiveSelector>().unwrap(),
-            InclusiveSelector::Group(GroupSelector::Stable(StableHandle {
-                tag: "beta".to_string()
-            }))
+            InclusiveSelector::Group(GroupSelector::Bare("beta".to_string()))
         );
     }
 
     #[test]
-    fn after_selector_parses_keywords_and_stable_handle() {
+    fn after_selector_parses_keywords_and_explicit_selector() {
         assert_eq!(
             "bottom".parse::<AfterSelector>().unwrap(),
             AfterSelector::Bottom
@@ -344,15 +395,9 @@ mod tests {
         assert_eq!("last".parse::<AfterSelector>().unwrap(), AfterSelector::Top);
         assert_eq!(
             "pr:beta".parse::<AfterSelector>().unwrap(),
-            AfterSelector::Group(GroupSelector::Stable(StableHandle {
-                tag: "beta".to_string()
-            }))
-        );
-        assert_eq!(
-            "beta".parse::<AfterSelector>().unwrap(),
-            AfterSelector::Group(GroupSelector::Stable(StableHandle {
-                tag: "beta".to_string()
-            }))
+            AfterSelector::Group(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+                "beta".to_string()
+            )))
         );
     }
 
@@ -361,9 +406,7 @@ mod tests {
         assert_eq!(
             "beta..3".parse::<GroupRangeSelector>().unwrap(),
             GroupRangeSelector::Inclusive {
-                start: GroupSelector::Stable(StableHandle {
-                    tag: "beta".to_string()
-                }),
+                start: GroupSelector::Bare("beta".to_string()),
                 end: GroupSelector::LocalPr(3)
             }
         );
@@ -371,49 +414,21 @@ mod tests {
             "2".parse::<GroupRangeSelector>().unwrap(),
             GroupRangeSelector::Single(GroupSelector::LocalPr(2))
         );
-        assert_eq!(
-            "beta..gamma".parse::<GroupRangeSelector>().unwrap(),
-            GroupRangeSelector::Inclusive {
-                start: GroupSelector::Stable(StableHandle {
-                    tag: "beta".to_string()
-                }),
-                end: GroupSelector::Stable(StableHandle {
-                    tag: "gamma".to_string()
-                })
-            }
-        );
     }
 
     #[test]
-    fn malformed_stable_handle_is_rejected() {
-        let err = "beta!oops".parse::<GroupSelector>().unwrap_err();
-        assert!(
-            err.contains("ASCII letters, digits"),
-            "unexpected error: {err}"
-        );
+    fn malformed_explicit_selectors_are_rejected() {
+        assert!("pr:1beta".parse::<GroupSelector>().is_err());
+        assert!("branch:bad..name".parse::<GroupSelector>().is_err());
     }
 
     #[test]
-    fn digit_prefixed_stable_handle_is_rejected() {
-        let err = "1beta".parse::<GroupSelector>().unwrap_err();
-        assert!(
-            err.contains("must start with an ASCII letter"),
-            "unexpected error: {err}"
-        );
-        let prefixed = "pr:1beta".parse::<GroupSelector>().unwrap_err();
-        assert!(
-            prefixed.contains("must start with an ASCII letter"),
-            "unexpected error: {prefixed}"
-        );
-    }
-
-    #[test]
-    fn prefixed_keyword_can_still_target_a_stable_handle() {
+    fn prefixed_keyword_can_still_target_an_explicit_selector() {
         assert_eq!(
             "pr:all".parse::<AfterSelector>().unwrap(),
-            AfterSelector::Group(GroupSelector::Stable(StableHandle {
-                tag: "all".to_string()
-            }))
+            AfterSelector::Group(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+                "all".to_string()
+            )))
         );
     }
 
@@ -430,48 +445,55 @@ mod tests {
     }
 
     #[test]
-    fn stable_handle_resolution_survives_local_pr_renumbering() {
-        let before = groups(&["alpha", "beta", "gamma"]);
-        let after = groups(&["beta", "gamma"]);
-        let selector = GroupSelector::Stable(StableHandle {
-            tag: "beta".to_string(),
-        });
+    fn bare_selector_resolution_survives_local_pr_renumbering() {
+        let before = pr_groups(&["alpha", "beta", "gamma"]);
+        let after = pr_groups(&["beta", "gamma"]);
+        let selector = GroupSelector::Bare("beta".to_string());
 
         let before_index = resolve_group_index(&before, &selector).unwrap();
         let after_index = resolve_group_index(&after, &selector).unwrap();
 
-        assert_eq!(before[before_index].tag, "beta");
-        assert_eq!(after[after_index].tag, "beta");
+        assert_eq!(before[before_index].bare_selector_text(), "beta");
+        assert_eq!(after[after_index].bare_selector_text(), "beta");
         assert_eq!(before_index + 1, 2);
         assert_eq!(after_index + 1, 1);
     }
 
     #[test]
-    fn stable_handle_resolution_remains_exact_case() {
-        let groups = groups(&["Alpha"]);
-        let selector = GroupSelector::Stable(StableHandle {
-            tag: "alpha".to_string(),
-        });
+    fn bare_selector_rejects_ambiguity_between_marker_kinds() {
+        let groups = vec![pr_group("beta"), branch_group("beta")];
+        let selector = GroupSelector::Bare("beta".to_string());
+
+        let err = resolve_group_index(&groups, &selector).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("Bare selector `beta` is ambiguous"));
+        assert!(err.to_string().contains("`pr:beta` and `branch:beta`"));
+    }
+
+    #[test]
+    fn explicit_selector_resolution_remains_exact_case() {
+        let groups = pr_groups(&["Alpha"]);
+        let selector = GroupSelector::Explicit(ExplicitGroupSelector::PrLabel("alpha".to_string()));
 
         let err = resolve_group_index(&groups, &selector).unwrap_err();
 
         assert!(
             err.to_string()
-                .contains("No outstanding PR group matches stable handle `pr:alpha`"),
+                .contains("No outstanding PR group matches selector `pr:alpha`"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
     fn resolution_helpers_map_boundaries_to_counts() {
-        let groups = groups(&["alpha", "beta", "gamma"]);
+        let groups = pr_groups(&["alpha", "beta", "gamma"]);
 
         assert_eq!(
             resolve_inclusive_count(
                 &groups,
-                &InclusiveSelector::Group(GroupSelector::Stable(StableHandle {
-                    tag: "beta".to_string()
-                }))
+                &InclusiveSelector::Group(GroupSelector::Bare("beta".to_string()))
             )
             .unwrap(),
             2
@@ -479,9 +501,7 @@ mod tests {
         assert_eq!(
             resolve_after_count(
                 &groups,
-                &AfterSelector::Group(GroupSelector::Stable(StableHandle {
-                    tag: "beta".to_string()
-                }))
+                &AfterSelector::Group(GroupSelector::Bare("beta".to_string()))
             )
             .unwrap(),
             2
@@ -490,9 +510,7 @@ mod tests {
             resolve_group_range(
                 &groups,
                 &GroupRangeSelector::Inclusive {
-                    start: GroupSelector::Stable(StableHandle {
-                        tag: "beta".to_string()
-                    }),
+                    start: GroupSelector::Bare("beta".to_string()),
                     end: GroupSelector::LocalPr(3)
                 }
             )

--- a/src/stack_metadata.rs
+++ b/src/stack_metadata.rs
@@ -51,7 +51,7 @@ pub struct PrBranchName(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct PrTag(pub String);
+pub struct GroupSelectorText(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -74,7 +74,8 @@ pub struct StackRecord {
 pub enum PrBranchRecord {
     Live {
         stack_id: StackId,
-        tag: PrTag,
+        #[serde(rename = "tag")]
+        selector: GroupSelectorText,
         last_group_seed: String,
         last_group_tip: String,
         last_stack_head: String,
@@ -82,7 +83,8 @@ pub enum PrBranchRecord {
     },
     Tombstoned {
         stack_id: StackId,
-        tag: PrTag,
+        #[serde(rename = "tag")]
+        selector: GroupSelectorText,
         last_group_seed: String,
         last_group_tip: String,
         last_stack_head: String,
@@ -98,9 +100,9 @@ impl PrBranchRecord {
         }
     }
 
-    pub fn tag(&self) -> &PrTag {
+    pub fn selector(&self) -> &GroupSelectorText {
         match self {
-            Self::Live { tag, .. } | Self::Tombstoned { tag, .. } => tag,
+            Self::Live { selector, .. } | Self::Tombstoned { selector, .. } => selector,
         }
     }
 
@@ -138,14 +140,14 @@ impl PrBranchRecord {
         match self {
             Self::Live {
                 stack_id,
-                tag,
+                selector,
                 last_group_seed,
                 last_group_tip,
                 last_stack_head,
                 updated_at,
             } => Some(LivePrBranchRecord {
                 stack_id,
-                tag,
+                selector,
                 last_group_seed,
                 last_group_tip,
                 last_stack_head,
@@ -159,7 +161,7 @@ impl PrBranchRecord {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LivePrBranchRecord<'a> {
     pub stack_id: &'a StackId,
-    pub tag: &'a PrTag,
+    pub selector: &'a GroupSelectorText,
     pub last_group_seed: &'a str,
     pub last_group_tip: &'a str,
     pub last_stack_head: &'a str,
@@ -195,7 +197,7 @@ pub struct StackSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StackSnapshotGroup {
     pub pr_branch: PrBranchName,
-    pub tag: PrTag,
+    pub selector: GroupSelectorText,
     pub last_group_seed: String,
     pub last_group_tip: String,
 }
@@ -295,12 +297,22 @@ fn resolve_stack_id_for_snapshot(
         return resolve_stack_id_for_empty_snapshot(metadata, &snapshot.stack_branch);
     }
 
-    let matching_stack_ids = snapshot
+    let branch_match_ids = metadata
+        .stacks
+        .iter()
+        .filter(|(_, record)| {
+            record.preferred_branch == snapshot.stack_branch
+                || record.known_branches.contains(&snapshot.stack_branch)
+        })
+        .map(|(stack_id, _)| stack_id.clone());
+    let group_match_ids = snapshot
         .groups
         .iter()
         .filter_map(|group| metadata.pr_branches.get(&group.pr_branch))
         .filter_map(PrBranchRecord::as_live)
-        .map(|record| record.stack_id.clone())
+        .map(|record| record.stack_id.clone());
+    let matching_stack_ids = branch_match_ids
+        .chain(group_match_ids)
         .collect::<BTreeSet<_>>();
     if matching_stack_ids.len() > 1 {
         bail!(
@@ -317,7 +329,7 @@ fn resolve_stack_id_for_snapshot(
 fn tombstone_record(record: &PrBranchRecord, updated_at: &str) -> PrBranchRecord {
     PrBranchRecord::Tombstoned {
         stack_id: record.stack_id().clone(),
-        tag: record.tag().clone(),
+        selector: record.selector().clone(),
         last_group_seed: record.last_group_seed().to_string(),
         last_group_tip: record.last_group_tip().to_string(),
         last_stack_head: record.last_stack_head().to_string(),
@@ -387,11 +399,24 @@ fn apply_snapshot(
     }
 
     for group in &snapshot.groups {
+        if let Some(PrBranchRecord::Live {
+            stack_id: owner, ..
+        }) = metadata.pr_branches.get(&group.pr_branch)
+        {
+            if *owner != stack_id {
+                bail!(
+                    "branch {} is already owned by verified live stack {} and cannot also belong to stack {}",
+                    group.pr_branch.0,
+                    owner.0,
+                    stack_id.0
+                );
+            }
+        }
         metadata.pr_branches.insert(
             group.pr_branch.clone(),
             PrBranchRecord::Live {
                 stack_id: stack_id.clone(),
-                tag: group.tag.clone(),
+                selector: group.selector.clone(),
                 last_group_seed: group.last_group_seed.clone(),
                 last_group_tip: group.last_group_tip.clone(),
                 last_stack_head: snapshot.stack_head.clone(),
@@ -529,28 +554,27 @@ pub fn build_snapshot_for_branch(
     let (leading_ignored, parsed_groups) = parse_groups_with_ignored(&lines, ignore_tag)?;
     let (groups, _skipped_handles) = split_groups_for_update(&leading_ignored, parsed_groups);
     let branch_identities = group_branch_identities(&groups, prefix)?;
-    let groups = groups
-        .iter()
-        .zip(branch_identities.iter())
-        .map(|(group, identity)| {
-            let last_group_seed = group
-                .commits
-                .first()
-                .cloned()
-                .ok_or_else(|| anyhow!("group pr:{} has no seed commit", group.tag))?;
-            let last_group_tip = group
-                .commits
-                .last()
-                .cloned()
-                .ok_or_else(|| anyhow!("group pr:{} has no tip commit", group.tag))?;
-            Ok(StackSnapshotGroup {
-                pr_branch: PrBranchName(identity.exact.clone()),
-                tag: PrTag(group.tag.clone()),
-                last_group_seed,
-                last_group_tip,
+    let groups =
+        groups
+            .iter()
+            .zip(branch_identities.iter())
+            .map(|(group, identity)| {
+                let last_group_seed =
+                    group.commits.first().cloned().ok_or_else(|| {
+                        anyhow!("group {} has no seed commit", group.selector_text())
+                    })?;
+                let last_group_tip =
+                    group.commits.last().cloned().ok_or_else(|| {
+                        anyhow!("group {} has no tip commit", group.selector_text())
+                    })?;
+                Ok(StackSnapshotGroup {
+                    pr_branch: PrBranchName(identity.exact.clone()),
+                    selector: GroupSelectorText(group.selector_text()),
+                    last_group_seed,
+                    last_group_tip,
+                })
             })
-        })
-        .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>>>()?;
 
     Ok(StackSnapshot {
         stack_branch: StackBranchName(stack_branch.to_string()),
@@ -727,8 +751,8 @@ pub fn current_branch_or_none(repo_path: &str) -> Result<Option<String>> {
 mod tests {
     use super::{
         acquire_lock, apply_snapshot, load_metadata_from_path, metadata_lock_path,
-        ordered_known_branches, write_metadata_atomically, PrBranchName, PrBranchRecord, PrTag,
-        StackBranchName, StackId, StackMetadataFile, StackRecord, StackSnapshot,
+        ordered_known_branches, write_metadata_atomically, GroupSelectorText, PrBranchName,
+        PrBranchRecord, StackBranchName, StackId, StackMetadataFile, StackRecord, StackSnapshot,
         StackSnapshotGroup, TombstoneReason, STACK_METADATA_SCHEMA_VERSION,
     };
     use std::collections::BTreeMap;
@@ -745,7 +769,10 @@ mod tests {
                 .iter()
                 .map(|(branch_name, seed, tip)| StackSnapshotGroup {
                     pr_branch: PrBranchName((*branch_name).to_string()),
-                    tag: PrTag(branch_name.rsplit('/').next().unwrap().to_string()),
+                    selector: GroupSelectorText(format!(
+                        "pr:{}",
+                        branch_name.rsplit('/').next().unwrap()
+                    )),
                     last_group_seed: (*seed).to_string(),
                     last_group_tip: (*tip).to_string(),
                 })
@@ -789,7 +816,7 @@ mod tests {
                     PrBranchName("dank-spr/alpha".to_string()),
                     PrBranchRecord::Live {
                         stack_id: StackId("stack-1".to_string()),
-                        tag: PrTag("alpha".to_string()),
+                        selector: GroupSelectorText("pr:alpha".to_string()),
                         last_group_seed: "a1".to_string(),
                         last_group_tip: "a2".to_string(),
                         last_stack_head: "old-head".to_string(),
@@ -800,7 +827,7 @@ mod tests {
                     PrBranchName("dank-spr/beta".to_string()),
                     PrBranchRecord::Live {
                         stack_id: StackId("stack-1".to_string()),
-                        tag: PrTag("beta".to_string()),
+                        selector: GroupSelectorText("pr:beta".to_string()),
                         last_group_seed: "b1".to_string(),
                         last_group_tip: "b2".to_string(),
                         last_stack_head: "old-head".to_string(),
@@ -849,7 +876,7 @@ mod tests {
                 PrBranchName("dank-spr/alpha".to_string()),
                 PrBranchRecord::Live {
                     stack_id: StackId("stack-1".to_string()),
-                    tag: PrTag("alpha".to_string()),
+                    selector: GroupSelectorText("pr:alpha".to_string()),
                     last_group_seed: "a1".to_string(),
                     last_group_tip: "a2".to_string(),
                     last_stack_head: "old-head".to_string(),
@@ -870,6 +897,67 @@ mod tests {
             }
             other => panic!("expected tombstone, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn apply_snapshot_rejects_branch_owned_by_different_known_live_stack() {
+        let existing = StackMetadataFile {
+            schema_version: STACK_METADATA_SCHEMA_VERSION,
+            stacks: BTreeMap::from([
+                (
+                    StackId("stack-1".to_string()),
+                    StackRecord {
+                        preferred_branch: StackBranchName("dank/stack-one".to_string()),
+                        known_branches: vec![StackBranchName("dank/stack-one".to_string())],
+                        base: "origin/main".to_string(),
+                        prefix: "dank-spr/".to_string(),
+                        last_seen_head: "head-one".to_string(),
+                        updated_at: "2026-03-05T00:00:00Z".to_string(),
+                    },
+                ),
+                (
+                    StackId("stack-2".to_string()),
+                    StackRecord {
+                        preferred_branch: StackBranchName("dank/stack-two".to_string()),
+                        known_branches: vec![StackBranchName("dank/stack-two".to_string())],
+                        base: "origin/main".to_string(),
+                        prefix: "dank-spr/".to_string(),
+                        last_seen_head: "head-two".to_string(),
+                        updated_at: "2026-03-05T00:00:00Z".to_string(),
+                    },
+                ),
+            ]),
+            pr_branches: BTreeMap::from([(
+                PrBranchName("feature/login".to_string()),
+                PrBranchRecord::Live {
+                    stack_id: StackId("stack-2".to_string()),
+                    selector: GroupSelectorText("branch:feature/login".to_string()),
+                    last_group_seed: "a1".to_string(),
+                    last_group_tip: "a2".to_string(),
+                    last_stack_head: "head-two".to_string(),
+                    updated_at: "2026-03-05T00:00:00Z".to_string(),
+                },
+            )]),
+        };
+        let snapshot = StackSnapshot {
+            stack_branch: StackBranchName("dank/stack-one".to_string()),
+            stack_head: "head-one-new".to_string(),
+            base: "origin/main".to_string(),
+            prefix: "dank-spr/".to_string(),
+            groups: vec![StackSnapshotGroup {
+                pr_branch: PrBranchName("feature/login".to_string()),
+                selector: GroupSelectorText("branch:feature/login".to_string()),
+                last_group_seed: "b1".to_string(),
+                last_group_tip: "b2".to_string(),
+            }],
+        };
+
+        let err = apply_snapshot(existing, &snapshot, "2026-03-05T03:00:00Z").unwrap_err();
+
+        assert!(
+            err.to_string().contains("disagree on stack ownership"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add exact-branch groups so any PR group can use a chosen branch name instead of a prefix-derived one. 

This means you can now "adopt" one or more existing PRs into a stack. You can create a PR that's user-managed, then later make it part of an spr-managed stack (and it can be anywhere in the stack, not just the prefix of the stack).

A typed marker model, explicit selectors, and one shared branch-resolution path keep mixed stacks coherent across parsing, updates, metadata, and local branch sync.

# Problem Solved

SPR previously chose every PR branch name from the configured prefix plus a label, which made it awkward to adopt an existing branch-backed PR without closing and recreating it. Exact-branch groups let users preserve a pre-existing branch name, or intentionally request a future custom branch name, at any position in the stack.

# Syntax

- `pr:<tag>` keeps the existing prefix-derived form.
- `branch:<branch-name>` uses that exact Git branch name for the group.

For example, if GitHub already has a non-SPR PR on `feature/login` and you want to build an SPR PR on top of it without renaming or recreating the existing branch, the stack can look like:

```text
feat: add profile screen pr:profile
feat: adopt existing login work branch:feature/login
```

The lower `branch:feature/login` group keeps the existing branch, and the upper `pr:profile` group uses the normal SPR-derived branch.

# Mental model

Each group has exactly one marker: the label form derives the concrete branch from the configured prefix, while the exact-branch form preserves the requested Git branch name. Bare selectors stay a convenience only when they resolve uniquely; concrete branch-name uniqueness is checked separately.

# Tests

Validation covers mixed marker parsing, branch-name validation, selector ambiguity, concrete-branch collision detection, update/relink/absorb flows, local branch sync, metadata, and list rendering.

- `cargo test`

<!-- spr-stack:start -->
**Stack**:
-   #137
-   #136
-   #135
- ➡ #134

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
