### PR TITLE
prs: keep base-chain repairs consistent across commands

### DIFF
--- a/src/commands/relink_prs.rs
+++ b/src/commands/relink_prs.rs
@@ -1,17 +1,17 @@
 use anyhow::Result;
-use std::collections::HashMap;
 use tracing::info;
 
-use crate::branch_names::{canonical_branch_conflict_key, group_branch_identities};
-use crate::commands::common;
 use crate::execution::ExecutionMode;
 use crate::git::{gh_rw, normalize_branch_name, sanitize_gh_base_ref};
-use crate::github::list_open_prs_for_heads;
 use crate::maintenance_output::{
     MaintenanceOptions, MaintenanceRepoContext, RelinkExpectedBaseData, RelinkPrAction,
     RelinkPrDecisionData, RelinkPrsSummaryData,
 };
 use crate::parsing::derive_local_groups;
+use crate::pr_base_chain::{
+    build_desired_pr_base_chain, plan_base_reconciliation, verify_base_edits_converged,
+    BaseReconciliationAction, ObservedPrBaseChain,
+};
 
 fn render_relink_action(action: RelinkPrAction) -> &'static str {
     match action {
@@ -57,77 +57,71 @@ pub fn relink_prs(
             decisions: Vec::new(),
         });
     }
-    let branch_identities = group_branch_identities(&groups, prefix)?;
-
-    let heads: Vec<String> = branch_identities
+    let desired_chain = build_desired_pr_base_chain(&normalized_base, &groups, prefix)?;
+    let heads: Vec<String> = desired_chain
         .iter()
-        .map(|identity| identity.exact.clone())
+        .map(|desired| desired.head_branch.clone())
         .collect();
-    let prs = list_open_prs_for_heads(&heads)?;
-    let prs_by_head: HashMap<_, _> = prs
+    let observed_chain = ObservedPrBaseChain::observe_for_heads(&heads)?;
+    let expected_chain: Vec<RelinkExpectedBaseData> = desired_chain
         .iter()
-        .map(|pr| (canonical_branch_conflict_key(&pr.head), pr))
-        .collect();
-    let expected = common::build_head_base_chain(&normalized_base, &groups, prefix)?;
-    let expected_chain: Vec<RelinkExpectedBaseData> = expected
-        .iter()
-        .enumerate()
-        .map(
-            |(group_idx, (head_branch, expected_base_ref))| RelinkExpectedBaseData {
-                local_pr_number: group_idx + 1,
-                stable_handle: common::group_selector_text(&groups[group_idx]),
-                head_branch: head_branch.clone(),
-                expected_base_ref: expected_base_ref.clone(),
-            },
-        )
+        .map(|desired| RelinkExpectedBaseData {
+            local_pr_number: desired.local_pr_number,
+            stable_handle: desired.stable_handle.clone(),
+            head_branch: desired.head_branch.clone(),
+            expected_base_ref: desired.expected_base_ref.clone(),
+        })
         .collect();
 
