### PR TITLE
feat: add adopt-prefix workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ Behavior:
 - `rollback` preserves the historical cleanup-on-conflict behavior and attempts to remove the temp restack worktree and branch (cleanup failures may require manual cleanup).
 - When restack suspends, resolve conflicts inside the printed temp worktree path, stage the resolution, and run the printed `spr resume <path>` command. Resolving in your original worktree does not advance the suspended cherry-pick.
 
+### spr adopt-prefix
+
+Use `spr adopt-prefix` after rewriting an already-live bottom prefix locally while keeping its explicit `pr:` and `branch:` selectors intact. Run it from the rewritten candidate checkout. SPR resolves the owning live stack from those selectors, verifies that the candidate is still the exact live bottom sequence, preserves the existing stack merge base, and rebuilds the remaining raw history above the adopted prefix.
+
+- The current checkout is the prefix source. The verified owning full-stack branch is the destination branch that gets moved.
+- The candidate checkout may be detached. The owning full-stack branch must not be checked out in another worktree while SPR moves it.
+- The selector sequence through `HEAD` must match an existing live bottom sequence exactly. This command does not also drop merged groups, reorder groups, or change the stack base.
+- Ignored blocks are allowed only when adoption leaves the publishable selector sequence unchanged.
+- `--preview` resolves and prints the plan without rewriting, creating backup tags, or touching GitHub.
+- With `--safe`, SPR creates a backup tag named like `backup/adopt-prefix/<owning-stack-branch>-<short-sha>` at the old owning stack tip first.
+- Before rewriting, `spr adopt-prefix` follows the shared `dirty_worktree` policy.
+- On cherry-pick conflict, `spr adopt-prefix` suspends the rewrite, leaves the temp worktree in place, and prints `spr resume <path>`.
+- This command is local-only. Inspect the rebuilt stack and run `spr update` when you are ready to publish the rewritten stack.
+
 ### spr drop-merged-prefix
 
 Drop the bottom local PR groups whose GitHub PRs already merged, without landing or updating any
@@ -328,7 +342,7 @@ metadata stored under the repository common Git directory:
 - The filename is a stable historical path; the JSON `schema_version` inside the file is the
   authoritative format version
 - Metadata is refreshed after successful `spr update`, `spr restack`,
-  `spr absorb`, `spr move`, `spr fix-pr`, `spr resume`, and `spr land` when it
+  `spr adopt-prefix`, `spr absorb`, `spr move`, `spr fix-pr`, `spr resume`, and `spr land` when it
   also finishes the local follow-on restack
 - Supported targets:
   - no argument: current branch
@@ -373,7 +387,7 @@ Behavior:
 ### spr resume
 
 Resume a suspended local rewrite from the exact path printed by `spr restack`,
-`spr absorb`, `spr move`, or `spr fix-pr`.
+`spr adopt-prefix`, `spr absorb`, `spr move`, or `spr fix-pr`.
 
 Behavior:
 
@@ -394,7 +408,7 @@ Machine-readable `--json` mode:
   output mode.
 - Supported on operational commands including `spr list pr`, `spr list commit`, `spr status`,
   `spr sync-local-branches`, `spr update`, `spr prep`, `spr relink-prs`, `spr cleanup`,
-  `spr restack`, `spr absorb`, `spr move`, `spr fix-pr`, `spr land`, `spr resume`, and
+  `spr restack`, `spr adopt-prefix`, `spr absorb`, `spr move`, `spr fix-pr`, `spr land`, `spr resume`, and
   `spr resolve-stack`
 - Also supported for display output: `spr --json --help`, `spr --help --json`,
   `spr --json help list commit`, `spr list commit --help --json`, `spr --json --version`, and
@@ -425,9 +439,16 @@ Machine-readable `--json` mode:
   a `data` object containing the local base ref/SHA, current branch/HEAD, selected dropped groups,
   remaining groups, ignored-segment count, planned cherry-pick operation count, operations that a
   real run would perform, and the checks not validated by preview
+- `spr adopt-prefix --preview --json` writes one preview object with `result: "preview"` and
+  a `data` object containing candidate HEAD/groups, owning stack ID/branch/old head, shared merge
+  base, replaced raw boundary, replay suffix groups, planned cherry-pick operation count,
+  publishable selectors before/after, execution side-effect booleans, and the checks not validated
+  by preview
 - `spr restack --json` without `--preview` keeps the rewrite lifecycle contract:
   it writes one completed or suspended object, not a preview object. Completed rewrite JSON includes
   `local_pr_branch_actions`, which is empty unless local per-PR branch sync is enabled.
+- `spr adopt-prefix --json` uses the same completed rewrite envelope and also includes
+  `destination_branch` on successful apply, naming the owning stack branch that was moved.
 - JSON errors across commands use one typed error envelope with `result: "error"` plus
   `error_kind` values such as `synthetic_branch_name_collision`, `invalid_arguments`, and
   `internal`
@@ -485,18 +506,21 @@ Fallback rewrite mental model:
 
 Suspend/resume flow:
 
-1. The original command (`spr restack`, `spr absorb`, `spr move`, or `spr fix-pr`) computes a replay plan for the rewritten stack.
+1. The original command (`spr restack`, `spr adopt-prefix`, `spr absorb`, `spr move`, or `spr fix-pr`) computes a replay plan for the rewritten stack.
 2. If that command uses the temp rewrite executor, `spr` creates a temp branch and temp worktree at the right base commit.
 3. `spr` starts replaying the plan as individual cherry-picks in that temp worktree.
 4. If Git reports a cherry-pick conflict, `spr` records the paused rewrite state in the resume file, including the temp worktree path, the original branch identity, the paused temp-worktree `HEAD`, and the index of the failed replay step.
-5. `spr` prints the temp worktree path, temp branch, original branch, and `spr resume <path>`, then leaves the temp worktree in place. The original branch has still not moved.
+5. `spr` prints the temp worktree path, temp branch, original branch, and `spr resume <path>`, then leaves the temp worktree in place. The recorded rewrite destination has still not moved.
 6. The user resolves only the current conflict in the printed temp worktree and stages the resolution with `git add`.
 7. The user runs `spr resume <path>` from any worktree in the same repository.
 8. `spr resume` reloads the checkpoint, validates that it still belongs to the current repository, validates that the temp worktree still exists, and then reconciles the paused step:
    - If `CHERRY_PICK_HEAD` is still present, `spr` continues that paused cherry-pick itself.
    - If `CHERRY_PICK_HEAD` is gone and the temp worktree advanced by exactly one commit, `spr` treats that as one accidental manual `git cherry-pick --continue` and resumes the remaining replay.
 9. `spr` then continues the remaining replay steps under `spr` control. If another conflict happens, it rewrites the same resume file with the new paused step and suspends again.
-10. Only after all replay steps succeed does `spr` reset the original branch to the rebuilt temp tip, remove the temp worktree and temp branch, and delete the resume file.
+10. Only after all replay steps succeed does `spr` finalize the recorded rewrite destination:
+   - Checked-out-branch rewrites reset the original branch to the rebuilt temp tip.
+   - Unchecked-out branch-ref rewrites such as `spr adopt-prefix` move that destination ref to the rebuilt temp tip while leaving the candidate checkout where it started.
+   In both cases, `spr` then removes the temp worktree and temp branch and deletes the resume file.
 
 Operator rules:
 

