### PR TITLE
config: keep enum fallbacks explicit

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,13 +35,12 @@ pub enum LocalPrBranchSyncPolicy {
 /// Behavior when `spr restack` encounters a cherry-pick conflict.
 ///
 /// This is YAML-deserializable and avoids stringly-typed policy handling.
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum RestackConflictPolicy {
     /// Abort and clean up temp restack state.
     Rollback,
     /// Suspend, leave the temp worktree in place, and resume with `spr resume`.
-    #[default]
     Halt,
 }
 
@@ -50,7 +49,7 @@ pub enum RestackConflictPolicy {
 /// This applies to commands that rebuild the checked-out branch and then move
 /// it to a rewritten tip, such as `spr restack`, `spr move`, `spr fix-pr`, and
 /// `spr absorb`.
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DirtyWorktreePolicy {
     /// Preserve the historical behavior: proceed and let the rewrite replace
@@ -60,7 +59,6 @@ pub enum DirtyWorktreePolicy {
     /// reapply them with `git stash apply --index`.
     Stash,
     /// Refuse to rewrite until the worktree is clean.
-    #[default]
     Halt,
 }
 


### PR DESCRIPTION
Remove unused enum-level `Default` implementations for `RestackConflictPolicy` and `DirtyWorktreePolicy`. The real config fallbacks already live in `default_config()`, so keeping only that path makes the defaults explicit without changing behavior.

<!-- spr-stack:start -->
**Stack**:
-   #137
-   #136
- ➡ #135

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->