-    let mut decisions: Vec<RelinkPrDecisionData> = Vec::with_capacity(expected_chain.len());
-    for expected in &expected_chain {
-        if let Some(pr) = prs_by_head
-            .get(&canonical_branch_conflict_key(&expected.head_branch))
-            .copied()
-        {
-            let action = if pr.base == expected.expected_base_ref {
-                RelinkPrAction::AlreadyCorrect
-            } else {
-                gh_rw(
-                    execution_mode,
-                    [
-                        "pr",
-                        "edit",
-                        &format!("#{}", pr.number),
-                        "--base",
-                        &sanitize_gh_base_ref(&expected.expected_base_ref),
-                    ]
-                    .as_slice(),
-                )?;
-                if dry_run {
-                    RelinkPrAction::DryRunEdit
-                } else {
-                    RelinkPrAction::Edited
+    let reconciliation = plan_base_reconciliation(&desired_chain, &observed_chain);
+    let edited_head_branches = reconciliation
+        .iter()
+        .filter(|decision| decision.action == BaseReconciliationAction::NeedsEdit)
+        .map(|decision| decision.desired.head_branch.clone())
+        .collect::<Vec<_>>();
+    let decisions = reconciliation
+        .into_iter()
+        .map(|decision| {
+            let action = match decision.action {
+                BaseReconciliationAction::AlreadyCorrect => RelinkPrAction::AlreadyCorrect,
+                BaseReconciliationAction::NeedsEdit => {
+                    let remote_pr_number = decision
+                        .remote_pr_number
+                        .expect("editable decisions must have an open PR");
+                    gh_rw(
+                        execution_mode,
+                        [
+                            "pr",
+                            "edit",
+                            &format!("#{}", remote_pr_number),
+                            "--base",
+                            &sanitize_gh_base_ref(&decision.desired.expected_base_ref),
+                        ]
+                        .as_slice(),
+                    )?;
+                    if dry_run {
+                        RelinkPrAction::DryRunEdit
+                    } else {
+                        RelinkPrAction::Edited
+                    }
                 }
+                BaseReconciliationAction::MissingOpenPr => RelinkPrAction::MissingOpenPr,
             };
-            decisions.push(RelinkPrDecisionData {
-                local_pr_number: expected.local_pr_number,
-                stable_handle: expected.stable_handle.clone(),
-                head_branch: expected.head_branch.clone(),
-                expected_base_ref: expected.expected_base_ref.clone(),
-                current_base_ref: Some(pr.base.clone()),
-                remote_pr_number: Some(pr.number),
+            Ok(RelinkPrDecisionData {
+                local_pr_number: decision.desired.local_pr_number,
+                stable_handle: decision.desired.stable_handle,
+                head_branch: decision.desired.head_branch,
+                expected_base_ref: decision.desired.expected_base_ref,
+                current_base_ref: decision.current_base_ref,
+                remote_pr_number: decision.remote_pr_number,
                 action,
-            });
-        } else {
-            decisions.push(RelinkPrDecisionData {
-                local_pr_number: expected.local_pr_number,
-                stable_handle: expected.stable_handle.clone(),
-                head_branch: expected.head_branch.clone(),
-                expected_base_ref: expected.expected_base_ref.clone(),
-                current_base_ref: None,
-                remote_pr_number: None,
-                action: RelinkPrAction::MissingOpenPr,
-            });
-        }
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if !edited_head_branches.is_empty() && execution_mode == ExecutionMode::Apply {
+        let refreshed_chain = ObservedPrBaseChain::observe_for_heads(&heads)?;
+        let refreshed_decisions = plan_base_reconciliation(&desired_chain, &refreshed_chain);
+        verify_base_edits_converged(&edited_head_branches, &refreshed_decisions)?;
     }
 
     Ok(RelinkPrsSummaryData {
@@ -224,10 +218,16 @@ mod tests {
         let _guard = DirGuard::change_to(&repo);
         let log_path = repo.join("gh.log");
         let exact_open_path = repo.join("exact-open.json");
+        let exact_open_after_edit_path = repo.join("exact-open-after-edit.json");
         let search_open_path = repo.join("search-open.json");
         fs::write(
             &exact_open_path,
             "{\"data\":{\"repository\":{\"pr0\":{\"nodes\":[{\"number\":17,\"headRefName\":\"skilltest/alpha\",\"baseRefName\":\"main\",\"state\":\"OPEN\",\"mergedAt\":null,\"closedAt\":null,\"url\":\"https://github.com/o/r/pull/17\",\"autoMergeRequest\":null}]},\"pr1\":{\"nodes\":[{\"number\":22,\"headRefName\":\"skilltest/beta\",\"baseRefName\":\"main\",\"state\":\"OPEN\",\"mergedAt\":null,\"closedAt\":null,\"url\":\"https://github.com/o/r/pull/22\",\"autoMergeRequest\":null}]}}}}",
+        )
+        .unwrap();
+        fs::write(
+            &exact_open_after_edit_path,
+            "{\"data\":{\"repository\":{\"pr0\":{\"nodes\":[{\"number\":17,\"headRefName\":\"skilltest/alpha\",\"baseRefName\":\"main\",\"state\":\"OPEN\",\"mergedAt\":null,\"closedAt\":null,\"url\":\"https://github.com/o/r/pull/17\",\"autoMergeRequest\":null}]},\"pr1\":{\"nodes\":[{\"number\":22,\"headRefName\":\"skilltest/beta\",\"baseRefName\":\"skilltest/alpha\",\"state\":\"OPEN\",\"mergedAt\":null,\"closedAt\":null,\"url\":\"https://github.com/o/r/pull/22\",\"autoMergeRequest\":null}]}}}}",
         )
         .unwrap();
         fs::write(
@@ -236,10 +236,12 @@ mod tests {
         )
         .unwrap();
         let script = format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*) cat \"{}\" ;;\n    *\"is:pr is:open head:skilltest/alpha\"*) cat \"{}\" ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"edit\" ]; then\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*) cat \"{}\" ;;\n    *\"is:pr is:open head:skilltest/alpha\"*) cat \"{}\" ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"edit\" ]; then\n  cp \"{}\" \"{}\"\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
             log_path.display(),
             exact_open_path.display(),
             search_open_path.display(),
+            exact_open_after_edit_path.display(),
+            exact_open_path.display(),
         );
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -13,11 +13,15 @@ use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
 use crate::execution::ExecutionMode;
 use crate::git::{get_remote_branches_sha, gh_rw, git_is_ancestor, git_rw, sanitize_gh_base_ref};
 use crate::github::{
-    fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape, list_open_prs_for_heads,
+    fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape,
     list_recent_terminal_prs_for_heads, upsert_pr_cached, TerminalPrState,
 };
 use crate::limit::{apply_limit_groups, Limit};
 use crate::parsing::Group;
+use crate::pr_base_chain::{
+    build_desired_pr_base_chain, plan_base_reconciliation, verify_base_edits_converged,
+    BaseReconciliationAction, ObservedPrBaseChain,
+};
 use crate::update_output::{
     SkippedUpdateGroupData, UpdateEditAction, UpdateExecutionData, UpdateGroupData, UpdatePrAction,
     UpdatePushAction, UpdateSkippedReason,
@@ -114,40 +118,6 @@ fn pr_number_for_head(
     head: &str,
 ) -> Option<u64> {
     prs_by_head.get(&head_key(head)).copied()
-}
-
-fn open_pr_state_for_heads(
-    heads: &[String],
-) -> Result<(
-    HashMap<CanonicalBranchConflictKey, u64>,
-    HashMap<u64, String>,
-)> {
-    let mut prs_by_head = HashMap::new();
-    let mut current_base_by_number = HashMap::new();
-    for pr in list_open_prs_for_heads(heads)? {
-        prs_by_head.insert(head_key(&pr.head), pr.number);
-        current_base_by_number.insert(pr.number, pr.base);
-    }
-    Ok((prs_by_head, current_base_by_number))
-}
-
-fn planned_base_updates(
-    current_base_by_number: &HashMap<u64, String>,
-    desired_base_by_number: &HashMap<u64, String>,
-) -> Vec<u64> {
-    let mut numbers = desired_base_by_number
-        .iter()
-        .filter_map(|(number, desired_base)| {
-            let desired_base_ref = sanitize_gh_base_ref(desired_base);
-            current_base_by_number
-                .get(number)
-                .map(|base_ref| sanitize_gh_base_ref(base_ref) != desired_base_ref)
-                .unwrap_or(true)
-                .then_some(*number)
-        })
-        .collect::<Vec<_>>();
-    numbers.sort_unstable();
-    numbers
 }
 
 /// Fail `spr update` early when branch-name reuse matches a recently closed or merged PR.
@@ -472,10 +442,16 @@ fn build_from_groups_internal(
     }
     let total_groups = groups.len();
     let branch_identities = group_branch_identities(&groups, prefix)?;
-    let desired_base_by_head: HashMap<String, String> =
-        common::build_head_base_chain(base, &groups, prefix)?
-            .into_iter()
-            .collect();
+    let desired_chain = build_desired_pr_base_chain(base, &groups, prefix)?;
+    let desired_base_by_head: HashMap<String, String> = desired_chain
+        .iter()
+        .map(|desired| {
+            (
+                desired.head_branch.clone(),
+                desired.expected_base_ref.clone(),
+            )
+        })
+        .collect();
 
     info!("Preparing {} group(s)…", groups.len());
 
@@ -483,11 +459,12 @@ fn build_from_groups_internal(
         .iter()
         .map(|identity| identity.exact.clone())
         .collect();
-    let (mut prs_by_head, mut current_base_by_number) = if no_pr {
-        (HashMap::new(), HashMap::new())
+    let mut observed_pr_bases = if no_pr {
+        ObservedPrBaseChain::default()
     } else {
-        open_pr_state_for_heads(&heads)?
+        ObservedPrBaseChain::observe_for_heads(&heads)?
     };
+    let mut prs_by_head = observed_pr_bases.pr_numbers_by_head();
     enforce_branch_reuse_guard(
         no_pr,
         allow_branch_reuse,
@@ -664,7 +641,6 @@ fn build_from_groups_internal(
                 pr_actions_by_group[group_idx] = if was_known {
                     UpdatePrAction::Existing
                 } else {
-                    current_base_by_number.insert(number, sanitize_gh_base_ref(&parent_branch));
                     UpdatePrAction::Created
                 };
             }
@@ -673,10 +649,8 @@ fn build_from_groups_internal(
     }
 
     if !no_pr && !dry_run {
-        let (refreshed_prs_by_head, refreshed_current_base_by_number) =
-            open_pr_state_for_heads(&heads)?;
-        prs_by_head.extend(refreshed_prs_by_head);
-        current_base_by_number.extend(refreshed_current_base_by_number);
+        observed_pr_bases = ObservedPrBaseChain::observe_for_heads(&heads)?;
+        prs_by_head.extend(observed_pr_bases.pr_numbers_by_head());
     }
 
     if !no_pr {
@@ -765,10 +739,20 @@ fn build_from_groups_internal(
                 }
             }
         }
-        let base_update_numbers =
-            planned_base_updates(&current_base_by_number, &desired_base_by_number)
-                .into_iter()
-                .collect::<HashSet<_>>();
+        let base_reconciliation = plan_base_reconciliation(&desired_chain, &observed_pr_bases);
+        let edited_head_branches = base_reconciliation
+            .iter()
+            .filter(|decision| decision.action == BaseReconciliationAction::NeedsEdit)
+            .map(|decision| decision.desired.head_branch.clone())
+            .collect::<Vec<_>>();
+        let base_update_numbers = base_reconciliation
+            .into_iter()
+            .filter_map(|decision| {
+                (decision.action == BaseReconciliationAction::NeedsEdit)
+                    .then_some(decision.remote_pr_number)
+                    .flatten()
+            })
+            .collect::<HashSet<_>>();
         for (&number, want_base) in &desired_base_by_number {
             if let Some(info) = bodies_by_number.get(&number) {
                 let desired_base_ref = sanitize_gh_base_ref(want_base);
@@ -788,6 +772,7 @@ fn build_from_groups_internal(
         for group_idx in created_without_number {
             description_actions_by_group[group_idx] = UpdateEditAction::Updated;
         }
+        let should_verify_base_updates = !edited_head_branches.is_empty();
         if !base_updates.is_empty() || !body_updates.is_empty() {
             if !base_updates.is_empty() {
                 run_update_mutations(
@@ -810,6 +795,12 @@ fn build_from_groups_internal(
                     false,
                     render_progress,
                 )?;
+            }
+            if should_verify_base_updates && execution_mode == ExecutionMode::Apply {
+                let refreshed_pr_bases = ObservedPrBaseChain::observe_for_heads(&heads)?;
+                let refreshed_decisions =
+                    plan_base_reconciliation(&desired_chain, &refreshed_pr_bases);
+                verify_base_edits_converged(&edited_head_branches, &refreshed_decisions)?;
             }
         } else {
             info!("All PR descriptions/base refs up-to-date; no edits needed");
@@ -997,8 +988,7 @@ mod tests {
     use super::{
         branch_reuse_guard_window, build_from_groups, build_from_tags, head_key,
         heads_without_open_prs, ignored_boundary_warning, parse_github_timestamp_rfc3339,
-        planned_base_updates, pr_number_for_head, recent_pr_age, recent_pr_age_blocks_recreation,
-        terminal_pr_action,
+        pr_number_for_head, recent_pr_age, recent_pr_age_blocks_recreation, terminal_pr_action,
     };
     use crate::branch_names::group_branch_identities;
     use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
@@ -1085,29 +1075,6 @@ mod tests {
 
         assert!(missing.is_empty());
         assert_eq!(pr_number_for_head(&prs_by_head, "dank-spr/alpha"), Some(17));
-    }
-
-    #[test]
-    fn planned_base_updates_only_retargets_the_post_land_bottom_pr() {
-        let current = HashMap::from([
-            (2, "dank-spr/alpha".to_string()),
-            (3, "dank-spr/beta".to_string()),
-        ]);
-        let desired = HashMap::from([(2, "main".to_string()), (3, "dank-spr/beta".to_string())]);
-
-        assert_eq!(planned_base_updates(&current, &desired), vec![2]);
-    }
-
-    #[test]
-    fn planned_base_updates_leave_a_correct_rewritten_chain_untouched() {
-        let current = HashMap::from([
-            (1, "main".to_string()),
-            (2, "dank-spr/alpha".to_string()),
-            (3, "dank-spr/beta".to_string()),
-        ]);
-        let desired = current.clone();
-
-        assert!(planned_base_updates(&current, &desired).is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod local_pr_branches;
 mod machine_output;
 mod maintenance_output;
 mod parsing;
+mod pr_base_chain;
 mod pr_labels;
 mod read_only_output;
 mod restack_output;
@@ -1434,6 +1435,19 @@ mod tests {
         )
     }
 
+    fn stale_update_base_gh_script(
+        log_path: &std::path::Path,
+        open_prs_path: &std::path::Path,
+        body_json_path: &std::path::Path,
+    ) -> String {
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*) cat \"{}\" ;;\n    *\"is:pr is:open head:dank-spr/alpha\"*|*\"is:pr is:open head:dank-spr/beta\"*)\n      echo '{{\"data\":{{\"pr0\":{{\"nodes\":[]}},\"pr1\":{{\"nodes\":[]}}}}}}' ;;\n    *\"pullRequest(number: 17)\"*\"pullRequest(number: 18)\"*) cat \"{}\" ;;\n    *\"mutation {{\"*) echo '{{\"data\":{{}}}}' ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display(),
+            open_prs_path.display(),
+            body_json_path.display(),
+        )
+    }
+
     #[test]
     fn working_directory_override_changes_repo_context() {
         let _lock = lock_cwd();
@@ -2613,6 +2627,99 @@ mod tests {
             }
             other => panic!("unexpected command output: {:?}", other),
         }
+    }
+
+    #[test]
+    fn update_rejects_base_edits_that_do_not_converge_after_apply() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let origin_url = format!("file://{}", dir.path().join("origin.git").display());
+        git(
+            &repo,
+            ["remote", "set-url", "origin", origin_url.as_str()].as_slice(),
+        );
+        let log_path = repo.join("gh.log");
+        let open_prs_path = repo.join("gh-open.json");
+        let body_json_path = repo.join("gh-bodies.json");
+        fs::write(
+            &open_prs_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "nodes": [{
+                                "number": 17,
+                                "headRefName": "dank-spr/alpha",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/17",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        },
+                        "pr1": {
+                            "nodes": [{
+                                "number": 18,
+                                "headRefName": "dank-spr/beta",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/18",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &body_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "id": "PR_17",
+                            "body": "alpha body"
+                        },
+                        "pr1": {
+                            "id": "PR_18",
+                            "body": "beta body"
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let script = stale_update_base_gh_script(&log_path, &open_prs_path, &body_json_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "update",
+        ])
+        .unwrap();
+
+        let err = run_cli(cli, OutputFormat::Human).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "GitHub PR base chain did not converge after update: dank-spr/beta: main -> dank-spr/alpha"
+        );
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("baseRefName:\"dank-spr/alpha\""), "{log}");
     }
 
     #[test]

--- a/src/pr_base_chain.rs
+++ b/src/pr_base_chain.rs
@@ -1,0 +1,329 @@
+//! Shared desired-vs-observed PR base-chain reconciliation.
+
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+
+use crate::branch_names::{
+    canonical_branch_conflict_key, group_branch_identities, CanonicalBranchConflictKey,
+};
+use crate::commands::common;
+use crate::git::sanitize_gh_base_ref;
+use crate::github::{list_open_prs_for_heads, PrInfo};
+use crate::parsing::Group;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DesiredPrBase {
+    pub local_pr_number: usize,
+    pub stable_handle: String,
+    pub head_branch: String,
+    pub expected_base_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedOpenPrBase {
+    pub remote_pr_number: u64,
+    pub head_branch: String,
+    pub current_base_ref: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ObservedPrBaseChain {
+    by_head: HashMap<CanonicalBranchConflictKey, ObservedOpenPrBase>,
+}
+
+impl ObservedPrBaseChain {
+    pub fn from_open_prs(prs: Vec<PrInfo>) -> Self {
+        let by_head = prs
+            .into_iter()
+            .map(|pr| {
+                (
+                    canonical_branch_conflict_key(&pr.head),
+                    ObservedOpenPrBase {
+                        remote_pr_number: pr.number,
+                        head_branch: pr.head,
+                        current_base_ref: pr.base,
+                    },
+                )
+            })
+            .collect();
+        Self { by_head }
+    }
+
+    pub fn observe_for_heads(heads: &[String]) -> Result<Self> {
+        Ok(Self::from_open_prs(list_open_prs_for_heads(heads)?))
+    }
+
+    pub fn pr_numbers_by_head(&self) -> HashMap<CanonicalBranchConflictKey, u64> {
+        self.by_head
+            .iter()
+            .map(|(head, pr)| (head.clone(), pr.remote_pr_number))
+            .collect()
+    }
+
+    fn get_for_head(&self, head: &str) -> Option<&ObservedOpenPrBase> {
+        self.by_head.get(&canonical_branch_conflict_key(head))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BaseReconciliationAction {
+    AlreadyCorrect,
+    NeedsEdit,
+    MissingOpenPr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseReconciliationDecision {
+    pub desired: DesiredPrBase,
+    pub current_base_ref: Option<String>,
+    pub remote_pr_number: Option<u64>,
+    pub action: BaseReconciliationAction,
+}
+
+pub fn build_desired_pr_base_chain(
+    base: &str,
+    groups: &[Group],
+    prefix: &str,
+) -> Result<Vec<DesiredPrBase>> {
+    let branch_identities = group_branch_identities(groups, prefix)?;
+    let expected_by_head: HashMap<String, String> =
+        common::build_head_base_chain(base, groups, prefix)?
+            .into_iter()
+            .collect();
+
+    groups
+        .iter()
+        .zip(branch_identities)
+        .enumerate()
+        .map(|(group_idx, (group, identity))| {
+            let expected_base_ref = expected_by_head
+                .get(&identity.exact)
+                .cloned()
+                .unwrap_or_else(|| base.to_string());
+            Ok(DesiredPrBase {
+                local_pr_number: group_idx + 1,
+                stable_handle: common::group_selector_text(group),
+                head_branch: identity.exact,
+                expected_base_ref,
+            })
+        })
+        .collect()
+}
+
+pub fn plan_base_reconciliation(
+    desired_chain: &[DesiredPrBase],
+    observed_chain: &ObservedPrBaseChain,
+) -> Vec<BaseReconciliationDecision> {
+    desired_chain
+        .iter()
+        .map(|desired| {
+            if let Some(observed) = observed_chain.get_for_head(&desired.head_branch) {
+                let action = if sanitize_gh_base_ref(&observed.current_base_ref)
+                    == sanitize_gh_base_ref(&desired.expected_base_ref)
+                {
+                    BaseReconciliationAction::AlreadyCorrect
+                } else {
+                    BaseReconciliationAction::NeedsEdit
+                };
+                BaseReconciliationDecision {
+                    desired: desired.clone(),
+                    current_base_ref: Some(observed.current_base_ref.clone()),
+                    remote_pr_number: Some(observed.remote_pr_number),
+                    action,
+                }
+            } else {
+                BaseReconciliationDecision {
+                    desired: desired.clone(),
+                    current_base_ref: None,
+                    remote_pr_number: None,
+                    action: BaseReconciliationAction::MissingOpenPr,
+                }
+            }
+        })
+        .collect()
+}
+
+pub fn verify_base_edits_converged(
+    edited_head_branches: &[String],
+    decisions: &[BaseReconciliationDecision],
+) -> Result<()> {
+    let edited_heads = edited_head_branches
+        .iter()
+        .map(|head| canonical_branch_conflict_key(head))
+        .collect::<Vec<_>>();
+    let pending = decisions
+        .iter()
+        .filter(|decision| {
+            edited_heads.contains(&canonical_branch_conflict_key(
+                &decision.desired.head_branch,
+            )) && decision.action != BaseReconciliationAction::AlreadyCorrect
+        })
+        .map(|decision| {
+            format!(
+                "{}: {} -> {}",
+                decision.desired.head_branch,
+                decision.current_base_ref.as_deref().unwrap_or("<missing>"),
+                decision.desired.expected_base_ref
+            )
+        })
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "GitHub PR base chain did not converge after update: {}",
+            pending.join(", ")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_desired_pr_base_chain, plan_base_reconciliation, verify_base_edits_converged,
+        BaseReconciliationAction, ObservedPrBaseChain,
+    };
+    use crate::github::PrInfo;
+    use crate::parsing::Group;
+
+    fn groups(tags: &[&str]) -> Vec<Group> {
+        tags.iter()
+            .map(|tag| Group {
+                marker: crate::group_markers::GroupMarker::PrLabel(tag.to_string()),
+                subjects: vec![format!("feat: {tag}")],
+                commits: vec![format!("{tag}1")],
+                first_message: Some(format!("feat: {tag} pr:{tag}")),
+                ignored_after: Vec::new(),
+            })
+            .collect()
+    }
+
+    fn pr(number: u64, head: &str, base: &str) -> PrInfo {
+        PrInfo {
+            number,
+            head: head.to_string(),
+            base: base.to_string(),
+        }
+    }
+
+    #[test]
+    fn desired_chain_follows_local_group_order() {
+        let desired =
+            build_desired_pr_base_chain("main", &groups(&["alpha", "beta", "gamma"]), "spr/")
+                .unwrap();
+
+        assert_eq!(
+            desired
+                .iter()
+                .map(|row| (row.head_branch.as_str(), row.expected_base_ref.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("spr/alpha", "main"),
+                ("spr/beta", "spr/alpha"),
+                ("spr/gamma", "spr/beta"),
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_leaves_a_correct_chain_untouched() {
+        let desired =
+            build_desired_pr_base_chain("main", &groups(&["alpha", "beta", "gamma"]), "spr/")
+                .unwrap();
+        let observed = ObservedPrBaseChain::from_open_prs(vec![
+            pr(1, "spr/alpha", "main"),
+            pr(2, "spr/beta", "spr/alpha"),
+            pr(3, "spr/gamma", "spr/beta"),
+        ]);
+
+        assert_eq!(
+            plan_base_reconciliation(&desired, &observed)
+                .iter()
+                .map(|decision| decision.action)
+                .collect::<Vec<_>>(),
+            vec![
+                BaseReconciliationAction::AlreadyCorrect,
+                BaseReconciliationAction::AlreadyCorrect,
+                BaseReconciliationAction::AlreadyCorrect,
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_only_retargets_the_post_land_bottom_pr() {
+        let desired =
+            build_desired_pr_base_chain("main", &groups(&["beta", "gamma"]), "spr/").unwrap();
+        let observed = ObservedPrBaseChain::from_open_prs(vec![
+            pr(2, "spr/beta", "spr/alpha"),
+            pr(3, "spr/gamma", "spr/beta"),
+        ]);
+
+        assert_eq!(
+            plan_base_reconciliation(&desired, &observed)
+                .iter()
+                .map(|decision| decision.action)
+                .collect::<Vec<_>>(),
+            vec![
+                BaseReconciliationAction::NeedsEdit,
+                BaseReconciliationAction::AlreadyCorrect,
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_keeps_missing_open_prs_explicit() {
+        let desired =
+            build_desired_pr_base_chain("main", &groups(&["alpha", "beta"]), "spr/").unwrap();
+        let observed = ObservedPrBaseChain::from_open_prs(vec![pr(1, "spr/alpha", "main")]);
+
+        assert_eq!(
+            plan_base_reconciliation(&desired, &observed)
+                .iter()
+                .map(|decision| decision.action)
+                .collect::<Vec<_>>(),
+            vec![
+                BaseReconciliationAction::AlreadyCorrect,
+                BaseReconciliationAction::MissingOpenPr,
+            ]
+        );
+    }
+
+    #[test]
+    fn verification_ignores_missing_prs_that_were_not_edited() {
+        let desired =
+            build_desired_pr_base_chain("main", &groups(&["alpha", "beta"]), "spr/").unwrap();
+        let observed = ObservedPrBaseChain::from_open_prs(vec![pr(1, "spr/alpha", "main")]);
+        let decisions = plan_base_reconciliation(&desired, &observed);
+
+        verify_base_edits_converged(&["spr/alpha".to_string()], &decisions).unwrap();
+    }
+
+    #[test]
+    fn verification_rejects_edited_prs_that_stay_pending() {
+        let desired =
+            build_desired_pr_base_chain("main", &groups(&["alpha", "beta"]), "spr/").unwrap();
+        let observed = ObservedPrBaseChain::from_open_prs(vec![pr(1, "spr/alpha", "other")]);
+        let decisions = plan_base_reconciliation(&desired, &observed);
+
+        let err = verify_base_edits_converged(&["spr/alpha".to_string()], &decisions).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "GitHub PR base chain did not converge after update: spr/alpha: other -> main"
+        );
+    }
+
+    #[test]
+    fn verification_rejects_edited_prs_that_disappear() {
+        let desired = build_desired_pr_base_chain("main", &groups(&["alpha"]), "spr/").unwrap();
+        let observed = ObservedPrBaseChain::default();
+        let decisions = plan_base_reconciliation(&desired, &observed);
+
+        let err = verify_base_edits_converged(&["spr/alpha".to_string()], &decisions).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "GitHub PR base chain did not converge after update: spr/alpha: <missing> -> main"
+        );
+    }
+}


### PR DESCRIPTION
Mostly refactoring, with a small behavioral change.

- Refactor PR base-chain reconciliation into one shared owner for update and relink-prs
- and verify attempted GitHub base repairs actually converge/materialize before reporting success.

Move PR base-chain planning into one shared owner and make both `update` and `relink-prs` re-read edited PRs before accepting a repair. That keeps both commands on the same desired-vs-observed chain logic and rejects GitHub base edits that do not actually converge.

# Problem Solved

`update` and `relink-prs` were enforcing the same PR-base invariant through separate implementations. That duplicated the desired-chain logic, left room for the two commands to drift, and let a command assume an applied base edit had succeeded without proving that GitHub now reflected the intended chain.

# Mental model

The shared layer now models one desired local chain, one observed open-PR chain, and one reconciliation result for each PR head: already correct, needs an edit, or missing remotely. `update` and `relink-prs` keep their command-specific policies, but they evaluate the same base-chain state before and after mutations.

# Non-goals

- Route `land` through the shared high-level reconciler.
- Change which command may create missing PRs.
- Change stack identity, selector, or branch-naming semantics.

# Tradeoffs

The shared contract adds one focused abstraction and one extra GitHub read after actual base edits. That extra read only happens when a repair is attempted, and it buys a single invariant owner plus an explicit failure when GitHub does not converge.

# Architecture

`pr_base_chain` owns desired-chain construction, observed open-PR snapshots, reconciliation planning, and post-edit convergence checks. `update` still owns publication and PR creation, while `relink-prs` remains repair-only and maps the shared decisions back into its existing output shape.

# Observability

A non-converging repair now fails with the affected head branch and the observed-to-expected base transition, instead of silently treating the mutation as successful. Unedited missing PRs remain reportable without being confused with failed edits.

# Tests

Validation covered the shared planner, command-specific integration behavior, and the stale post-edit readback failure path:

- `cargo test`

<!-- spr-stack:start -->
**Stack**:
-   #140
-   #141
- ➡ #139

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->