--- a/src/adopt_prefix_output.rs
+++ b/src/adopt_prefix_output.rs
@@ -1,0 +1,198 @@
+//! Output contract for read-only adopt-prefix previews.
+
+use serde::Serialize;
+
+use crate::json_output::{JsonCommand, JSON_OUTPUT_SCHEMA_VERSION};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdoptPrefixPreviewResult {
+    Preview,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AdoptPrefixPreviewOutput {
+    pub schema_version: u32,
+    pub command: JsonCommand,
+    pub result: AdoptPrefixPreviewResult,
+    pub data: AdoptPrefixPreviewData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AdoptPrefixPreviewGroup {
+    pub stable_handle: String,
+    pub commit_count: usize,
+    pub ignored_after_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AdoptPrefixPreviewData {
+    pub candidate_head: String,
+    pub candidate_groups: Vec<AdoptPrefixPreviewGroup>,
+    pub owning_stack_id: String,
+    pub owning_stack_branch: String,
+    pub old_stack_head: String,
+    pub merge_base: String,
+    pub replaced_old_boundary: String,
+    pub replay_suffix_groups: Vec<AdoptPrefixPreviewGroup>,
+    pub replay_operation_count: usize,
+    pub publishable_before: Vec<String>,
+    pub publishable_after: Vec<String>,
+    pub would_create_backup_tag: bool,
+    pub would_create_temp_worktree: bool,
+    pub would_move_stack_branch: bool,
+    pub would_refresh_stack_metadata: bool,
+    pub not_validated: Vec<String>,
+}
+
+pub fn preview(data: AdoptPrefixPreviewData) -> AdoptPrefixPreviewOutput {
+    AdoptPrefixPreviewOutput {
+        schema_version: JSON_OUTPUT_SCHEMA_VERSION,
+        command: JsonCommand::AdoptPrefix,
+        result: AdoptPrefixPreviewResult::Preview,
+        data,
+    }
+}
+
+impl AdoptPrefixPreviewOutput {
+    pub fn exit_code(&self) -> i32 {
+        crate::json_output::EXIT_SUCCESS
+    }
+
+    pub fn render_human(&self) -> String {
+        render_human_preview(&self.data)
+    }
+}
+
+fn render_groups(groups: &[AdoptPrefixPreviewGroup]) -> String {
+    if groups.is_empty() {
+        "<none>".to_string()
+    } else {
+        groups
+            .iter()
+            .map(|group| {
+                if group.ignored_after_count == 0 {
+                    format!("{} ({} commit(s))", group.stable_handle, group.commit_count)
+                } else {
+                    format!(
+                        "{} ({} commit(s), {} ignored after)",
+                        group.stable_handle, group.commit_count, group.ignored_after_count
+                    )
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
+fn render_selectors(selectors: &[String]) -> String {
+    if selectors.is_empty() {
+        "<none>".to_string()
+    } else {
+        selectors.join("; ")
+    }
+}
+
+pub fn render_human_preview(data: &AdoptPrefixPreviewData) -> String {
+    format!(
+        "Adopt-prefix preview:\n  candidate HEAD: {}\n  candidate prefix: {}\n  owning stack: {} on {} @ {}\n  shared merge base: {}\n  replace old raw boundary through: {}\n  replay suffix: {}\n  planned cherry-pick operations: {}\n  publishable before: {}\n  publishable after: {}\n  execution would: {}; {}; {}; {}\n  not validated by preview: {}",
+        data.candidate_head,
+        render_groups(&data.candidate_groups),
+        data.owning_stack_id,
+        data.owning_stack_branch,
+        data.old_stack_head,
+        data.merge_base,
+        data.replaced_old_boundary,
+        render_groups(&data.replay_suffix_groups),
+        data.replay_operation_count,
+        render_selectors(&data.publishable_before),
+        render_selectors(&data.publishable_after),
+        if data.would_create_backup_tag {
+            "create backup tag"
+        } else {
+            "skip backup tag"
+        },
+        if data.would_create_temp_worktree {
+            "create temp adopt-prefix worktree"
+        } else {
+            "skip temp adopt-prefix worktree"
+        },
+        if data.would_move_stack_branch {
+            "move owning stack branch"
+        } else {
+            "leave owning stack branch unchanged"
+        },
+        if data.would_refresh_stack_metadata {
+            "refresh stack metadata"
+        } else {
+            "leave stack metadata untouched"
+        },
+        data.not_validated.join("; ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        preview, render_human_preview, AdoptPrefixPreviewData, AdoptPrefixPreviewGroup,
+        AdoptPrefixPreviewResult,
+    };
+
+    fn sample_preview_data() -> AdoptPrefixPreviewData {
+        AdoptPrefixPreviewData {
+            candidate_head: "candidate123".to_string(),
+            candidate_groups: vec![AdoptPrefixPreviewGroup {
+                stable_handle: "pr:alpha".to_string(),
+                commit_count: 2,
+                ignored_after_count: 0,
+            }],
+            owning_stack_id: "stack-1".to_string(),
+            owning_stack_branch: "stack".to_string(),
+            old_stack_head: "stack123".to_string(),
+            merge_base: "base123".to_string(),
+            replaced_old_boundary: "alpha-old".to_string(),
+            replay_suffix_groups: vec![AdoptPrefixPreviewGroup {
+                stable_handle: "pr:beta".to_string(),
+                commit_count: 1,
+                ignored_after_count: 1,
+            }],
+            replay_operation_count: 2,
+            publishable_before: vec!["pr:alpha".to_string(), "pr:beta".to_string()],
+            publishable_after: vec!["pr:alpha".to_string(), "pr:beta".to_string()],
+            would_create_backup_tag: true,
+            would_create_temp_worktree: true,
+            would_move_stack_branch: true,
+            would_refresh_stack_metadata: true,
+            not_validated: vec!["cherry-pick conflicts".to_string()],
+        }
+    }
+
+    #[test]
+    fn adopt_prefix_preview_json_uses_preview_envelope() {
+        let output = preview(sample_preview_data());
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(output.result, AdoptPrefixPreviewResult::Preview);
+        assert_eq!(json["command"], "adopt-prefix");
+        assert_eq!(json["result"], "preview");
+        assert_eq!(
+            json["data"]["candidate_groups"][0]["stable_handle"],
+            "pr:alpha"
+        );
+        assert_eq!(
+            json["data"]["replay_suffix_groups"][0]["stable_handle"],
+            "pr:beta"
+        );
+    }
+
+    #[test]
+    fn adopt_prefix_preview_human_renderer_names_plan_and_guards() {
+        let rendered = render_human_preview(&sample_preview_data());
+
+        assert!(rendered.contains("Adopt-prefix preview:"));
+        assert!(rendered.contains("candidate prefix: pr:alpha (2 commit(s))"));
+        assert!(rendered.contains("owning stack: stack-1 on stack @ stack123"));
+        assert!(rendered.contains("publishable before: pr:alpha; pr:beta"));
+        assert!(rendered.contains("not validated by preview: cherry-pick conflicts"));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,6 +142,23 @@ pub enum Cmd {
         dry_run: DryRunArgs,
     },
 
+    /// Adopt rewritten lower-stack history as the new prefix of its live stack
+    #[command(
+        long_about = "Adopt rewritten lower-stack history as the new prefix of its existing live stack.\n\nRun this from a checkout whose committed history through `HEAD` is the rewritten bottom prefix you want to keep. `spr adopt-prefix` resolves the owning live stack from explicit `pr:` and `branch:` selectors, verifies that the candidate still represents the same live bottom sequence, then rebuilds the remaining raw history above the verified stack branch. Adoption preserves the verified live stack merge base and rejects candidates that would change the publishable selector sequence.\n\nThe candidate checkout is the prefix source, not the rebuilt destination branch. The verified owning full-stack branch must not be checked out in another worktree while adoption runs. `spr adopt-prefix` is local-only and does not update GitHub; run `spr update` after inspecting the result."
+    )]
+    AdoptPrefix {
+        /// Create a local backup tag at the old owning stack tip before rewriting
+        #[arg(long)]
+        safe: bool,
+
+        /// Print the resolved adoption plan and do not rewrite or publish
+        #[arg(long)]
+        preview: bool,
+
+        #[command(flatten)]
+        dry_run: DryRunArgs,
+    },
+
     /// Drop bottom PR groups whose GitHub PRs already merged, without landing or mutating PRs
     #[command(
         long_about = "Drop bottom PR groups whose GitHub PRs already merged, without landing or mutating PRs.\n\n`spr drop-merged-prefix` is local post-merge maintenance. It reads GitHub PR state, verifies each dropped PR's GitHub merge commit is contained in the configured SPR base, and then rewrites only the checked-out local stack.\n\nIt does not merge, close, retarget, comment on, or push GitHub PRs. After inspecting the rewritten stack, run `spr update` to publish remaining PR branch updates."
@@ -189,7 +206,7 @@ pub enum Cmd {
 
     /// Resume a suspended local rewrite from a resume-state file
     #[command(
-        long_about = "Resume a suspended local rewrite from a resume-state file.\n\nRun `spr resume <path>` with the exact path printed by `spr restack`, `spr absorb`, `spr move`, or `spr fix-pr` after a cherry-pick conflict. The supported workflow is: resolve the conflict in the printed temp rewrite worktree, stage the resolution, and then run the printed `spr resume <path>` command from any worktree in the same repository.\n\nThe resume file lives under the repository common Git directory, usually `.git/spr/resume/`. `spr resume` tolerates one accidental manual `git cherry-pick --continue` for the paused step, but broader manual replay edits are rejected."
+        long_about = "Resume a suspended local rewrite from a resume-state file.\n\nRun `spr resume <path>` with the exact path printed by `spr restack`, `spr adopt-prefix`, `spr absorb`, `spr move`, or `spr fix-pr` after a cherry-pick conflict. The supported workflow is: resolve the conflict in the printed temp rewrite worktree, stage the resolution, and then run the printed `spr resume <path>` command from any worktree in the same repository.\n\nThe resume file lives under the repository common Git directory, usually `.git/spr/resume/`. `spr resume` tolerates one accidental manual `git cherry-pick --continue` for the paused step, but broader manual replay edits are rejected."
     )]
     Resume {
         /// Explicit path to the suspended rewrite's resume-state JSON file
@@ -531,6 +548,26 @@ mod tests {
                 dry_run,
             } => {
                 assert_eq!(after.to_string(), "pr:alpha");
+                assert!(safe);
+                assert!(preview);
+                assert_eq!(ExecutionMode::from(dry_run), ExecutionMode::Apply);
+                assert_eq!(cli.output.format(), OutputFormat::Json);
+            }
+            other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn adopt_prefix_preview_flag_parses_with_json_and_safe() {
+        let cli =
+            Cli::try_parse_from(["spr", "adopt-prefix", "--safe", "--preview", "--json"]).unwrap();
+
+        match cli.cmd {
+            Cmd::AdoptPrefix {
+                safe,
+                preview,
+                dry_run,
+            } => {
                 assert!(safe);
                 assert!(preview);
                 assert_eq!(ExecutionMode::from(dry_run), ExecutionMode::Apply);

--- a/src/commands/adopt_prefix.rs
+++ b/src/commands/adopt_prefix.rs
@@ -1,0 +1,1020 @@
+//! Adopt rewritten lower-stack history as the new prefix of a live stack.
+
+use anyhow::{anyhow, bail, Result};
+use tracing::info;
+
+use crate::adopt_prefix_output::{AdoptPrefixPreviewData, AdoptPrefixPreviewGroup};
+use crate::commands::common::{self, CherryPickOp};
+use crate::commands::owning_stack;
+use crate::commands::rewrite_resume::{
+    self, RewriteCommandKind, RewriteCommandOutcome, RewriteConflictPolicy, RewriteDestinationKind,
+    RewriteSession,
+};
+use crate::config::DirtyWorktreePolicy;
+use crate::execution::ExecutionMode;
+use crate::git::{git_rev_parse, git_ro, git_rw};
+use crate::parsing::{
+    derive_groups_between_with_ignored, derive_local_groups_with_leading_commits,
+    split_groups_for_update, Group, ParsedGroups,
+};
+use crate::stack_metadata::{
+    build_snapshot_from_groups, preflight_snapshot_update, RefreshMetadataContext, StackId,
+};
+
+#[derive(Debug, Clone)]
+pub struct AdoptPrefixPlan {
+    pub candidate_head: String,
+    pub candidate_groups: Vec<Group>,
+    pub owning_stack_id: StackId,
+    pub owning_stack_branch: String,
+    pub old_stack_head: String,
+    pub merge_base: String,
+    pub replaced_old_boundary: String,
+    pub replay_suffix_groups: Vec<Group>,
+    pub operations: Vec<CherryPickOp>,
+    pub publishable_before: Vec<String>,
+    pub publishable_after: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptPrefixOutcome {
+    pub rewrite_outcome: RewriteCommandOutcome,
+    pub owning_stack_branch: String,
+}
+
+impl AdoptPrefixPlan {
+    fn preview_data(&self, safe_requested: bool) -> AdoptPrefixPreviewData {
+        AdoptPrefixPreviewData {
+            candidate_head: self.candidate_head.clone(),
+            candidate_groups: self.candidate_groups.iter().map(group_preview).collect(),
+            owning_stack_id: self.owning_stack_id.0.clone(),
+            owning_stack_branch: self.owning_stack_branch.clone(),
+            old_stack_head: self.old_stack_head.clone(),
+            merge_base: self.merge_base.clone(),
+            replaced_old_boundary: self.replaced_old_boundary.clone(),
+            replay_suffix_groups: self
+                .replay_suffix_groups
+                .iter()
+                .map(group_preview)
+                .collect(),
+            replay_operation_count: self.operations.len(),
+            publishable_before: self.publishable_before.clone(),
+            publishable_after: self.publishable_after.clone(),
+            would_create_backup_tag: safe_requested,
+            would_create_temp_worktree: !self.operations.is_empty(),
+            would_move_stack_branch: self.old_stack_head != self.candidate_head
+                || !self.operations.is_empty(),
+            would_refresh_stack_metadata: true,
+            not_validated: [
+                "cherry-pick conflicts",
+                "tests",
+                "pre-push hooks",
+                "GitHub mergeability",
+                "spr update result",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        }
+    }
+}
+
+fn group_preview(group: &Group) -> AdoptPrefixPreviewGroup {
+    AdoptPrefixPreviewGroup {
+        stable_handle: group.selector_text(),
+        commit_count: group.commits.len(),
+        ignored_after_count: group.ignored_after.len(),
+    }
+}
+
+fn publishable_selector_sequence(leading_ignored: &[String], groups: &[Group]) -> Vec<String> {
+    let (publishable, _skipped_handles) = split_groups_for_update(leading_ignored, groups.to_vec());
+    owning_stack::selector_sequence(&publishable)
+}
+
+fn ensure_exact_bottom_sequence(
+    candidate_selectors: &[String],
+    old_groups: &[Group],
+) -> Result<()> {
+    let old_prefix = owning_stack::selector_sequence(
+        old_groups
+            .get(..candidate_selectors.len())
+            .unwrap_or(old_groups),
+    );
+    if candidate_selectors.len() > old_groups.len() || old_prefix != candidate_selectors {
+        bail!(
+            "candidate selector sequence [{}] is not an exact bottom sequence of live stack [{}]",
+            candidate_selectors.join(", "),
+            owning_stack::selector_sequence(old_groups).join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn build_replay_suffix(
+    candidate_groups: &[Group],
+    old_groups: &[Group],
+) -> Result<(String, Vec<Group>, Vec<CherryPickOp>)> {
+    let matched_count = candidate_groups.len();
+    let old_boundary_group = old_groups
+        .get(matched_count.saturating_sub(1))
+        .ok_or_else(|| anyhow!("candidate prefix has no matching old boundary group"))?;
+    let candidate_trailing_ignored = candidate_groups
+        .last()
+        .map(|group| !group.ignored_after.is_empty())
+        .unwrap_or(false);
+    let replaced_old_boundary = if candidate_trailing_ignored {
+        old_boundary_group
+            .ignored_after
+            .last()
+            .cloned()
+            .unwrap_or_else(|| {
+                old_boundary_group
+                    .commits
+                    .last()
+                    .cloned()
+                    .expect("groups have at least one commit")
+            })
+    } else {
+        old_boundary_group
+            .commits
+            .last()
+            .cloned()
+            .expect("groups have at least one commit")
+    };
+
+    let replay_boundary_ignored = if candidate_trailing_ignored {
+        Vec::new()
+    } else {
+        old_boundary_group.ignored_after.clone()
+    };
+    let replay_suffix_groups = old_groups[matched_count..].to_vec();
+    let mut operations = Vec::new();
+    if let Some(operation) = CherryPickOp::from_commits(&replay_boundary_ignored) {
+        operations.push(operation);
+    }
+    for group in &replay_suffix_groups {
+        if let Some(operation) = CherryPickOp::from_commits(&group.commits) {
+            operations.push(operation);
+        }
+        if let Some(operation) = CherryPickOp::from_commits(&group.ignored_after) {
+            operations.push(operation);
+        }
+    }
+    Ok((replaced_old_boundary, replay_suffix_groups, operations))
+}
+
+fn build_post_adoption_groups(
+    candidate_groups: &[Group],
+    old_groups: &[Group],
+) -> Result<Vec<Group>> {
+    let mut groups = candidate_groups.to_vec();
+    let matched_count = groups.len();
+    let old_boundary_group = old_groups
+        .get(matched_count.saturating_sub(1))
+        .ok_or_else(|| anyhow!("candidate prefix has no matching old boundary group"))?;
+    if let Some(last_group) = groups.last_mut() {
+        if last_group.ignored_after.is_empty() {
+            last_group.ignored_after = old_boundary_group.ignored_after.clone();
+        }
+    }
+    groups.extend_from_slice(&old_groups[matched_count..]);
+    Ok(groups)
+}
+
+fn build_adopt_prefix_plan(metadata_context: &RefreshMetadataContext) -> Result<AdoptPrefixPlan> {
+    let (
+        candidate_merge_base,
+        ParsedGroups {
+            leading_ungrouped: candidate_leading_ungrouped,
+            leading_ignored: candidate_leading_ignored,
+            groups: candidate_groups,
+        },
+    ) = derive_local_groups_with_leading_commits(
+        &metadata_context.base,
+        &metadata_context.ignore_tag,
+    )?;
+    if !candidate_leading_ungrouped.is_empty() {
+        bail!(
+            "candidate history contains ungrouped commits before the first explicit selector; every adopted commit must belong to an explicit selector group"
+        );
+    }
+    let candidate_selectors = owning_stack::selector_sequence(&candidate_groups);
+    let resolved_stack = owning_stack::load_recorded_owning_stack_for_candidate_groups(
+        metadata_context,
+        &candidate_groups,
+    )?
+    .ok_or_else(|| anyhow!("no stack metadata recorded for this repository"))?;
+    let owning_stack_id = resolved_stack.stack_id;
+    let owning_stack_branch = resolved_stack.stack_branch;
+    let metadata = resolved_stack.metadata;
+    let branch_ref = format!("refs/heads/{owning_stack_branch}");
+    let old_stack_head = git_rev_parse(&branch_ref)?;
+    let (old_merge_base, old_leading_ignored, old_groups) = derive_groups_between_with_ignored(
+        &metadata_context.base,
+        &branch_ref,
+        &metadata_context.ignore_tag,
+    )?;
+    if candidate_merge_base != old_merge_base {
+        bail!(
+            "candidate history uses merge base {}, but live stack {} uses {}; use `spr restack` for base changes before adoption",
+            candidate_merge_base,
+            owning_stack_branch,
+            old_merge_base
+        );
+    }
+    ensure_exact_bottom_sequence(&candidate_selectors, &old_groups)?;
+    let publishable_before = publishable_selector_sequence(&old_leading_ignored, &old_groups);
+    let post_adoption_groups = build_post_adoption_groups(&candidate_groups, &old_groups)?;
+    let publishable_after =
+        publishable_selector_sequence(&candidate_leading_ignored, &post_adoption_groups);
+    if publishable_before != publishable_after {
+        bail!(
+            "adopting candidate prefix would change publishable selector sequence from [{}] to [{}]",
+            publishable_before.join(", "),
+            publishable_after.join(", ")
+        );
+    }
+    let candidate_head = git_rev_parse("HEAD")?;
+    let post_adoption_snapshot = build_snapshot_from_groups(
+        &owning_stack_branch,
+        &candidate_head,
+        &metadata_context.base,
+        &metadata_context.prefix,
+        &post_adoption_groups,
+    )?;
+    preflight_snapshot_update(&metadata, &post_adoption_snapshot)?;
+    let (replaced_old_boundary, replay_suffix_groups, operations) =
+        build_replay_suffix(&candidate_groups, &old_groups)?;
+    Ok(AdoptPrefixPlan {
+        candidate_head,
+        candidate_groups,
+        owning_stack_id,
+        owning_stack_branch,
+        old_stack_head,
+        merge_base: old_merge_base,
+        replaced_old_boundary,
+        replay_suffix_groups,
+        operations,
+        publishable_before,
+        publishable_after,
+    })
+}
+
+pub fn preview_adopt_prefix(
+    metadata_context: &RefreshMetadataContext,
+    safe_requested: bool,
+) -> Result<AdoptPrefixPreviewData> {
+    Ok(build_adopt_prefix_plan(metadata_context)?.preview_data(safe_requested))
+}
+
+fn move_branch_ref_to_candidate(
+    plan: &AdoptPrefixPlan,
+    metadata_context: &RefreshMetadataContext,
+    safe: bool,
+    execution_mode: ExecutionMode,
+) -> Result<()> {
+    owning_stack::ensure_branch_not_checked_out(&plan.owning_stack_branch)?;
+    let old_short = git_ro(["rev-parse", "--short", &plan.old_stack_head].as_slice())?
+        .trim()
+        .to_string();
+    if safe {
+        let _ = common::create_backup_tag_at(
+            execution_mode,
+            "adopt-prefix",
+            &plan.owning_stack_branch,
+            &old_short,
+            &plan.old_stack_head,
+        )?;
+    }
+    let branch_ref = format!("refs/heads/{}", plan.owning_stack_branch);
+    let _ = git_rw(
+        execution_mode,
+        [
+            "update-ref",
+            branch_ref.as_str(),
+            plan.candidate_head.as_str(),
+            plan.old_stack_head.as_str(),
+        ]
+        .as_slice(),
+    )?;
+    if execution_mode == ExecutionMode::Apply {
+        crate::stack_metadata::refresh_metadata_for_branch(
+            &rewrite_resume::current_repo_root()?,
+            &plan.owning_stack_branch,
+            metadata_context,
+            None,
+        )?;
+    }
+    Ok(())
+}
+
+pub fn adopt_prefix(
+    metadata_context: &RefreshMetadataContext,
+    safe: bool,
+    execution_mode: ExecutionMode,
+    dirty_worktree_policy: DirtyWorktreePolicy,
+) -> Result<AdoptPrefixOutcome> {
+    let plan = build_adopt_prefix_plan(metadata_context)?;
+    owning_stack::ensure_branch_not_checked_out(&plan.owning_stack_branch)?;
+    let rewrite_outcome = common::with_dirty_worktree_policy(
+        execution_mode,
+        "spr adopt-prefix",
+        dirty_worktree_policy,
+        |deferred_dirty_worktree_restore| {
+            if plan.operations.is_empty() {
+                move_branch_ref_to_candidate(&plan, metadata_context, safe, execution_mode)?;
+                info!(
+                    "Adopted {} group(s) onto {} without replaying a suffix.",
+                    plan.candidate_groups.len(),
+                    plan.owning_stack_branch
+                );
+                Ok(RewriteCommandOutcome::Completed)
+            } else {
+                let candidate_short = git_ro(["rev-parse", "--short", "HEAD"].as_slice())?
+                    .trim()
+                    .to_string();
+                let old_short = git_ro(["rev-parse", "--short", &plan.old_stack_head].as_slice())?
+                    .trim()
+                    .to_string();
+                let backup_tag = if safe {
+                    Some(common::create_backup_tag_at(
+                        execution_mode,
+                        "adopt-prefix",
+                        &plan.owning_stack_branch,
+                        &old_short,
+                        &plan.old_stack_head,
+                    )?)
+                } else {
+                    None
+                };
+                let resume_path = rewrite_resume::prepare_resume_path_for_new_session(
+                    execution_mode,
+                    RewriteCommandKind::AdoptPrefix,
+                    &plan.owning_stack_branch,
+                    &plan.old_stack_head,
+                )?;
+                let (tmp_path, tmp_branch) = common::create_temp_worktree(
+                    execution_mode,
+                    "adopt-prefix",
+                    &plan.candidate_head,
+                    &candidate_short,
+                )?;
+                let outcome = rewrite_resume::run_rewrite_session(
+                    execution_mode,
+                    RewriteSession {
+                        command_kind: RewriteCommandKind::AdoptPrefix,
+                        conflict_policy: RewriteConflictPolicy::Suspend,
+                        original_worktree_root: rewrite_resume::current_repo_root()?,
+                        original_branch: plan.owning_stack_branch.clone(),
+                        original_head: plan.old_stack_head.clone(),
+                        destination_kind: RewriteDestinationKind::UncheckedOutBranchRef,
+                        resume_path,
+                        temp_branch: tmp_branch,
+                        temp_worktree_path: tmp_path,
+                        backup_tag,
+                        operations: plan.operations.clone(),
+                        deferred_dirty_worktree_restore,
+                        post_success_hint: Some(
+                            "No GitHub changes were made. Run `spr update` after inspecting the rewritten stack."
+                                .to_string(),
+                        ),
+                        metadata_refresh_context: Some(metadata_context.clone()),
+                    },
+                )?;
+                if outcome == RewriteCommandOutcome::Completed {
+                    info!(
+                        "Adopted {} group(s) onto {} and replayed the remaining raw stack history.",
+                        plan.candidate_groups.len(),
+                        plan.owning_stack_branch
+                    );
+                }
+                Ok(outcome)
+            }
+        },
+    )?;
+    Ok(AdoptPrefixOutcome {
+        rewrite_outcome,
+        owning_stack_branch: plan.owning_stack_branch,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        adopt_prefix, build_post_adoption_groups, build_replay_suffix,
+        ensure_exact_bottom_sequence, preview_adopt_prefix, publishable_selector_sequence,
+    };
+    use crate::commands::RewriteCommandOutcome;
+    use crate::config::DirtyWorktreePolicy;
+    use crate::execution::ExecutionMode;
+    use crate::group_markers::GroupMarker;
+    use crate::parsing::Group;
+    use crate::stack_metadata::{refresh_metadata_for_branch, RefreshMetadataContext};
+    use crate::test_support::{commit_file, git, lock_cwd, DirGuard};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    fn group(tag: &str, ignored_after: &[&str]) -> Group {
+        Group {
+            marker: GroupMarker::PrLabel(tag.to_string()),
+            subjects: vec![format!("feat: {tag}")],
+            commits: vec![format!("{tag}1")],
+            first_message: Some(format!("feat: {tag}\n\npr:{tag}")),
+            ignored_after: ignored_after.iter().map(|sha| (*sha).to_string()).collect(),
+        }
+    }
+
+    fn metadata_context() -> RefreshMetadataContext {
+        RefreshMetadataContext {
+            base: "main".to_string(),
+            prefix: "dank-spr/".to_string(),
+            ignore_tag: "ignore".to_string(),
+        }
+    }
+
+    struct AdoptPrefixRepo {
+        _dir: TempDir,
+        repo: PathBuf,
+    }
+
+    impl AdoptPrefixRepo {
+        fn init() -> Self {
+            let dir = crate::test_support::init_repo();
+            let repo = dir.path().to_path_buf();
+            git(&repo, ["checkout", "-b", "stack"].as_slice());
+            commit_file(
+                &repo,
+                "alpha.txt",
+                "old-alpha-1\n",
+                "feat: alpha\n\npr:alpha",
+            );
+            commit_file(
+                &repo,
+                "alpha.txt",
+                "old-alpha-1\nold-alpha-2\n",
+                "feat: alpha follow-up",
+            );
+            commit_file(&repo, "beta.txt", "beta\n", "feat: beta\n\npr:beta");
+            commit_file(&repo, "gamma.txt", "gamma\n", "feat: gamma\n\npr:gamma");
+            refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &metadata_context(), None)
+                .unwrap();
+            git(&repo, ["checkout", "-b", "candidate", "main"].as_slice());
+            commit_file(
+                &repo,
+                "alpha.txt",
+                "new-alpha-1\n",
+                "feat: alpha rewritten\n\npr:alpha",
+            );
+            commit_file(
+                &repo,
+                "alpha.txt",
+                "new-alpha-1\nnew-alpha-2\n",
+                "feat: alpha rewritten follow-up",
+            );
+            Self { _dir: dir, repo }
+        }
+
+        fn with_cwd<T>(&self, f: impl FnOnce() -> T) -> T {
+            let _lock = lock_cwd();
+            let _guard = DirGuard::change_to(&self.repo);
+            f()
+        }
+    }
+
+    fn read_preview_side_effect_snapshot(repo: &Path) -> String {
+        [
+            git(repo, ["rev-parse", "HEAD"].as_slice()),
+            git(repo, ["branch", "--format=%(refname:short)"].as_slice()),
+            git(repo, ["tag", "--list"].as_slice()),
+            git(repo, ["worktree", "list", "--porcelain"].as_slice()),
+            fs::read_dir(repo.join(".git/spr/resume"))
+                .map(|entries| entries.count().to_string())
+                .unwrap_or_else(|_| "<no-resume-dir>".to_string()),
+        ]
+        .join("\n---\n")
+    }
+
+    #[test]
+    fn ensure_exact_bottom_sequence_rejects_reordered_candidate() {
+        let old = vec![group("alpha", &[]), group("beta", &[]), group("gamma", &[])];
+
+        let err =
+            ensure_exact_bottom_sequence(&["pr:alpha".to_string(), "pr:gamma".to_string()], &old)
+                .unwrap_err();
+
+        assert!(err.to_string().contains("not an exact bottom sequence"));
+    }
+
+    #[test]
+    fn build_replay_suffix_skips_replaced_trailing_ignored_block() {
+        let candidate = vec![group("alpha", &["candidate-ignore"])];
+        let old = vec![
+            group("alpha", &["old-ignore"]),
+            group("beta", &[]),
+            group("gamma", &[]),
+        ];
+
+        let (boundary, replay_groups, operations) = build_replay_suffix(&candidate, &old).unwrap();
+
+        assert_eq!(boundary, "old-ignore");
+        assert_eq!(replay_groups.len(), 2);
+        assert_eq!(operations.len(), 2);
+    }
+
+    #[test]
+    fn build_post_adoption_groups_preserves_old_ignore_when_candidate_ends_at_group_tip() {
+        let candidate = vec![group("alpha", &[])];
+        let old = vec![group("alpha", &["old-ignore"]), group("beta", &[])];
+
+        let groups = build_post_adoption_groups(&candidate, &old).unwrap();
+
+        assert_eq!(groups[0].ignored_after, vec!["old-ignore".to_string()]);
+        assert_eq!(
+            publishable_selector_sequence(&[], &groups),
+            vec!["pr:alpha".to_string()]
+        );
+    }
+
+    #[test]
+    fn adopt_prefix_rebuilds_descendants_on_rewritten_candidate_prefix() {
+        let repo = AdoptPrefixRepo::init();
+
+        repo.with_cwd(|| {
+            let candidate_head = git(&repo.repo, ["rev-parse", "HEAD"].as_slice())
+                .trim()
+                .to_string();
+            let outcome = adopt_prefix(
+                &metadata_context(),
+                false,
+                ExecutionMode::Apply,
+                DirtyWorktreePolicy::Halt,
+            )
+            .unwrap();
+
+            assert_eq!(outcome.rewrite_outcome, RewriteCommandOutcome::Completed);
+            assert_eq!(outcome.owning_stack_branch, "stack");
+            assert_eq!(
+                git(&repo.repo, ["rev-parse", "HEAD"].as_slice()).trim(),
+                candidate_head
+            );
+            assert_eq!(
+                git(
+                    &repo.repo,
+                    ["log", "--format=%s", "--reverse", "main..stack"].as_slice()
+                )
+                .lines()
+                .collect::<Vec<_>>(),
+                vec![
+                    "feat: alpha rewritten",
+                    "feat: alpha rewritten follow-up",
+                    "feat: beta",
+                    "feat: gamma",
+                ]
+            );
+            assert_eq!(
+                fs::read_to_string(repo.repo.join("alpha.txt")).unwrap(),
+                "new-alpha-1\nnew-alpha-2\n"
+            );
+        });
+    }
+
+    #[test]
+    fn preview_reports_plan_and_leaves_git_state_unchanged() {
+        let repo = AdoptPrefixRepo::init();
+
+        repo.with_cwd(|| {
+            let before = read_preview_side_effect_snapshot(&repo.repo);
+            let preview = preview_adopt_prefix(&metadata_context(), true).unwrap();
+
+            assert_eq!(preview.owning_stack_branch, "stack");
+            assert_eq!(preview.candidate_groups[0].stable_handle, "pr:alpha");
+            assert_eq!(preview.replay_suffix_groups.len(), 2);
+            assert!(preview.would_create_backup_tag);
+            assert!(preview.would_create_temp_worktree);
+            assert_eq!(read_preview_side_effect_snapshot(&repo.repo), before);
+        });
+    }
+
+    #[test]
+    fn preview_allows_owning_stack_branch_checked_out_elsewhere() {
+        let repo = AdoptPrefixRepo::init();
+
+        repo.with_cwd(|| {
+            let stack_worktree = repo.repo.join("stack-worktree");
+            git(
+                &repo.repo,
+                ["worktree", "add", stack_worktree.to_str().unwrap(), "stack"].as_slice(),
+            );
+
+            let preview = preview_adopt_prefix(&metadata_context(), false).unwrap();
+
+            assert_eq!(preview.owning_stack_branch, "stack");
+        });
+    }
+
+    #[test]
+    fn adopt_prefix_accepts_detached_candidate_head() {
+        let repo = AdoptPrefixRepo::init();
+
+        repo.with_cwd(|| {
+            git(&repo.repo, ["checkout", "--detach", "HEAD"].as_slice());
+
+            let outcome = adopt_prefix(
+                &metadata_context(),
+                false,
+                ExecutionMode::Apply,
+                DirtyWorktreePolicy::Halt,
+            )
+            .unwrap();
+
+            assert_eq!(outcome.rewrite_outcome, RewriteCommandOutcome::Completed);
+            assert_eq!(
+                git(&repo.repo, ["rev-parse", "--abbrev-ref", "HEAD"].as_slice()).trim(),
+                "HEAD"
+            );
+        });
+    }
+
+    #[test]
+    fn adopt_prefix_rejects_candidate_with_ungrouped_leading_commits() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "old-alpha\n", "feat: alpha\n\npr:alpha");
+        commit_file(repo, "beta.txt", "beta\n", "feat: beta\n\npr:beta");
+        refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &metadata_context(), None)
+            .unwrap();
+        let stack_before = git(repo, ["rev-parse", "stack"].as_slice());
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(repo, "scratch.txt", "scratch\n", "wip: local scratch");
+        commit_file(
+            repo,
+            "alpha.txt",
+            "new-alpha\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+
+        let err = adopt_prefix(
+            &metadata_context(),
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("ungrouped commits before the first explicit selector"));
+        assert_eq!(git(repo, ["rev-parse", "stack"].as_slice()), stack_before);
+    }
+
+    #[test]
+    fn adopt_prefix_preflights_post_adoption_snapshot_before_moving_stack_branch() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        let initial_context = RefreshMetadataContext {
+            base: "main".to_string(),
+            prefix: "x/".to_string(),
+            ignore_tag: "ignore".to_string(),
+        };
+        let adoption_context = RefreshMetadataContext {
+            base: "main".to_string(),
+            prefix: "other/".to_string(),
+            ignore_tag: "ignore".to_string(),
+        };
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "old-alpha\n", "feat: alpha\n\npr:alpha");
+        commit_file(
+            repo,
+            "other-alpha.txt",
+            "other-alpha\n",
+            "feat: other alpha\n\nbranch:other/alpha",
+        );
+        refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &initial_context, None)
+            .unwrap();
+        let stack_before = git(repo, ["rev-parse", "stack"].as_slice());
+        let metadata_path = repo.join(".git/spr/stack_metadata_v1.json");
+        let metadata_before = fs::read_to_string(&metadata_path).unwrap();
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "alpha.txt",
+            "new-alpha\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+
+        let err = adopt_prefix(
+            &adoption_context,
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("derive conflicting branch names"));
+        assert_eq!(git(repo, ["rev-parse", "stack"].as_slice()), stack_before);
+        assert_eq!(fs::read_to_string(metadata_path).unwrap(), metadata_before);
+    }
+
+    #[test]
+    fn adopt_prefix_uses_candidate_trailing_ignore_instead_of_replaying_old_ignore() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "old-alpha\n", "feat: alpha\n\npr:alpha");
+        commit_file(
+            repo,
+            "old-ignore.txt",
+            "old-ignore\n",
+            "local old ignore\n\npr:ignore",
+        );
+        commit_file(repo, "beta.txt", "beta\n", "feat: beta\n\npr:beta");
+        refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &metadata_context(), None)
+            .unwrap();
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "alpha.txt",
+            "new-alpha\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+        commit_file(
+            repo,
+            "candidate-ignore.txt",
+            "candidate-ignore\n",
+            "local candidate ignore\n\npr:ignore",
+        );
+
+        let outcome = adopt_prefix(
+            &metadata_context(),
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.rewrite_outcome, RewriteCommandOutcome::Completed);
+        assert_eq!(
+            git(
+                repo,
+                ["log", "--format=%s", "--reverse", "main..stack"].as_slice()
+            )
+            .lines()
+            .collect::<Vec<_>>(),
+            vec![
+                "feat: alpha rewritten",
+                "local candidate ignore",
+                "feat: beta",
+            ]
+        );
+    }
+
+    #[test]
+    fn adopt_prefix_accepts_existing_local_only_groups_after_ignored_boundary() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "old-alpha\n", "feat: alpha\n\npr:alpha");
+        commit_file(
+            repo,
+            "old-ignore.txt",
+            "old-ignore\n",
+            "local old ignore\n\npr:ignore",
+        );
+        commit_file(repo, "beta.txt", "old-beta\n", "feat: beta\n\npr:beta");
+        commit_file(repo, "gamma.txt", "gamma\n", "feat: gamma\n\npr:gamma");
+        refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &metadata_context(), None)
+            .unwrap();
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "alpha.txt",
+            "new-alpha\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+        commit_file(
+            repo,
+            "candidate-ignore.txt",
+            "candidate-ignore\n",
+            "local candidate ignore\n\npr:ignore",
+        );
+        commit_file(
+            repo,
+            "beta.txt",
+            "new-beta\n",
+            "feat: beta rewritten\n\npr:beta",
+        );
+
+        let outcome = adopt_prefix(
+            &metadata_context(),
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.rewrite_outcome, RewriteCommandOutcome::Completed);
+        assert_eq!(
+            git(
+                repo,
+                ["log", "--format=%s", "--reverse", "main..stack"].as_slice()
+            )
+            .lines()
+            .collect::<Vec<_>>(),
+            vec![
+                "feat: alpha rewritten",
+                "local candidate ignore",
+                "feat: beta rewritten",
+                "feat: gamma",
+            ]
+        );
+    }
+
+    #[test]
+    fn adopt_prefix_accepts_entirely_local_only_stack_when_publishability_is_unchanged() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(
+            repo,
+            "old-ignore.txt",
+            "old-ignore\n",
+            "local old ignore\n\npr:ignore",
+        );
+        commit_file(repo, "alpha.txt", "old-alpha\n", "feat: alpha\n\npr:alpha");
+        commit_file(repo, "beta.txt", "beta\n", "feat: beta\n\npr:beta");
+        refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &metadata_context(), None)
+            .unwrap();
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "candidate-ignore.txt",
+            "candidate-ignore\n",
+            "local candidate ignore\n\npr:ignore",
+        );
+        commit_file(
+            repo,
+            "alpha.txt",
+            "new-alpha\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+
+        let outcome = adopt_prefix(
+            &metadata_context(),
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.rewrite_outcome, RewriteCommandOutcome::Completed);
+        assert_eq!(
+            git(
+                repo,
+                ["log", "--format=%s", "--reverse", "main..stack"].as_slice()
+            )
+            .lines()
+            .collect::<Vec<_>>(),
+            vec![
+                "local candidate ignore",
+                "feat: alpha rewritten",
+                "feat: beta",
+            ]
+        );
+    }
+
+    #[test]
+    fn adopt_prefix_rejects_raw_prefix_that_matches_multiple_verified_stacks() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        for stack_branch in ["stack-a", "stack-b"] {
+            git(repo, ["checkout", "-b", stack_branch, "main"].as_slice());
+            commit_file(
+                repo,
+                &format!("{stack_branch}-ignore.txt"),
+                "ignore\n",
+                "local ignore\n\npr:ignore",
+            );
+            commit_file(
+                repo,
+                &format!("{stack_branch}-alpha.txt"),
+                "alpha\n",
+                "feat: alpha\n\npr:alpha",
+            );
+            refresh_metadata_for_branch(
+                repo.to_str().unwrap(),
+                stack_branch,
+                &metadata_context(),
+                None,
+            )
+            .unwrap();
+        }
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "candidate-ignore.txt",
+            "candidate-ignore\n",
+            "local candidate ignore\n\npr:ignore",
+        );
+        commit_file(
+            repo,
+            "alpha.txt",
+            "new-alpha\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+
+        let err = adopt_prefix(
+            &metadata_context(),
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("matches more than one verified stack history"));
+    }
+
+    #[test]
+    fn adopt_prefix_rejects_candidate_that_changes_publishable_sequence() {
+        let dir = crate::test_support::init_repo();
+        let repo = dir.path();
+        let _lock = lock_cwd();
+        let _guard = DirGuard::change_to(repo);
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "alpha\n", "feat: alpha\n\npr:alpha");
+        commit_file(repo, "beta.txt", "beta\n", "feat: beta\n\npr:beta");
+        commit_file(
+            repo,
+            "old-ignore.txt",
+            "ignore\n",
+            "local ignore\n\npr:ignore",
+        );
+        commit_file(repo, "gamma.txt", "gamma\n", "feat: gamma\n\npr:gamma");
+        refresh_metadata_for_branch(repo.to_str().unwrap(), "stack", &metadata_context(), None)
+            .unwrap();
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "alpha.txt",
+            "alpha rewritten\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+        commit_file(
+            repo,
+            "candidate-ignore.txt",
+            "candidate ignore\n",
+            "local candidate ignore\n\npr:ignore",
+        );
+
+        let err = adopt_prefix(
+            &metadata_context(),
+            false,
+            ExecutionMode::Apply,
+            DirtyWorktreePolicy::Halt,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("would change publishable selector sequence"));
+    }
+
+    #[test]
+    fn adopt_prefix_rejects_owning_stack_branch_checked_out_elsewhere() {
+        let repo = AdoptPrefixRepo::init();
+
+        repo.with_cwd(|| {
+            let stack_worktree = repo.repo.join("stack-worktree");
+            git(
+                &repo.repo,
+                ["worktree", "add", stack_worktree.to_str().unwrap(), "stack"].as_slice(),
+            );
+
+            let err = adopt_prefix(
+                &metadata_context(),
+                false,
+                ExecutionMode::Apply,
+                DirtyWorktreePolicy::Halt,
+            )
+            .unwrap_err();
+
+            assert!(err.to_string().contains("checked out in worktree"));
+        });
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod absorb;
+pub mod adopt_prefix;
 pub mod cleanup;
 pub mod common;
 pub mod drop_merged_prefix;
@@ -17,6 +18,7 @@ pub mod update;
 pub use absorb::{
     absorb_branch_tails, query_absorb_changed_branches, AbsorbOptions, CopiedLaterStackCommitPolicy,
 };
+pub use adopt_prefix::{adopt_prefix, preview_adopt_prefix};
 pub use cleanup::{cleanup_remote_branches, print_cleanup_summary};
 pub use drop_merged_prefix::drop_merged_prefix;
 pub use fix_pr::fix_pr_tail;

--- a/src/commands/rewrite_resume.rs
+++ b/src/commands/rewrite_resume.rs
@@ -62,6 +62,7 @@ pub enum RewriteCommandKind {
     Absorb,
     Move,
     FixPr,
+    AdoptPrefix,
 }
 
 impl RewriteCommandKind {
@@ -71,6 +72,7 @@ impl RewriteCommandKind {
             Self::Absorb => "absorb",
             Self::Move => "move",
             Self::FixPr => "fix-pr",
+            Self::AdoptPrefix => "adopt-prefix",
         }
     }
 
@@ -80,6 +82,7 @@ impl RewriteCommandKind {
             Self::Absorb => "spr absorb",
             Self::Move => "spr move",
             Self::FixPr => "spr fix-pr",
+            Self::AdoptPrefix => "spr adopt-prefix",
         }
     }
 }

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -15,6 +15,7 @@ pub enum JsonCommand {
     Help,
     Version,
     Restack,
+    AdoptPrefix,
     DropMergedPrefix,
     Absorb,
     Move,
@@ -303,6 +304,8 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
                 return JsonCommand::ListCommit;
             } else if arg == "restack" {
                 return JsonCommand::Restack;
+            } else if arg == "adopt-prefix" {
+                return JsonCommand::AdoptPrefix;
             } else if arg == "drop-merged-prefix" {
                 return JsonCommand::DropMergedPrefix;
             } else if arg == "absorb" {
@@ -599,6 +602,17 @@ mod tests {
         ];
 
         assert_eq!(command_for_raw_args(&args), JsonCommand::DropMergedPrefix);
+    }
+
+    #[test]
+    fn raw_args_detect_adopt_prefix_command() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("adopt-prefix"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(command_for_raw_args(&args), JsonCommand::AdoptPrefix);
     }
 
     #[test]

