### PR TITLE
config: read repo policy from the main worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Configuration
 spr reads configuration from YAML in two locations (repo overrides home):
 
 1. `$HOME/.spr_multicommit_cfg.yml`
-2. `<repo-root>/.spr_multicommit_cfg.yml`
+2. `<git-main-worktree-root>/.spr_multicommit_cfg.yml`
+
+When `spr` runs from a linked worktree, repository config still comes from Git's main worktree.
+A `.spr_multicommit_cfg.yml` that exists only in the linked worktree is ignored.
 
 Supported keys:
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -35,7 +35,7 @@ use tracing::{info, warn};
 
 use crate::config::DirtyWorktreePolicy;
 use crate::execution::ExecutionMode;
-use crate::git::{git_ro, git_rw, normalize_branch_name, repo_root};
+use crate::git::{git_ro, git_rw, repo_root, worktree_entries};
 use crate::parsing::Group;
 
 /// Returns the current branch name and the short SHA of `HEAD`.
@@ -170,53 +170,12 @@ pub fn run_native_rebase_with_abort(
     }
 }
 
-/// A single parsed entry from `git worktree list --porcelain`.
-///
-/// The `branch` value, when present, is normalized to a local branch name.
-#[derive(Debug, Clone)]
-struct WorktreeEntry {
-    path: String,
-    branch: Option<String>,
-}
-
-/// Lists worktrees in porcelain form and extracts their paths and branches.
-///
-/// We parse porcelain output to reliably determine whether a temp branch is
-/// currently checked out elsewhere, which must be resolved before deleting the
-/// branch.
-fn list_worktrees() -> Result<Vec<WorktreeEntry>> {
-    let out = git_ro(["worktree", "list", "--porcelain"].as_slice())?;
-    let mut entries: Vec<WorktreeEntry> = Vec::new();
-    let mut cur_path: Option<String> = None;
-    let mut cur_branch: Option<String> = None;
-
-    for line in out.lines() {
-        if let Some(rest) = line.strip_prefix("worktree ") {
-            if let Some(path) = cur_path.take() {
-                entries.push(WorktreeEntry {
-                    path,
-                    branch: cur_branch.take(),
-                });
-            }
-            cur_path = Some(rest.trim().to_string());
-            cur_branch = None;
-            continue;
-        }
-        if let Some(rest) = line.strip_prefix("branch ") {
-            if cur_path.is_some() {
-                cur_branch = Some(normalize_branch_name(rest.trim()));
-            }
-        }
-    }
-
-    if let Some(path) = cur_path.take() {
-        entries.push(WorktreeEntry {
-            path,
-            branch: cur_branch.take(),
-        });
-    }
-
-    Ok(entries)
+/// Returns the worktree path that currently has `branch` checked out, if any.
+pub fn checked_out_worktree_for_branch(branch: &str) -> Result<Option<String>> {
+    Ok(worktree_entries()?
+        .into_iter()
+        .find(|entry| entry.branch.as_deref() == Some(branch))
+        .map(|entry| entry.path))
 }
 
 /// Returns true when a local branch with the given name exists.
@@ -236,7 +195,7 @@ fn cleanup_existing_temp_state(
     tmp_path: &str,
     tmp_branch: &str,
 ) -> Result<()> {
-    let entries = list_worktrees()?;
+    let entries = worktree_entries()?;
     let mut removed_paths: HashSet<String> = HashSet::new();
 
     // If the temp branch is checked out in any worktree, remove those first

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -170,14 +170,6 @@ pub fn run_native_rebase_with_abort(
     }
 }
 
-/// Returns the worktree path that currently has `branch` checked out, if any.
-pub fn checked_out_worktree_for_branch(branch: &str) -> Result<Option<String>> {
-    Ok(worktree_entries()?
-        .into_iter()
-        .find(|entry| entry.branch.as_deref() == Some(branch))
-        .map(|entry| entry.path))
-}
-
 /// Returns true when a local branch with the given name exists.
 fn branch_exists(branch: &str) -> Result<bool> {
     let out = git_ro(["branch", "--list", branch].as_slice())?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Repository and user configuration for `spr`.
 //!
 //! Configuration is loaded from `$HOME/.spr_multicommit_cfg.yml` and then
-//! overridden by `<repo-root>/.spr_multicommit_cfg.yml` when present.
+//! overridden by `<git-main-worktree-root>/.spr_multicommit_cfg.yml` when present.
 
 use anyhow::{anyhow, Context, Result};
 use clap::ValueEnum;
@@ -251,7 +251,7 @@ pub fn load_config() -> Result<Config> {
     }
 
     // Repo config overrides home
-    if let Ok(Some(root)) = crate::git::repo_root() {
+    if let Some(root) = crate::git::main_worktree_root()? {
         let mut p = PathBuf::from(root);
         p.push(".spr_multicommit_cfg.yml");
         if let Some(repo_cfg) = read_config_file(&p)? {
@@ -266,12 +266,55 @@ pub fn load_config() -> Result<Config> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_overrides, default_config, normalize_config, normalize_prefix, read_config_file,
-        DirtyWorktreePolicy, FileConfig, LocalPrBranchSyncPolicy, PrDescriptionMode,
-        RestackConflictPolicy,
+        apply_overrides, default_config, load_config, normalize_config, normalize_prefix,
+        read_config_file, DirtyWorktreePolicy, FileConfig, LocalPrBranchSyncPolicy,
+        PrDescriptionMode, RestackConflictPolicy,
     };
+    use crate::test_support::{git, init_repo, lock_cwd, DirGuard};
+    use std::env;
     use std::fs;
+    use std::path::{Path, PathBuf};
     use tempfile::tempdir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            let old = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(old) = &self.old {
+                env::set_var(self.key, old);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn add_linked_worktree(repo: &Path) -> (tempfile::TempDir, PathBuf) {
+        let linked_parent = tempdir().unwrap();
+        let linked_path = linked_parent.path().join("linked-worktree");
+        git(repo, ["branch", "linked-config-test", "HEAD"].as_slice());
+        git(
+            repo,
+            [
+                "worktree",
+                "add",
+                linked_path.to_str().unwrap(),
+                "linked-config-test",
+            ]
+            .as_slice(),
+        );
+        (linked_parent, linked_path)
+    }
 
     #[test]
     fn read_config_file_allows_yaml_comments() {
@@ -377,6 +420,51 @@ restack_conflict: rollback
         let cfg = default_config();
 
         assert_eq!(cfg.local_pr_branches, LocalPrBranchSyncPolicy::Off);
+    }
+
+    #[test]
+    fn load_config_reads_main_worktree_repo_config_from_linked_worktree() {
+        let _lock = lock_cwd();
+        let home = tempdir().unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", home.path().display().to_string());
+        let repo_dir = init_repo();
+        let repo = repo_dir.path().to_path_buf();
+        fs::write(
+            repo.join(".spr_multicommit_cfg.yml"),
+            "base: origin/release-candidate\n",
+        )
+        .unwrap();
+        let (_linked_parent, linked_path) = add_linked_worktree(&repo);
+        fs::write(
+            linked_path.join(".spr_multicommit_cfg.yml"),
+            "base: origin/linked-worktree-only\n",
+        )
+        .unwrap();
+        let _guard = DirGuard::change_to(&linked_path);
+
+        let cfg = load_config().unwrap();
+
+        assert_eq!(cfg.base, "origin/release-candidate");
+    }
+
+    #[test]
+    fn load_config_ignores_linked_worktree_repo_config_without_main_repo_config() {
+        let _lock = lock_cwd();
+        let home = tempdir().unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", home.path().display().to_string());
+        let repo_dir = init_repo();
+        let repo = repo_dir.path().to_path_buf();
+        let (_linked_parent, linked_path) = add_linked_worktree(&repo);
+        fs::write(
+            linked_path.join(".spr_multicommit_cfg.yml"),
+            "base: origin/linked-worktree-only\n",
+        )
+        .unwrap();
+        let _guard = DirGuard::change_to(&linked_path);
+
+        let cfg = load_config().unwrap();
+
+        assert_eq!(cfg.base, "");
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -219,6 +219,69 @@ pub fn repo_root() -> Result<Option<String>> {
     }
 }
 
+/// A single parsed entry from `git worktree list --porcelain`.
+///
+/// Git reports the main worktree first. The `branch` value, when present, is
+/// normalized to a local branch name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeEntry {
+    pub path: String,
+    pub branch: Option<String>,
+}
+
+fn parse_worktree_list_porcelain(output: &str) -> Vec<WorktreeEntry> {
+    let mut entries = Vec::new();
+    let mut cur_path: Option<String> = None;
+    let mut cur_branch: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            if let Some(path) = cur_path.take() {
+                entries.push(WorktreeEntry {
+                    path,
+                    branch: cur_branch.take(),
+                });
+            }
+            cur_path = Some(rest.trim().to_string());
+            cur_branch = None;
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            if cur_path.is_some() {
+                cur_branch = Some(normalize_branch_name(rest.trim()));
+            }
+        }
+    }
+
+    if let Some(path) = cur_path {
+        entries.push(WorktreeEntry {
+            path,
+            branch: cur_branch,
+        });
+    }
+
+    entries
+}
+
+/// Lists the repository's worktrees in Git's stable porcelain order.
+pub fn worktree_entries() -> Result<Vec<WorktreeEntry>> {
+    let out = git_ro(["worktree", "list", "--porcelain"].as_slice())?;
+    Ok(parse_worktree_list_porcelain(&out))
+}
+
+/// Returns the Git main worktree root when the current process is in a worktree.
+///
+/// `git worktree list --porcelain` reports the main worktree first. That root
+/// is the canonical repository config surface shared by every linked worktree.
+pub fn main_worktree_root() -> Result<Option<String>> {
+    if repo_root()?.is_none() {
+        return Ok(None);
+    }
+
+    let Some(main_worktree) = worktree_entries()?.into_iter().next() else {
+        bail!("git worktree list --porcelain returned no worktrees");
+    };
+    Ok(Some(main_worktree.path))
+}
+
 fn canonicalize_existing_path(path: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(path)
         .with_context(|| format!("failed to canonicalize path {}", path.display()))
@@ -520,4 +583,35 @@ pub fn list_remote_branches_with_prefix(prefix: &str) -> Result<Vec<String>> {
         }
     }
     Ok(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_worktree_list_porcelain;
+
+    #[test]
+    fn parse_worktree_list_porcelain_preserves_main_worktree_first() {
+        let entries = parse_worktree_list_porcelain(
+            "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /tmp/repo-stack\nHEAD def456\nbranch refs/heads/stack\n\n",
+        );
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].path, "/repo");
+        assert_eq!(entries[0].branch.as_deref(), Some("main"));
+        assert_eq!(entries[1].path, "/tmp/repo-stack");
+        assert_eq!(entries[1].branch.as_deref(), Some("stack"));
+    }
+
+    #[test]
+    fn parse_worktree_list_porcelain_keeps_detached_entries() {
+        let entries = parse_worktree_list_porcelain(
+            "worktree /repo\nHEAD abc123\ndetached\n\nworktree /tmp/repo-stack\nHEAD def456\nbranch refs/heads/stack\n",
+        );
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].path, "/repo");
+        assert_eq!(entries[0].branch, None);
+        assert_eq!(entries[1].path, "/tmp/repo-stack");
+        assert_eq!(entries[1].branch.as_deref(), Some("stack"));
+    }
 }