--- a/src/machine_output.rs
+++ b/src/machine_output.rs
@@ -19,6 +19,7 @@ pub enum MachineRewriteCommandKind {
     Absorb,
     Move,
     FixPr,
+    AdoptPrefix,
 }
 
 impl From<RewriteCommandKind> for MachineRewriteCommandKind {
@@ -28,6 +29,7 @@ impl From<RewriteCommandKind> for MachineRewriteCommandKind {
             RewriteCommandKind::Absorb => Self::Absorb,
             RewriteCommandKind::Move => Self::Move,
             RewriteCommandKind::FixPr => Self::FixPr,
+            RewriteCommandKind::AdoptPrefix => Self::AdoptPrefix,
         }
     }
 }
@@ -203,5 +205,33 @@ mod tests {
             }
             other => panic!("unexpected machine payload: {:?}", other),
         }
+    }
+
+    #[test]
+    fn completed_output_carries_destination_branch_when_present() {
+        let output = MachineOutput::completed_with_destination_branch(
+            MachineCommand::AdoptPrefix,
+            Some("stack".to_string()),
+            Vec::new(),
+        );
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["command"], "adopt-prefix");
+        assert_eq!(json["result"], "completed");
+        assert_eq!(json["destination_branch"], "stack");
+        assert_eq!(json["local_pr_branch_actions"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn completed_output_omits_destination_branch_when_absent() {
+        let output = MachineOutput::completed_with_local_pr_branch_actions(
+            MachineCommand::Restack,
+            Vec::new(),
+        );
+        let json = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["command"], "restack");
+        assert_eq!(json["result"], "completed");
+        assert!(json.get("destination_branch").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use crate::execution::ExecutionMode;
 
 mod absorb_output;
+mod adopt_prefix_output;
 mod branch_names;
 mod cli;
 mod commands;
@@ -72,6 +73,7 @@ fn resolve_update_pr_limit(
 fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
     match cmd {
         crate::cli::Cmd::Restack { .. }
+        | crate::cli::Cmd::AdoptPrefix { .. }
         | crate::cli::Cmd::Absorb { .. }
         | crate::cli::Cmd::Resume { .. }
         | crate::cli::Cmd::SyncLocalBranches
@@ -96,6 +98,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
 enum CommandOutput {
     None,
     AbsorbQuery(crate::absorb_output::AbsorbChangedBranchesOutput),
+    AdoptPrefixPreview(crate::adopt_prefix_output::AdoptPrefixPreviewOutput),
     Machine(crate::machine_output::MachineOutput),
     ReadOnly(crate::read_only_output::ReadOnlyOutput),
     RestackPreview(crate::restack_output::RestackPreviewOutput),
@@ -606,6 +609,57 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 )?))
             }
         }
+        crate::cli::Cmd::AdoptPrefix {
+            safe,
+            preview,
+            dry_run,
+        } => {
+            let execution_mode = ExecutionMode::from(dry_run);
+            set_dry_run_env(execution_mode, false);
+            if preview {
+                Ok(CommandOutput::AdoptPrefixPreview(
+                    crate::adopt_prefix_output::preview(crate::commands::preview_adopt_prefix(
+                        &metadata_refresh_context,
+                        safe,
+                    )?),
+                ))
+            } else {
+                let outcome = crate::commands::adopt_prefix(
+                    &metadata_refresh_context,
+                    safe,
+                    execution_mode,
+                    dirty_worktree_policy,
+                )?;
+                let (destination_branch, local_pr_branch_actions) = if outcome.rewrite_outcome
+                    == crate::commands::RewriteCommandOutcome::Completed
+                    && execution_mode == ExecutionMode::Apply
+                {
+                    let stack_ref = format!("refs/heads/{}", outcome.owning_stack_branch);
+                    let local_pr_branch_actions = sync_local_pr_branches_for_branch(
+                        local_pr_branch_policy,
+                        execution_mode,
+                        &base,
+                        &prefix,
+                        &ignore_tag,
+                        &stack_ref,
+                    )?;
+                    (
+                        Some(outcome.owning_stack_branch.clone()),
+                        local_pr_branch_actions,
+                    )
+                } else {
+                    (None, Vec::new())
+                };
+                Ok(CommandOutput::Machine(ensure_rewrite_completed(
+                    output_format,
+                    "spr adopt-prefix",
+                    crate::machine_output::MachineCommand::AdoptPrefix,
+                    outcome.rewrite_outcome,
+                    destination_branch,
+                    local_pr_branch_actions,
+                )?))
+            }
+        }
         crate::cli::Cmd::DropMergedPrefix { safe, dry_run } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, false);
@@ -1112,6 +1166,13 @@ fn main() {
                     println!("{}", output.render_human());
                 }
             }
+            CommandOutput::AdoptPrefixPreview(output) => {
+                if output_format == crate::cli::OutputFormat::Json {
+                    exit_with_json(&output, output.exit_code());
+                } else {
+                    println!("{}", output.render_human());
+                }
+            }
             CommandOutput::Machine(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
                     exit_with_json(&output, output.exit_code());
@@ -1167,6 +1228,7 @@ fn main() {
 fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonCommand {
     match cmd {
         crate::cli::Cmd::Restack { .. } => crate::machine_output::MachineCommand::Restack,
+        crate::cli::Cmd::AdoptPrefix { .. } => crate::machine_output::MachineCommand::AdoptPrefix,
         crate::cli::Cmd::DropMergedPrefix { .. } => {
             crate::machine_output::MachineCommand::DropMergedPrefix
         }
@@ -1194,8 +1256,9 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_working_directory_override, command_requires_gh, json_command_for_raw_args,
-        parse_failure_as_json_output, resolve_update_pr_limit, run_cli, CommandOutput,
+        apply_working_directory_override, command_requires_gh, ensure_rewrite_completed,
+        json_command_for_raw_args, parse_failure_as_json_output, resolve_update_pr_limit, run_cli,
+        CommandOutput,
     };
     use crate::cli::{DryRunArgs, OutputFormat};
     use crate::json_output::{ErrorPayload, JsonCommand, JsonError, EXIT_FAILURE};
@@ -1218,6 +1281,30 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process::Command;
     use tempfile::TempDir;
+
+    #[test]
+    fn completed_adopt_prefix_json_reports_destination_branch() {
+        let output = ensure_rewrite_completed(
+            OutputFormat::Json,
+            "spr adopt-prefix",
+            crate::machine_output::MachineCommand::AdoptPrefix,
+            crate::commands::RewriteCommandOutcome::Completed,
+            Some("stack".to_string()),
+            Vec::new(),
+        )
+        .unwrap();
+
+        match output.payload {
+            crate::machine_output::MachinePayload::Completed {
+                destination_branch,
+                local_pr_branch_actions,
+            } => {
+                assert_eq!(destination_branch.as_deref(), Some("stack"));
+                assert!(local_pr_branch_actions.is_empty());
+            }
+            other => panic!("unexpected machine payload: {:?}", other),
+        }
+    }
 
     struct CurrentDirGuard {
         original: PathBuf,
@@ -1336,6 +1423,15 @@ mod tests {
             from: None,
             allow_replayed_duplicates: false,
             query_changed_branches: false,
+            dry_run: DryRunArgs::default(),
+        }));
+    }
+
+    #[test]
+    fn adopt_prefix_is_local_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::AdoptPrefix {
+            safe: false,
+            preview: false,
             dry_run: DryRunArgs::default(),
         }));
     }