--- a/src/local_pr_branches.rs
+++ b/src/local_pr_branches.rs
@@ -12,7 +12,7 @@ use tracing::info;
 use crate::branch_names::group_branch_name;
 use crate::config::LocalPrBranchSyncPolicy;
 use crate::execution::ExecutionMode;
-use crate::git::{git_is_ancestor, git_local_branch_tip, git_ro, git_rw};
+use crate::git::{git_is_ancestor, git_local_branch_tip, git_rw, worktree_entries};
 use crate::parsing::Group;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -268,12 +268,10 @@ fn backup_tag_for_non_fast_forward(
 }
 
 fn checked_out_local_branches() -> Result<HashSet<String>> {
-    let output = git_ro(["worktree", "list", "--porcelain"].as_slice())
-        .context("failed to list git worktrees")?;
-    Ok(output
-        .lines()
-        .filter_map(|line| line.strip_prefix("branch refs/heads/"))
-        .map(str::to_string)
+    Ok(worktree_entries()
+        .context("failed to list git worktrees")?
+        .into_iter()
+        .filter_map(|entry| entry.branch)
         .collect())
 }
 


### PR DESCRIPTION
Share repository-scoped .spr_multicommit_cfg.yml through Git's main worktree when spr runs from linked worktrees.

Ignore linked-worktree-only config files, factor Git worktree enumeration into one helper shared by existing consumers, and cover the new authority boundary with docs and regression tests.

<!-- spr-stack:start -->
**Stack**:
-   #140
-   #141
- ➡ #143

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->