@@ -1491,10 +1587,63 @@ mod tests {
             .to_string()
     }
 
-    fn refresh_stack_metadata(repo: &Path) {
+    fn refresh_current_stack_metadata(repo: &Path) {
         let _guard = DirGuard::change_to(repo);
         crate::stack_metadata::refresh_metadata_for_current_checkout("main", "dank-spr/", "ignore")
             .unwrap();
+    }
+
+    fn refresh_stack_metadata(repo: &Path, branch: &str) {
+        crate::stack_metadata::refresh_metadata_for_branch(
+            repo.to_str().unwrap(),
+            branch,
+            &crate::stack_metadata::RefreshMetadataContext {
+                base: "main".to_string(),
+                prefix: "dank-spr/".to_string(),
+                ignore_tag: "ignore".to_string(),
+            },
+            None,
+        )
+        .unwrap();
+    }
+
+    fn init_adopt_prefix_conflict_repo() -> TempDir {
+        let dir = init_stack_repo();
+        let repo = dir.path();
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "story.txt", "alpha-old\n", "feat: alpha\n\npr:alpha");
+        commit_file(repo, "story.txt", "beta-old\n", "feat: beta\n\npr:beta");
+        refresh_stack_metadata(repo, "stack");
+        let alpha_tip = rev_parse(repo, "stack~1");
+        let beta_tip = rev_parse(repo, "stack");
+        git(repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        git(repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "story.txt",
+            "alpha-new\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+        dir
+    }
+
+    fn init_adopt_prefix_no_suffix_repo() -> TempDir {
+        let dir = init_stack_repo();
+        let repo = dir.path();
+        git(repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(repo, "alpha.txt", "alpha-old\n", "feat: alpha\n\npr:alpha");
+        refresh_stack_metadata(repo, "stack");
+        let alpha_tip = rev_parse(repo, "stack");
+        git(repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
+        git(repo, ["checkout", "-b", "candidate", "main"].as_slice());
+        commit_file(
+            repo,
+            "alpha.txt",
+            "alpha-new\n",
+            "feat: alpha rewritten\n\npr:alpha",
+        );
+        dir
     }
 
     fn prep_json_gh_script(log_path: &std::path::Path) -> String {
@@ -3033,7 +3182,7 @@ mod tests {
             .to_string();
         git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
         git(&repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
-        refresh_stack_metadata(&repo);
+        refresh_current_stack_metadata(&repo);
 
         git(&repo, ["checkout", "dank-spr/alpha"].as_slice());
         let alpha_tail = commit_file(
@@ -3139,7 +3288,7 @@ mod tests {
         let repo = dir.path().join("repo");
         let alpha_tip = rev_parse(&repo, "HEAD~1");
         git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
-        refresh_stack_metadata(&repo);
+        refresh_current_stack_metadata(&repo);
         git(&repo, ["checkout", "dank-spr/alpha"].as_slice());
         commit_file(
             &repo,
@@ -3215,7 +3364,7 @@ mod tests {
         let _restore = CurrentDirGuard::capture();
         let dir = init_update_stack_repo();
         let repo = dir.path().join("repo");
-        refresh_stack_metadata(&repo);
+        refresh_current_stack_metadata(&repo);
         git(&repo, ["checkout", "main"].as_slice());
         git(&repo, ["checkout", "-b", "unrelated"].as_slice());
         commit_file(
@@ -3255,7 +3404,7 @@ mod tests {
         let beta_tip = rev_parse(&repo, "HEAD");
         git(&repo, ["branch", "dank-spr/alpha", &alpha_tip].as_slice());
         git(&repo, ["branch", "dank-spr/beta", &beta_tip].as_slice());
-        refresh_stack_metadata(&repo);
+        refresh_current_stack_metadata(&repo);
 
         git(&repo, ["checkout", "dank-spr/alpha"].as_slice());
         let alpha_tail = commit_file(
@@ -3312,6 +3461,146 @@ mod tests {
         assert_eq!(rev_parse(&repo, "dank-spr/alpha"), alpha_tail);
         assert_ne!(rev_parse(&repo, "dank-spr/alpha"), rewritten_alpha_tip);
         assert_eq!(rev_parse(&repo, "dank-spr/beta"), rev_parse(&repo, "stack"));
+    }
+
+    #[test]
+    fn run_cli_resume_adopt_prefix_syncs_unchecked_out_destination_branch_after_conflict() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_adopt_prefix_conflict_repo();
+        let repo = repo.path();
+        let candidate_head = rev_parse(repo, "HEAD");
+        let old_stack_head = rev_parse(repo, "stack");
+        let adopt_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "adopt-prefix",
+            "--json",
+        ])
+        .unwrap();
+
+        let suspended = run_cli(adopt_cli, OutputFormat::Json).unwrap();
+        let (resume_file, temp_worktree) = match suspended {
+            CommandOutput::Machine(output) => match output.payload {
+                crate::machine_output::MachinePayload::Suspended { details } => {
+                    assert_eq!(details.original_branch, "stack");
+                    assert_eq!(details.conflicted_paths, vec!["story.txt".to_string()]);
+                    (
+                        PathBuf::from(details.resume_file),
+                        PathBuf::from(details.temp_worktree),
+                    )
+                }
+                other => panic!("unexpected machine payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        };
+        assert_eq!(rev_parse(repo, "stack"), old_stack_head);
+        write_file(&temp_worktree, "story.txt", "beta-resolved\n");
+        git(&temp_worktree, ["add", "story.txt"].as_slice());
+        let resume_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "resume",
+            "--json",
+            resume_file.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let resumed = run_cli(resume_cli, OutputFormat::Json).unwrap();
+
+        match resumed {
+            CommandOutput::Machine(output) => match output.payload {
+                crate::machine_output::MachinePayload::Completed {
+                    local_pr_branch_actions,
+                    ..
+                } => {
+                    assert_eq!(local_pr_branch_actions.len(), 2);
+                    assert_eq!(local_pr_branch_actions[0].stable_handle, "pr:alpha");
+                    assert_eq!(
+                        local_pr_branch_actions[0].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                    );
+                    assert_eq!(local_pr_branch_actions[1].stable_handle, "pr:beta");
+                    assert_eq!(
+                        local_pr_branch_actions[1].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                    );
+                }
+                other => panic!("unexpected machine payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+
+        let rewritten_stack_head = rev_parse(repo, "stack");
+        assert_ne!(rewritten_stack_head, old_stack_head);
+        assert_eq!(rev_parse(repo, "HEAD"), candidate_head);
+        assert_eq!(rev_parse(repo, "dank-spr/alpha"), candidate_head);
+        assert_eq!(rev_parse(repo, "dank-spr/beta"), rewritten_stack_head);
+        assert!(!resume_file.exists());
+    }
+
+    #[test]
+    fn run_cli_adopt_prefix_no_suffix_syncs_destination_branch_after_direct_ref_move() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_adopt_prefix_no_suffix_repo();
+        let repo = repo.path();
+        let candidate_head = rev_parse(repo, "HEAD");
+        let old_stack_head = rev_parse(repo, "stack");
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--local-pr-branches",
+            "create-or-update",
+            "adopt-prefix",
+            "--json",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Machine(output) => match output.payload {
+                crate::machine_output::MachinePayload::Completed {
+                    destination_branch,
+                    local_pr_branch_actions,
+                } => {
+                    assert_eq!(destination_branch.as_deref(), Some("stack"));
+                    assert_eq!(local_pr_branch_actions.len(), 1);
+                    assert_eq!(local_pr_branch_actions[0].stable_handle, "pr:alpha");
+                    assert_eq!(
+                        local_pr_branch_actions[0].action,
+                        crate::local_pr_branches::LocalPrBranchActionKind::Updated
+                    );
+                }
+                other => panic!("unexpected machine payload: {:?}", other),
+            },
+            other => panic!("unexpected command output: {:?}", other),
+        }
+
+        assert_ne!(candidate_head, old_stack_head);
+        assert_eq!(rev_parse(repo, "HEAD"), candidate_head);
+        assert_eq!(rev_parse(repo, "stack"), candidate_head);
+        assert_eq!(rev_parse(repo, "dank-spr/alpha"), candidate_head);
     }
 
     #[test]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -29,6 +29,17 @@ pub struct Group {
     pub ignored_after: Vec<String>,
 }
 
+/// Parsed PR groups plus any commits that appeared before the first group marker.
+#[derive(Debug, Clone)]
+pub struct ParsedGroups {
+    /// Ordinary commits before the first explicit selector.
+    pub leading_ungrouped: Vec<String>,
+    /// Explicit ignore-block commits before the first explicit selector.
+    pub leading_ignored: Vec<String>,
+    /// Parsed PR groups, oldest -> newest.
+    pub groups: Vec<Group>,
+}
+
 impl Group {
     pub fn selector_text(&self) -> String {
         self.marker.explicit_selector_text()
@@ -158,8 +169,7 @@ fn ensure_unique_group_markers(groups: &[Group]) -> Result<()> {
 ///
 /// Returns an error if any commit message contains more than one group marker.
 pub fn parse_groups(raw: &str, ignore_tag: &str) -> Result<Vec<Group>> {
-    let (_leading_ignored, groups) = parse_groups_with_ignored(raw, ignore_tag)?;
-    Ok(groups)
+    Ok(parse_groups_with_leading_commits(raw, ignore_tag)?.groups)
 }
 
 /// Parse a reversed git log stream into PR groups while retaining ignored commits.
@@ -172,10 +182,24 @@ pub fn parse_groups(raw: &str, ignore_tag: &str) -> Result<Vec<Group>> {
 ///
 /// Returns an error if any commit message contains more than one group marker.
 pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<String>, Vec<Group>)> {
+    let parsed = parse_groups_with_leading_commits(raw, ignore_tag)?;
+    Ok((parsed.leading_ignored, parsed.groups))
+}
+
+/// Parse a reversed git log stream into PR groups while retaining pre-group commits.
+///
+/// Ordinary ungrouped commits and explicit ignore-block commits that appear before the first group
+/// marker are kept separate so callers can decide whether each kind is valid for their workflow.
+///
+/// # Errors
+///
+/// Returns an error if any commit message contains more than one group marker.
+pub fn parse_groups_with_leading_commits(raw: &str, ignore_tag: &str) -> Result<ParsedGroups> {
     let mut groups: Vec<Group> = vec![];
     let mut current: Option<Group> = None;
     let mut ignoring = false;
     let mut ignored_block: Vec<String> = vec![];
+    let mut leading_ungrouped: Vec<String> = vec![];
     let mut leading_ignored: Vec<String> = vec![];
 
     let flush_current = |current: &mut Option<Group>, groups: &mut Vec<Group>| {
@@ -245,6 +269,7 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
             g.commits.push(sha);
         } else {
             warn!("Untagged commit before first group marker; ignored");
+            leading_ungrouped.push(sha);
         }
     }
     flush_current(&mut current, &mut groups);
@@ -252,7 +277,11 @@ pub fn parse_groups_with_ignored(raw: &str, ignore_tag: &str) -> Result<(Vec<Str
         flush_ignored(&mut ignored_block, &mut groups, &mut leading_ignored);
     }
     ensure_unique_group_markers(&groups)?;
-    Ok((leading_ignored, groups))
+    Ok(ParsedGroups {
+        leading_ungrouped,
+        leading_ignored,
+        groups,
+    })
 }
 
 /// Split parsed groups into the publishable update prefix and the local-only suffix.
@@ -330,6 +359,20 @@ pub fn derive_groups_between_with_ignored(
     to: &str,
     ignore_tag: &str,
 ) -> Result<(String, Vec<String>, Vec<Group>)> {
+    let (merge_base, parsed) = derive_groups_between_with_leading_commits(base, to, ignore_tag)?;
+    Ok((merge_base, parsed.leading_ignored, parsed.groups))
+}
+
+/// Derive PR groups plus pre-group commits from `merge-base(base, to)..to`.
+///
+/// # Errors
+///
+/// Returns errors from git commands or group parsing.
+pub fn derive_groups_between_with_leading_commits(
+    base: &str,
+    to: &str,
+    ignore_tag: &str,
+) -> Result<(String, ParsedGroups)> {
     let merge_base = git_ro(["merge-base", base, to].as_slice())?
         .trim()
         .to_string();
@@ -342,8 +385,8 @@ pub fn derive_groups_between_with_ignored(
         ]
         .as_slice(),
     )?;
-    let (leading_ignored, groups) = parse_groups_with_ignored(&lines, ignore_tag)?;
-    Ok((merge_base, leading_ignored, groups))
+    let parsed = parse_groups_with_leading_commits(&lines, ignore_tag)?;
+    Ok((merge_base, parsed))
 }
 
 /// Convenience: derive PR groups and leading ignored commits from merge-base(base, HEAD)..HEAD.
@@ -358,9 +401,24 @@ pub fn derive_local_groups_with_ignored(
     derive_groups_between_with_ignored(base, "HEAD", ignore_tag)
 }
 
+/// Convenience: derive PR groups plus pre-group commits from merge-base(base, HEAD)..HEAD.
+///
+/// # Errors
+///
+/// Returns errors from git commands or group parsing.
+pub fn derive_local_groups_with_leading_commits(
+    base: &str,
+    ignore_tag: &str,
+) -> Result<(String, ParsedGroups)> {
+    derive_groups_between_with_leading_commits(base, "HEAD", ignore_tag)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{parse_groups, parse_groups_with_ignored, split_groups_for_update};
+    use super::{
+        parse_groups, parse_groups_with_ignored, parse_groups_with_leading_commits,
+        split_groups_for_update,
+    };
 
     fn make_log(entries: &[(&str, &str)]) -> String {
         let mut out = String::new();
@@ -460,6 +518,20 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].bare_selector_text(), "alpha");
         assert!(groups[0].ignored_after.is_empty());
+    }
+
+    #[test]
+    fn parse_groups_with_leading_commits_tracks_ungrouped_prefix() {
+        let raw = make_log(&[
+            ("u1", "wip: local scratch"),
+            ("a1", "feat: alpha start pr:alpha"),
+        ]);
+        let parsed = parse_groups_with_leading_commits(&raw, "ignore").expect("parse_groups ok");
+
+        assert_eq!(parsed.leading_ungrouped, vec!["u1"]);
+        assert!(parsed.leading_ignored.is_empty());
+        assert_eq!(parsed.groups.len(), 1);
+        assert_eq!(parsed.groups[0].bare_selector_text(), "alpha");
     }
 
     #[test]

--- a/src/stack_metadata.rs
+++ b/src/stack_metadata.rs
@@ -23,7 +23,7 @@ use crate::git::{
     git_common_dir, git_common_dir_at, git_current_branch, git_current_branch_at,
     git_ref_exists_at, git_rev_parse_at, git_ro_in, repo_root,
 };
-use crate::parsing::{parse_groups_with_ignored, split_groups_for_update};
+use crate::parsing::{parse_groups_with_ignored, split_groups_for_update, Group};
 
 // TODO(2026-11-07): Drop schema v1 read compatibility after the six-month
 // migration window. Remove the `tag` serde aliases, legacy selector
@@ -618,7 +618,17 @@ pub fn build_snapshot_for_branch(
     )?;
     let (leading_ignored, parsed_groups) = parse_groups_with_ignored(&lines, ignore_tag)?;
     let (groups, _skipped_handles) = split_groups_for_update(&leading_ignored, parsed_groups);
-    let branch_identities = group_branch_identities(&groups, prefix)?;
+    build_snapshot_from_groups(stack_branch, &stack_head, base, prefix, &groups)
+}
+
+pub fn build_snapshot_from_groups(
+    stack_branch: &str,
+    stack_head: &str,
+    base: &str,
+    prefix: &str,
+    groups: &[Group],
+) -> Result<StackSnapshot> {
+    let branch_identities = group_branch_identities(groups, prefix)?;
     let groups =
         groups
             .iter()
@@ -643,11 +653,18 @@ pub fn build_snapshot_for_branch(
 
     Ok(StackSnapshot {
         stack_branch: StackBranchName(stack_branch.to_string()),
-        stack_head,
+        stack_head: stack_head.to_string(),
         base: base.to_string(),
         prefix: prefix.to_string(),
         groups,
     })
+}
+
+pub fn preflight_snapshot_update(
+    existing: &StackMetadataFile,
+    snapshot: &StackSnapshot,
+) -> Result<()> {
+    apply_snapshot(existing.clone(), snapshot, "preflight").map(|_| ())
 }
 
 pub fn build_snapshot_for_current_checkout(


### PR DESCRIPTION
Add `spr adopt-prefix` so an intentionally rewritten lower-stack prefix can replace the matching live bottom history without manually reconstructing the rest of the stack. The command proves the candidate belongs to exactly one live stack, preflights the post-adoption metadata snapshot, and only then rebuilds the owning stack branch above the adopted prefix.

# Problem Solved

SPR already knows how to restack or absorb changes, but it did not have a safe path for this workflow:

1. check out a live lower prefix,
2. rewrite that history intentionally,
3. adopt that rewritten prefix as the canonical bottom of the original stack, and
4. preserve the still-live stack suffix above it.

Without a dedicated command, that repair requires manual ref surgery or misuse of a neighboring workflow that does not own this contract. `spr adopt-prefix` makes the operation explicit and rejects ambiguous or unsafe candidates before any branch move.

# Mental model

- The current checkout is the replacement-prefix source.
- The verified owning full-stack branch is the destination ref that gets rebuilt.
- Explicit `pr:` / `branch:` selectors are the ownership proof; the candidate may be on a named branch or detached `HEAD`.
- The candidate selector sequence must match an exact live bottom sequence.
- Adoption preserves the existing stack merge base and publishable selector sequence, then replays the remaining raw suffix above the replacement prefix.

# Non-goals

- Do not change the stack base; `restack` owns base changes.
- Do not drop already-merged groups, reorder groups, or publish GitHub PRs as part of adoption.
- Do not infer ownership from checkout naming when explicit selectors are the canonical identity surface.

# Tradeoffs

This command is deliberately strict:

- It rejects ordinary ungrouped commits before the first explicit selector instead of adopting history that was never part of the ownership proof.
- It allows ignored blocks only when publishability is unchanged.
- It preflights the complete post-adoption metadata snapshot before ref movement, favoring atomic refusal over rollback after partial mutation.

Those checks narrow the accepted shape, but they keep "adopt this rewritten prefix" from silently changing which stack or which publishable PR sequence SPR is operating on.

# Architecture

This PR keeps the adopt-prefix-specific surface above the lower shared stack-resolution layer:

- `src/commands/adopt_prefix.rs` builds the adoption plan, validates the exact bottom sequence, preserves publishability, and drives replay.
- `src/adopt_prefix_output.rs` defines human and JSON preview output for the resolved plan.
- CLI, machine-output, metadata, resume, parsing, and README wiring expose the new command and its lifecycle consistently with the rest of SPR's rewrite commands.

The stacked parent PR provides the shared owning-stack resolution and rewrite plumbing that `adopt-prefix` consumes; this PR contains the command-specific planning, preview, safety policy, and execution behavior.

# Observability

`spr adopt-prefix --preview` reports the candidate prefix, owning stack, shared merge base, replaced boundary, replay suffix, publishable selectors before and after, and the mutations a real run would perform. JSON mode exposes the same plan shape, while successful apply output names the destination stack branch that moved.

That gives an operator a semantic preflight for a history rewrite that would otherwise be difficult to audit from raw Git state alone.

# Tests

Validation covered the adopt-prefix planner, suspended-resume behavior, and the full repository integration path:

- `cargo test adopt_prefix --tests`
- `cargo test resume --tests`
- `cargo test`

<!-- spr-stack:start -->
**Stack**:
-   #160
- ➡ #140

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
