### PR TITLE
github: split large GraphQL batches to avoid resource limits

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -46,6 +46,52 @@ fn resolve_landed_pr_segment<'a>(
     Ok((take_n, segment))
 }
 
+// Each older PR adds two mutative aliases: one comment and one close. GitHub does not publish a
+// safe alias count for this shape, so keep each write request deliberately small.
+const MAX_CLOSE_COMMENT_PRS_PER_MUTATION: usize = 3;
+
+fn build_land_merge_mutation(nth_id: &str, base: &str, mode: LandCmd) -> String {
+    let merge_method = match mode {
+        LandCmd::PerPr => "REBASE",
+        LandCmd::Flatten => "SQUASH",
+    };
+    format!(
+        "mutation {{b0: updatePullRequest(input:{{pullRequestId:\"{}\", baseRefName:\"{}\"}}){{ clientMutationId }} m0: mergePullRequest(input:{{pullRequestId:\"{}\", mergeMethod:{}}}){{ clientMutationId }} }}",
+        nth_id,
+        graphql_escape(&sanitize_gh_base_ref(base)),
+        nth_id,
+        merge_method,
+    )
+}
+
+fn build_close_comment_mutation(
+    prs: &[&crate::github::PrInfo],
+    ids_by_number: &HashMap<u64, String>,
+    merged_pr_number: u64,
+) -> Option<String> {
+    let mut mutation = String::from("mutation {");
+    let mut has_operations = false;
+    for (i, pr) in prs.iter().enumerate() {
+        let Some(id) = ids_by_number.get(&pr.number).filter(|id| !id.is_empty()) else {
+            continue;
+        };
+        has_operations = true;
+        let comment = format!("Merged as part of PR #{}", merged_pr_number);
+        mutation.push_str(&format!(
+            "c{}: addComment(input:{{subjectId:\"{}\", body:\"{}\"}}){{ clientMutationId }} ",
+            i,
+            id,
+            graphql_escape(&comment)
+        ));
+        mutation.push_str(&format!(
+            "x{}: closePullRequest(input:{{pullRequestId:\"{}\"}}){{ clientMutationId }} ",
+            i, id
+        ));
+    }
+    mutation.push('}');
+    has_operations.then_some(mutation)
+}
+
 pub fn land_until(
     base: &str,
     prefix: &str,
@@ -169,7 +215,7 @@ pub fn land_until(
         }
     }
 
-    // Batch: set base of Nth PR, merge it (rebase or squash), and close others with a comment via GraphQL
+    // Set base of Nth PR, merge it (rebase or squash), then close older PRs in bounded chunks.
     let nth = segment[take_n - 1];
     let mut nums: Vec<u64> = vec![nth.number];
     for pr in &segment[..take_n - 1] {
@@ -184,58 +230,30 @@ pub fn land_until(
         bail!("Failed to fetch GraphQL id for PR #{}", nth.number);
     }
 
-    let mut m = String::from("mutation {");
-    // Ensure base for nth
-    m.push_str(&format!(
-        "b0: updatePullRequest(input:{{pullRequestId:\"{}\", baseRefName:\"{}\"}}){{ clientMutationId }} ",
-        nth_id,
-        graphql_escape(&sanitize_gh_base_ref(base))
-    ));
-    if let LandCmd::PerPr = mode {
-        // Merge nth with REBASE
-        m.push_str(&format!(
-            "m0: mergePullRequest(input:{{pullRequestId:\"{}\", mergeMethod:REBASE}}){{ clientMutationId }} ",
-            nth_id
-        ));
-    } else {
-        // Merge nth with SQUASH
-        m.push_str(&format!(
-            "m0: mergePullRequest(input:{{pullRequestId:\"{}\", mergeMethod:SQUASH}}){{ clientMutationId }} ",
-            nth_id
-        ));
-    }
-    // Close others with a comment
-    for (i, pr) in segment[..take_n - 1].iter().enumerate() {
-        let id = bodies
-            .get(&pr.number)
-            .map(|x| x.id.clone())
-            .unwrap_or_default();
-        if id.is_empty() {
-            continue;
-        }
-        let idx = i + 1;
-        let comment = format!("Merged as part of PR #{}", nth.number);
-        m.push_str(&format!(
-            "c{}: addComment(input:{{subjectId:\"{}\", body:\"{}\"}}){{ clientMutationId }} ",
-            idx,
-            id,
-            graphql_escape(&comment)
-        ));
-        m.push_str(&format!(
-            "x{}: closePullRequest(input:{{pullRequestId:\"{}\"}}){{ clientMutationId }} ",
-            idx, id
-        ));
-    }
-    m.push('}');
+    let ids_by_number: HashMap<u64, String> = bodies
+        .iter()
+        .map(|(number, info)| (*number, info.id.clone()))
+        .collect();
     tracing::info!(
         "Merging PR #{} and closing {} other PR(s) on GitHub... this might take a few seconds.",
         nth.number,
         take_n - 1
     );
+    let merge_mutation = build_land_merge_mutation(&nth_id, base, mode);
     gh_rw(
         execution_mode,
-        ["api", "graphql", "-f", &format!("query={}", m)].as_slice(),
+        ["api", "graphql", "-f", &format!("query={}", merge_mutation)].as_slice(),
     )?;
+    for chunk in segment[..take_n - 1].chunks(MAX_CLOSE_COMMENT_PRS_PER_MUTATION) {
+        if let Some(close_mutation) =
+            build_close_comment_mutation(chunk, &ids_by_number, nth.number)
+        {
+            gh_rw(
+                execution_mode,
+                ["api", "graphql", "-f", &format!("query={}", close_mutation)].as_slice(),
+            )?;
+        }
+    }
 
     Ok(take_n)
 }
@@ -283,7 +301,10 @@ pub fn land_flatten_until(
 
 #[cfg(test)]
 mod tests {
-    use super::{land_until, resolve_land_take_count, resolve_landed_pr_segment};
+    use super::{
+        build_close_comment_mutation, build_land_merge_mutation, land_until,
+        resolve_land_take_count, resolve_landed_pr_segment,
+    };
     use crate::cli::LandCmd;
     use crate::execution::ExecutionMode;
     use crate::github::PrInfo;
@@ -397,5 +418,39 @@ mod tests {
                 .contains("pr:alpha and pr:Alpha derive conflicting branch names"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn land_merge_mutation_only_updates_and_merges_target_pr() {
+        let mutation = build_land_merge_mutation("PR_target", "origin/main", LandCmd::Flatten);
+
+        assert!(mutation.contains("updatePullRequest"));
+        assert!(mutation.contains("mergePullRequest"));
+        assert!(!mutation.contains("closePullRequest"));
+        assert!(!mutation.contains("addComment"));
+        assert!(mutation.contains("baseRefName:\"main\""));
+        assert!(mutation.contains("mergeMethod:SQUASH"));
+    }
+
+    #[test]
+    fn close_comment_mutation_only_closes_supplied_prs() {
+        let prs = [pr(1, "skilltest/alpha"), pr(2, "skilltest/beta")];
+        let ids = HashMap::from([(1, "PR_alpha".to_string()), (2, "PR_beta".to_string())]);
+
+        let mutation = build_close_comment_mutation(&[&prs[0]], &ids, 3).unwrap();
+
+        assert!(mutation.contains("PR_alpha"));
+        assert!(!mutation.contains("PR_beta"));
+        assert!(mutation.contains("Merged as part of PR #3"));
+        assert!(mutation.contains("addComment"));
+        assert!(mutation.contains("closePullRequest"));
+    }
+
+    #[test]
+    fn close_comment_mutation_skips_missing_and_empty_ids() {
+        let prs = [pr(1, "skilltest/alpha"), pr(2, "skilltest/beta")];
+        let ids = HashMap::from([(1, String::new())]);
+
+        assert!(build_close_comment_mutation(&[&prs[0], &prs[1]], &ids, 3).is_none());
     }
 }

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tracing::warn;
 
 use crate::branch_names::{canonical_branch_conflict_key, group_branch_identities};
@@ -7,8 +7,9 @@ use crate::cli::LandCmd;
 use crate::execution::ExecutionMode;
 use crate::git::{gh_rw, git_ro, git_rw, sanitize_gh_base_ref, to_remote_ref};
 use crate::github::{
-    fetch_pr_bodies_graphql, fetch_pr_ci_review_status, graphql_escape, list_open_prs_for_heads,
-    PrCiState, PrReviewDecision,
+    fetch_pr_bodies_graphql, fetch_pr_ci_review_status, fetch_pr_issue_comment_bodies_graphql,
+    graphql_escape, list_open_or_merged_prs_for_heads, PrCiState, PrInfoWithState,
+    PrReviewDecision, PrState,
 };
 use crate::parsing::derive_local_groups;
 use crate::selectors::{resolve_inclusive_count, InclusiveSelector};
@@ -20,20 +21,57 @@ fn resolve_land_take_count(
     resolve_inclusive_count(groups, until)
 }
 
-fn resolve_landed_pr_segment<'a>(
+#[derive(Debug)]
+enum LandPlan<'a> {
+    Fresh {
+        segment: Vec<&'a PrInfoWithState>,
+    },
+    Recovery {
+        target: &'a PrInfoWithState,
+        open_older_prs: Vec<&'a PrInfoWithState>,
+    },
+}
+
+fn resolve_land_plan<'a>(
     groups: &[crate::parsing::Group],
     branch_identities: &[crate::branch_names::GroupBranchIdentity],
-    prs_by_head: &HashMap<
-        crate::branch_names::CanonicalBranchConflictKey,
-        &'a crate::github::PrInfo,
-    >,
+    prs_by_head: &HashMap<crate::branch_names::CanonicalBranchConflictKey, &'a PrInfoWithState>,
     until: &InclusiveSelector,
-) -> Result<(usize, Vec<&'a crate::github::PrInfo>)> {
+) -> Result<(usize, LandPlan<'a>)> {
     let take_n = resolve_land_take_count(groups, until)?;
-    let mut segment: Vec<&crate::github::PrInfo> = Vec::with_capacity(take_n);
+    let target_identity = &branch_identities[take_n - 1];
+    let target = prs_by_head
+        .get(&target_identity.conflict_key)
+        .copied()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No open PR found for local group '{}' (branch '{}')",
+                groups[take_n - 1].selector_text(),
+                target_identity.exact
+            )
+        })?;
+    if target.state == PrState::Merged {
+        let open_older_prs = branch_identities[..take_n - 1]
+            .iter()
+            .filter_map(|identity| prs_by_head.get(&identity.conflict_key).copied())
+            .filter(|pr| pr.state == PrState::Open)
+            .collect();
+        return Ok((
+            take_n,
+            LandPlan::Recovery {
+                target,
+                open_older_prs,
+            },
+        ));
+    }
+    let mut segment = Vec::with_capacity(take_n);
     for (g, identity) in groups[..take_n].iter().zip(branch_identities.iter()) {
         let head_branch = &identity.exact;
-        if let Some(pr) = prs_by_head.get(&identity.conflict_key).copied() {
+        if let Some(pr) = prs_by_head
+            .get(&identity.conflict_key)
+            .copied()
+            .filter(|pr| pr.state == PrState::Open)
+        {
             segment.push(pr);
         } else {
             bail!(
@@ -43,7 +81,7 @@ fn resolve_landed_pr_segment<'a>(
             );
         }
     }
-    Ok((take_n, segment))
+    Ok((take_n, LandPlan::Fresh { segment }))
 }
 
 // Each older PR adds two mutative aliases: one comment and one close. GitHub does not publish a
@@ -64,10 +102,15 @@ fn build_land_merge_mutation(nth_id: &str, base: &str, mode: LandCmd) -> String 
     )
 }
 
+fn cleanup_comment(merged_pr_number: u64) -> String {
+    format!("Merged as part of PR #{merged_pr_number}")
+}
+
 fn build_close_comment_mutation(
-    prs: &[&crate::github::PrInfo],
+    prs: &[&PrInfoWithState],
     ids_by_number: &HashMap<u64, String>,
     merged_pr_number: u64,
+    add_comment_numbers: &HashSet<u64>,
 ) -> Option<String> {
     let mut mutation = String::from("mutation {");
     let mut has_operations = false;
@@ -76,13 +119,14 @@ fn build_close_comment_mutation(
             continue;
         };
         has_operations = true;
-        let comment = format!("Merged as part of PR #{}", merged_pr_number);
-        mutation.push_str(&format!(
-            "c{}: addComment(input:{{subjectId:\"{}\", body:\"{}\"}}){{ clientMutationId }} ",
-            i,
-            id,
-            graphql_escape(&comment)
-        ));
+        if add_comment_numbers.contains(&pr.number) {
+            mutation.push_str(&format!(
+                "c{}: addComment(input:{{subjectId:\"{}\", body:\"{}\"}}){{ clientMutationId }} ",
+                i,
+                id,
+                graphql_escape(&cleanup_comment(merged_pr_number))
+            ));
+        }
         mutation.push_str(&format!(
             "x{}: closePullRequest(input:{{pullRequestId:\"{}\"}}){{ clientMutationId }} ",
             i, id
@@ -90,6 +134,39 @@ fn build_close_comment_mutation(
     }
     mutation.push('}');
     has_operations.then_some(mutation)
+}
+
+struct LandMutationPlan<'a> {
+    base: &'a str,
+    mode: LandCmd,
+    target: &'a PrInfoWithState,
+    target_id: Option<&'a str>,
+    open_older_prs: &'a [&'a PrInfoWithState],
+    ids_by_number: &'a HashMap<u64, String>,
+    add_comment_numbers: &'a HashSet<u64>,
+}
+
+fn run_land_mutations<F>(plan: LandMutationPlan<'_>, mut run: F) -> Result<()>
+where
+    F: FnMut(String) -> Result<()>,
+{
+    if let Some(target_id) = plan.target_id {
+        run(build_land_merge_mutation(target_id, plan.base, plan.mode))?;
+    }
+    for chunk in plan
+        .open_older_prs
+        .chunks(MAX_CLOSE_COMMENT_PRS_PER_MUTATION)
+    {
+        if let Some(mutation) = build_close_comment_mutation(
+            chunk,
+            plan.ids_by_number,
+            plan.target.number,
+            plan.add_comment_numbers,
+        ) {
+            run(mutation)?;
+        }
+    }
+    Ok(())
 }
 
 pub fn land_until(
@@ -112,16 +189,70 @@ pub fn land_until(
         .iter()
         .map(|identity| identity.exact.clone())
         .collect();
-    let prs = list_open_prs_for_heads(&heads)?;
+    let prs = list_open_or_merged_prs_for_heads(&heads)?;
     let prs_by_head: HashMap<_, _> = prs
         .iter()
         .map(|pr| (canonical_branch_conflict_key(&pr.head), pr))
         .collect();
-    if prs.is_empty() {
-        bail!("No open PRs with head starting with `{prefix}`.");
-    }
-    let (_, ordered) = resolve_landed_pr_segment(&groups, &branch_identities, &prs_by_head, until)?;
-    let segment = ordered.as_slice();
+    let (_, plan) = resolve_land_plan(&groups, &branch_identities, &prs_by_head, until)?;
+    let LandPlan::Fresh { segment } = &plan else {
+        let LandPlan::Recovery {
+            target,
+            open_older_prs,
+        } = &plan
+        else {
+            unreachable!()
+        };
+        if open_older_prs.is_empty() {
+            tracing::info!(
+                "PR #{} is already merged and its older PR cleanup is complete.",
+                target.number
+            );
+            return Ok(take_n);
+        }
+        let numbers = open_older_prs
+            .iter()
+            .map(|pr| pr.number)
+            .collect::<Vec<_>>();
+        let bodies = fetch_pr_bodies_graphql(&numbers)?;
+        let ids_by_number = bodies
+            .iter()
+            .map(|(number, info)| (*number, info.id.clone()))
+            .collect::<HashMap<_, _>>();
+        let expected_comment = cleanup_comment(target.number);
+        let mut add_comment_numbers = std::collections::HashSet::new();
+        for pr in open_older_prs {
+            let comments = fetch_pr_issue_comment_bodies_graphql(pr.number)?;
+            if !comments.iter().any(|comment| comment == &expected_comment) {
+                add_comment_numbers.insert(pr.number);
+            }
+        }
+        tracing::info!(
+            "PR #{} is already merged; closing {} remaining older PR(s).",
+            target.number,
+            open_older_prs.len()
+        );
+        return run_land_mutations(
+            LandMutationPlan {
+                base,
+                mode,
+                target,
+                target_id: None,
+                open_older_prs,
+                ids_by_number: &ids_by_number,
+                add_comment_numbers: &add_comment_numbers,
+            },
+            |mutation| {
+                gh_rw(
+                    execution_mode,
+                    ["api", "graphql", "-f", &format!("query={mutation}")].as_slice(),
+                )?;
+                Ok(())
+            },
+        )
+        .map(|()| take_n);
+    };
+    let segment = segment.as_slice();
 
     // Safety validation: CI and Reviews must be passing/approved for all PRs being landed
     let numbers: Vec<u64> = segment.iter().map(|p| p.number).collect();
@@ -239,21 +370,28 @@ pub fn land_until(
         nth.number,
         take_n - 1
     );
-    let merge_mutation = build_land_merge_mutation(&nth_id, base, mode);
-    gh_rw(
-        execution_mode,
-        ["api", "graphql", "-f", &format!("query={}", merge_mutation)].as_slice(),
-    )?;
-    for chunk in segment[..take_n - 1].chunks(MAX_CLOSE_COMMENT_PRS_PER_MUTATION) {
-        if let Some(close_mutation) =
-            build_close_comment_mutation(chunk, &ids_by_number, nth.number)
-        {
+    let add_comment_numbers = segment[..take_n - 1]
+        .iter()
+        .map(|pr| pr.number)
+        .collect::<std::collections::HashSet<_>>();
+    run_land_mutations(
+        LandMutationPlan {
+            base,
+            mode,
+            target: nth,
+            target_id: Some(&nth_id),
+            open_older_prs: &segment[..take_n - 1],
+            ids_by_number: &ids_by_number,
+            add_comment_numbers: &add_comment_numbers,
+        },
+        |mutation| {
             gh_rw(
                 execution_mode,
-                ["api", "graphql", "-f", &format!("query={}", close_mutation)].as_slice(),
+                ["api", "graphql", "-f", &format!("query={mutation}")].as_slice(),
             )?;
-        }
-    }
+            Ok(())
+        },
+    )?;
 
     Ok(take_n)
 }
@@ -302,12 +440,13 @@ pub fn land_flatten_until(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_close_comment_mutation, build_land_merge_mutation, land_until,
-        resolve_land_take_count, resolve_landed_pr_segment,
+        build_close_comment_mutation, build_land_merge_mutation, land_until, resolve_land_plan,
+        resolve_land_take_count, run_land_mutations, LandMutationPlan, LandPlan,
     };
+    use crate::branch_names::canonical_branch_conflict_key;
     use crate::cli::LandCmd;
     use crate::execution::ExecutionMode;
-    use crate::github::PrInfo;
+    use crate::github::{PrInfoWithState, PrState};
     use crate::parsing::Group;
     use crate::selectors::{ExplicitGroupSelector, GroupSelector, InclusiveSelector};
     use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
@@ -325,11 +464,20 @@ mod tests {
             .collect()
     }
 
-    fn pr(number: u64, head: &str) -> PrInfo {
-        PrInfo {
+    fn pr(number: u64, head: &str) -> PrInfoWithState {
+        PrInfoWithState {
             number,
             head: head.to_string(),
             base: "main".to_string(),
+            state: PrState::Open,
+            url: format!("https://github.com/o/r/pull/{number}"),
+        }
+    }
+
+    fn merged_pr(number: u64, head: &str) -> PrInfoWithState {
+        PrInfoWithState {
+            state: PrState::Merged,
+            ..pr(number, head)
         }
     }
 
@@ -361,12 +509,15 @@ mod tests {
         let until = InclusiveSelector::Group(GroupSelector::LocalPr(1));
 
         let (take_n, ordered) =
-            resolve_landed_pr_segment(&groups, &branch_identities, &prs_by_head, &until).unwrap();
+            resolve_land_plan(&groups, &branch_identities, &prs_by_head, &until).unwrap();
 
         assert_eq!(take_n, 1);
-        assert_eq!(ordered.len(), 1);
-        assert_eq!(ordered[0].number, 14);
-        assert_eq!(ordered[0].head, "skilltest/rho");
+        let LandPlan::Fresh { segment } = ordered else {
+            panic!("expected fresh land plan");
+        };
+        assert_eq!(segment.len(), 1);
+        assert_eq!(segment[0].number, 14);
+        assert_eq!(segment[0].head, "skilltest/rho");
     }
 
     #[test]
@@ -386,8 +537,7 @@ mod tests {
             .collect();
         let until = InclusiveSelector::Group(GroupSelector::LocalPr(2));
 
-        let err = resolve_landed_pr_segment(&groups, &branch_identities, &prs_by_head, &until)
-            .unwrap_err();
+        let err = resolve_land_plan(&groups, &branch_identities, &prs_by_head, &until).unwrap_err();
 
         assert_eq!(
             err.to_string(),
@@ -437,7 +587,13 @@ mod tests {
         let prs = [pr(1, "skilltest/alpha"), pr(2, "skilltest/beta")];
         let ids = HashMap::from([(1, "PR_alpha".to_string()), (2, "PR_beta".to_string())]);
 
-        let mutation = build_close_comment_mutation(&[&prs[0]], &ids, 3).unwrap();
+        let mutation = build_close_comment_mutation(
+            &[&prs[0]],
+            &ids,
+            3,
+            &std::collections::HashSet::from([1]),
+        )
+        .unwrap();
 
         assert!(mutation.contains("PR_alpha"));
         assert!(!mutation.contains("PR_beta"));
@@ -451,6 +607,105 @@ mod tests {
         let prs = [pr(1, "skilltest/alpha"), pr(2, "skilltest/beta")];
         let ids = HashMap::from([(1, String::new())]);
 
-        assert!(build_close_comment_mutation(&[&prs[0], &prs[1]], &ids, 3).is_none());
+        assert!(build_close_comment_mutation(
+            &[&prs[0], &prs[1]],
+            &ids,
+            3,
+            &std::collections::HashSet::from([1, 2]),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn recovery_plan_skips_merge_and_closes_only_remaining_open_prs() {
+        let groups = groups(&["alpha", "beta", "gamma"]);
+        let branch_identities =
+            crate::branch_names::group_branch_identities(&groups, "skilltest/").unwrap();
+        let prs = [
+            pr(1, "skilltest/alpha"),
+            merged_pr(2, "skilltest/beta"),
+            merged_pr(3, "skilltest/gamma"),
+        ];
+        let prs_by_head = prs
+            .iter()
+            .map(|pr| (canonical_branch_conflict_key(&pr.head), pr))
+            .collect();
+
+        let (_, plan) = resolve_land_plan(
+            &groups,
+            &branch_identities,
+            &prs_by_head,
+            &InclusiveSelector::All,
+        )
+        .unwrap();
+        let LandPlan::Recovery {
+            target,
+            open_older_prs,
+        } = plan
+        else {
+            panic!("expected recovery plan");
+        };
+
+        assert_eq!(target.number, 3);
+        assert_eq!(
+            open_older_prs
+                .iter()
+                .map(|pr| pr.number)
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn partial_land_retry_skips_merge_and_does_not_duplicate_comment() {
+        let target = pr(3, "skilltest/gamma");
+        let older = pr(1, "skilltest/alpha");
+        let ids = HashMap::from([(1, "PR_alpha".to_string()), (3, "PR_gamma".to_string())]);
+        let comments = std::collections::HashSet::from([1]);
+        let mut first_calls = Vec::new();
+        let err = run_land_mutations(
+            LandMutationPlan {
+                base: "main",
+                mode: LandCmd::Flatten,
+                target: &target,
+                target_id: Some("PR_gamma"),
+                open_older_prs: &[&older],
+                ids_by_number: &ids,
+                add_comment_numbers: &comments,
+            },
+            |mutation| {
+                first_calls.push(mutation);
+                if first_calls.len() == 2 {
+                    anyhow::bail!("transient cleanup failure");
+                }
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("transient cleanup failure"));
+        assert!(first_calls[0].contains("mergePullRequest"));
+
+        let mut retry_calls = Vec::new();
+        run_land_mutations(
+            LandMutationPlan {
+                base: "main",
+                mode: LandCmd::Flatten,
+                target: &target,
+                target_id: None,
+                open_older_prs: &[&older],
+                ids_by_number: &ids,
+                add_comment_numbers: &std::collections::HashSet::new(),
+            },
+            |mutation| {
+                retry_calls.push(mutation);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(retry_calls.len(), 1);
+        assert!(!retry_calls[0].contains("mergePullRequest"));
+        assert!(!retry_calls[0].contains("addComment"));
+        assert!(retry_calls[0].contains("closePullRequest"));
     }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -13,7 +13,7 @@ use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
 use crate::execution::ExecutionMode;
 use crate::git::{get_remote_branches_sha, gh_rw, git_is_ancestor, git_rw, sanitize_gh_base_ref};
 use crate::github::{
-    fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape,
+    fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape, is_resource_limit_error,
     list_recent_terminal_prs_for_heads, upsert_pr_cached, TerminalPrState,
 };
 use crate::limit::{apply_limit_groups, Limit};
@@ -280,12 +280,6 @@ fn should_use_single_update_mutation(
     prefer_single
         && update_inputs.len() <= max_ops
         && mutation_len_for_inputs(update_inputs) <= max_chars
-}
-
-fn is_resource_limit_error(err: &anyhow::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("RESOURCE_LIMITS_EXCEEDED")
-        || msg.contains("Resource limits for this query exceeded")
 }
 
 fn run_update_chunk(execution_mode: ExecutionMode, update_inputs: &[String]) -> Result<()> {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -187,6 +187,9 @@ fn enforce_branch_reuse_guard(
     }
 }
 
+// GitHub does not publish a safe alias count for batched mutations. Base edits are small and retry
+// by bisection on RESOURCE_LIMITS_EXCEEDED; body edits remain one-per-request because body size is
+// user-controlled.
 const MAX_BASE_UPDATES_PER_MUTATION: usize = 50;
 const MAX_BASE_MUTATION_CHARS: usize = 20_000;
 const MAX_BODY_UPDATES_PER_MUTATION: usize = 1;
@@ -266,6 +269,17 @@ fn chunk_update_inputs(
         chunks.push(current);
     }
     chunks
+}
+
+fn should_use_single_update_mutation(
+    update_inputs: &[String],
+    max_ops: usize,
+    max_chars: usize,
+    prefer_single: bool,
+) -> bool {
+    prefer_single
+        && update_inputs.len() <= max_ops
+        && mutation_len_for_inputs(update_inputs) <= max_chars
 }
 
 fn is_resource_limit_error(err: &anyhow::Error) -> bool {
@@ -348,11 +362,12 @@ fn run_update_mutations(
     } else {
         None
     };
-    let chunks = if prefer_single && mutation_len_for_inputs(&update_inputs) <= max_chars {
-        vec![update_inputs]
-    } else {
-        chunk_update_inputs(&update_inputs, max_ops, max_chars)
-    };
+    let chunks =
+        if should_use_single_update_mutation(&update_inputs, max_ops, max_chars, prefer_single) {
+            vec![update_inputs]
+        } else {
+            chunk_update_inputs(&update_inputs, max_ops, max_chars)
+        };
     for chunk in chunks {
         if let Err(e) = run_update_chunk_with_retry(execution_mode, &chunk, progress_bar.as_ref()) {
             if let Some(progress_bar) = &progress_bar {
@@ -988,7 +1003,8 @@ mod tests {
     use super::{
         branch_reuse_guard_window, build_from_groups, build_from_tags, head_key,
         heads_without_open_prs, ignored_boundary_warning, parse_github_timestamp_rfc3339,
-        pr_number_for_head, recent_pr_age, recent_pr_age_blocks_recreation, terminal_pr_action,
+        pr_number_for_head, recent_pr_age, recent_pr_age_blocks_recreation,
+        should_use_single_update_mutation, terminal_pr_action,
     };
     use crate::branch_names::group_branch_identities;
     use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
@@ -1009,6 +1025,18 @@ mod tests {
 
         assert!(warning.contains("GitHub PRs above an ignored block include the ignored commits"));
         assert!(warning.contains("pr:beta, pr:gamma"));
+    }
+
+    #[test]
+    fn preferred_single_update_mutation_still_respects_max_operations() {
+        let update_inputs = vec!["a".to_string(), "b".to_string()];
+
+        assert!(!should_use_single_update_mutation(
+            &update_inputs,
+            1,
+            usize::MAX,
+            true
+        ));
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -88,6 +88,15 @@ pub struct TerminalPrInfo {
 
 const HEAD_SEARCH_LIMIT: usize = 100;
 const OPEN_CONFLICT_SEARCH_LIMIT: usize = 2;
+// GitHub documents a 500,000-node validation cap and additional undisclosed resource limits for
+// GraphQL queries. These are conservative operational starting points, not GitHub guarantees.
+// Keep the nested status query modest, and rely on run_read_chunk_with_retry to bisect any batch
+// that still triggers RESOURCE_LIMITS_EXCEEDED.
+const MAX_EXACT_HEADS_PER_QUERY: usize = 20;
+const MAX_CONFLICT_HEADS_PER_QUERY: usize = 10;
+const MAX_TERMINAL_HEADS_PER_QUERY: usize = 10;
+const MAX_PR_BODIES_PER_QUERY: usize = 10;
+const MAX_PR_STATUS_PER_QUERY: usize = 20;
 const HEAD_SEARCH_FIELDS: &str =
     "number,headRefName,baseRefName,state,mergedAt,closedAt,url,autoMergeRequest";
 const EXACT_HEAD_QUERY_LIMIT: usize = 10;
@@ -116,6 +125,33 @@ struct HeadSearchPr {
 
 fn head_key(head: &str) -> CanonicalBranchConflictKey {
     canonical_branch_conflict_key(head)
+}
+
+fn is_resource_limit_error(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("RESOURCE_LIMITS_EXCEEDED")
+        || msg.contains("Resource limits for this query exceeded")
+}
+
+fn run_read_chunk_with_retry<T, R, F, M>(items: &[T], run: &F, merge: &M) -> Result<R>
+where
+    F: Fn(&[T]) -> Result<R>,
+    M: Fn(R, R) -> R,
+{
+    match run(items) {
+        Ok(result) => Ok(result),
+        Err(err) if is_resource_limit_error(&err) && items.len() > 1 => {
+            info!(
+                "Resource limits for this query exceeded; retrying read with smaller chunks ({} item(s))",
+                items.len()
+            );
+            let mid = items.len() / 2;
+            let left = run_read_chunk_with_retry(&items[..mid], run, merge)?;
+            let right = run_read_chunk_with_retry(&items[mid..], run, merge)?;
+            Ok(merge(left, right))
+        }
+        Err(err) => Err(err),
+    }
 }
 
 fn head_search_query(head: &str) -> String {
@@ -176,6 +212,26 @@ fn list_prs_for_search_query(query: &str, state: &str, limit: usize) -> Result<V
 /// Case-variant remote heads are intentionally not discovered by this helper; conflict detection
 /// stays in the separate search-based helpers below.
 fn list_exact_prs_for_heads(
+    heads: &[String],
+    states: &[&str],
+    limit: usize,
+) -> Result<HashMap<String, Vec<HeadSearchPr>>> {
+    let mut out = HashMap::new();
+    for chunk in heads.chunks(MAX_EXACT_HEADS_PER_QUERY) {
+        let chunk_out = run_read_chunk_with_retry(
+            chunk,
+            &|subset| list_exact_prs_for_heads_chunk(subset, states, limit),
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        )?;
+        out.extend(chunk_out);
+    }
+    Ok(out)
+}
+
+fn list_exact_prs_for_heads_chunk(
     heads: &[String],
     states: &[&str],
     limit: usize,
@@ -260,6 +316,24 @@ fn list_prs_for_search_query_exhaustive(query: &str, state: &str) -> Result<Vec<
 /// locally because exact-head multiplicity is already handled by the structured GraphQL lookup;
 /// this helper only answers whether any additional case-insensitive open hit exists.
 fn list_open_conflicting_prs_for_heads_search(
+    heads: &[String],
+) -> Result<HashMap<String, Vec<HeadSearchPr>>> {
+    let mut out = HashMap::new();
+    for chunk in heads.chunks(MAX_CONFLICT_HEADS_PER_QUERY) {
+        let chunk_out = run_read_chunk_with_retry(
+            chunk,
+            &list_open_conflicting_prs_for_heads_search_chunk,
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        )?;
+        out.extend(chunk_out);
+    }
+    Ok(out)
+}
+
+fn list_open_conflicting_prs_for_heads_search_chunk(
     heads: &[String],
 ) -> Result<HashMap<String, Vec<HeadSearchPr>>> {
     let mut matches_by_head: HashMap<String, Vec<HeadSearchPr>> = heads
@@ -572,6 +646,22 @@ pub struct PrBodyInfo {
 
 pub fn fetch_pr_bodies_graphql(numbers: &[u64]) -> Result<HashMap<u64, PrBodyInfo>> {
     let mut out = HashMap::new();
+    for chunk in numbers.chunks(MAX_PR_BODIES_PER_QUERY) {
+        let chunk_out = run_read_chunk_with_retry(
+            chunk,
+            &fetch_pr_bodies_graphql_chunk,
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        )?;
+        out.extend(chunk_out);
+    }
+    Ok(out)
+}
+
+fn fetch_pr_bodies_graphql_chunk(numbers: &[u64]) -> Result<HashMap<u64, PrBodyInfo>> {
+    let mut out = HashMap::new();
     if numbers.is_empty() {
         return Ok(out);
     }
@@ -660,6 +750,22 @@ pub struct PrCiReviewStatus {
 }
 
 pub fn fetch_pr_ci_review_status(numbers: &[u64]) -> Result<HashMap<u64, PrCiReviewStatus>> {
+    let mut out = HashMap::new();
+    for chunk in numbers.chunks(MAX_PR_STATUS_PER_QUERY) {
+        let chunk_out = run_read_chunk_with_retry(
+            chunk,
+            &fetch_pr_ci_review_status_chunk,
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        )?;
+        out.extend(chunk_out);
+    }
+    Ok(out)
+}
+
+fn fetch_pr_ci_review_status_chunk(numbers: &[u64]) -> Result<HashMap<u64, PrCiReviewStatus>> {
     let mut out = HashMap::new();
     if numbers.is_empty() {
         return Ok(out);
@@ -939,6 +1045,25 @@ pub fn list_recent_terminal_prs_for_heads(
     heads: &[String],
     closed_since: OffsetDateTime,
 ) -> Result<Vec<TerminalPrInfo>> {
+    let mut out = Vec::new();
+    for chunk in heads.chunks(MAX_TERMINAL_HEADS_PER_QUERY) {
+        let mut chunk_out = run_read_chunk_with_retry(
+            chunk,
+            &|subset| list_recent_terminal_prs_for_heads_chunk(subset, closed_since),
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        )?;
+        out.append(&mut chunk_out);
+    }
+    Ok(out)
+}
+
+fn list_recent_terminal_prs_for_heads_chunk(
+    heads: &[String],
+    closed_since: OffsetDateTime,
+) -> Result<Vec<TerminalPrInfo>> {
     let mut out: Vec<TerminalPrInfo> = Vec::new();
     if heads.is_empty() {
         return Ok(out);
@@ -1197,11 +1322,13 @@ mod tests {
         filter_head_search_matches, list_conflicting_prs_for_heads_search_exhaustive,
         list_exact_prs_for_heads, list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
         list_recent_terminal_prs_for_heads, parse_open_pr_automerge_node, resolve_pr_url_head_ref,
-        select_latest_merged_pr_match, select_single_open_pr_match, HeadSearchPr, PrState,
-        TerminalPrState, EXACT_HEAD_QUERY_LIMIT,
+        run_read_chunk_with_retry, select_latest_merged_pr_match, select_single_open_pr_match,
+        HeadSearchPr, PrState, TerminalPrState, EXACT_HEAD_QUERY_LIMIT,
     };
     use crate::test_support::lock_cwd;
+    use anyhow::anyhow;
     use serde_json::{json, Value};
+    use std::cell::Cell;
     use std::env;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
@@ -1247,6 +1374,28 @@ mod tests {
             url: Some(format!("https://github.com/o/r/pull/{number}")),
             auto_merge_request: None,
         }
+    }
+
+    #[test]
+    fn read_chunk_retry_splits_resource_limit_failures_and_merges_results() {
+        let calls = Cell::new(0);
+        let run = |items: &[u64]| {
+            calls.set(calls.get() + 1);
+            if items.len() > 1 {
+                Err(anyhow!("RESOURCE_LIMITS_EXCEEDED"))
+            } else {
+                Ok(items.to_vec())
+            }
+        };
+        let merge = |mut left: Vec<u64>, right: Vec<u64>| {
+            left.extend(right);
+            left
+        };
+
+        let result = run_read_chunk_with_retry(&[1, 2, 3, 4], &run, &merge).unwrap();
+
+        assert_eq!(result, vec![1, 2, 3, 4]);
+        assert_eq!(calls.get(), 7);
     }
 
     fn install_gh_wrapper(script_body: &str) -> (TempDir, EnvVarGuard) {

--- a/src/github.rs
+++ b/src/github.rs
@@ -127,7 +127,7 @@ fn head_key(head: &str) -> CanonicalBranchConflictKey {
     canonical_branch_conflict_key(head)
 }
 
-fn is_resource_limit_error(err: &anyhow::Error) -> bool {
+pub(crate) fn is_resource_limit_error(err: &anyhow::Error) -> bool {
     let msg = err.to_string();
     msg.contains("RESOURCE_LIMITS_EXCEEDED")
         || msg.contains("Resource limits for this query exceeded")
@@ -658,6 +658,55 @@ pub fn fetch_pr_bodies_graphql(numbers: &[u64]) -> Result<HashMap<u64, PrBodyInf
         out.extend(chunk_out);
     }
     Ok(out)
+}
+
+pub fn fetch_pr_issue_comment_bodies_graphql(number: u64) -> Result<Vec<String>> {
+    let (owner, name) = get_repo_owner_name()?;
+    let query = "query($owner:String!,$name:String!,$number:Int!,$cursor:String){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ comments(first:100,after:$cursor){ pageInfo { hasNextPage endCursor } nodes { body } } } } }";
+    let mut cursor: Option<String> = None;
+    let mut bodies = Vec::new();
+    loop {
+        let mut args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("owner={owner}"),
+            "-F".to_string(),
+            format!("name={name}"),
+            "-F".to_string(),
+            format!("number={number}"),
+        ];
+        if let Some(cursor) = &cursor {
+            args.push("-F".to_string());
+            args.push(format!("cursor={cursor}"));
+        }
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let json = gh_ro(&arg_refs)?;
+        let value: serde_json::Value = serde_json::from_str(&json)?;
+        let comments = &value["data"]["repository"]["pullRequest"]["comments"];
+        bodies.extend(
+            comments["nodes"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|node| node["body"].as_str().map(str::to_string)),
+        );
+        if !comments["pageInfo"]["hasNextPage"]
+            .as_bool()
+            .unwrap_or(false)
+        {
+            break;
+        }
+        cursor = comments["pageInfo"]["endCursor"]
+            .as_str()
+            .map(str::to_string);
+        if cursor.is_none() {
+            bail!("PR #{number} comments page missing endCursor");
+        }
+    }
+    Ok(bodies)
 }
 
 fn fetch_pr_bodies_graphql_chunk(numbers: &[u64]) -> Result<HashMap<u64, PrBodyInfo>> {
@@ -1318,14 +1367,16 @@ pub fn append_warning_to_pr(
 #[cfg(test)]
 mod tests {
     use super::{
-        fetch_merged_pr_merge_commit_oids, filter_case_variant_head_search_matches,
-        filter_head_search_matches, list_conflicting_prs_for_heads_search_exhaustive,
-        list_exact_prs_for_heads, list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
+        fetch_merged_pr_merge_commit_oids, fetch_pr_bodies_graphql,
+        fetch_pr_issue_comment_bodies_graphql, filter_case_variant_head_search_matches,
+        filter_head_search_matches, is_resource_limit_error,
+        list_conflicting_prs_for_heads_search_exhaustive, list_exact_prs_for_heads,
+        list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
         list_recent_terminal_prs_for_heads, parse_open_pr_automerge_node, resolve_pr_url_head_ref,
         run_read_chunk_with_retry, select_latest_merged_pr_match, select_single_open_pr_match,
         HeadSearchPr, PrState, TerminalPrState, EXACT_HEAD_QUERY_LIMIT,
     };
-    use crate::test_support::lock_cwd;
+    use crate::test_support::{init_repo, lock_cwd, DirGuard};
     use anyhow::anyhow;
     use serde_json::{json, Value};
     use std::cell::Cell;
@@ -1396,6 +1447,17 @@ mod tests {
 
         assert_eq!(result, vec![1, 2, 3, 4]);
         assert_eq!(calls.get(), 7);
+    }
+
+    #[test]
+    fn resource_limit_classifier_accepts_both_github_spellings() {
+        assert!(is_resource_limit_error(&anyhow!(
+            "RESOURCE_LIMITS_EXCEEDED"
+        )));
+        assert!(is_resource_limit_error(&anyhow!(
+            "Resource limits for this query exceeded"
+        )));
+        assert!(!is_resource_limit_error(&anyhow!("different failure")));
     }
 
     fn install_gh_wrapper(script_body: &str) -> (TempDir, EnvVarGuard) {
@@ -1495,6 +1557,68 @@ mod tests {
             path_guard,
             log_path.display().to_string(),
         )
+    }
+
+    #[test]
+    fn fetch_pr_bodies_graphql_merges_results_across_wrapper_chunks() {
+        let _lock = lock_cwd();
+        let repo = init_repo();
+        crate::test_support::git(
+            repo.path(),
+            [
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/spr-test.git",
+            ]
+            .as_slice(),
+        );
+        let _guard = DirGuard::change_to(repo.path());
+        let data_dir = tempfile::tempdir().unwrap();
+        let log_path = data_dir.path().join("gh.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$*\" in\n  *\"pullRequest(number: 11)\"*) echo '{{\"data\":{{\"repository\":{{\"pr0\":{{\"id\":\"PR_11\",\"body\":\"body 11\"}}}}}}}}' ;;\n  *) echo '{{\"data\":{{\"repository\":{{\"pr0\":{{\"id\":\"PR_1\",\"body\":\"body 1\"}},\"pr1\":{{\"id\":\"PR_2\",\"body\":\"body 2\"}},\"pr2\":{{\"id\":\"PR_3\",\"body\":\"body 3\"}},\"pr3\":{{\"id\":\"PR_4\",\"body\":\"body 4\"}},\"pr4\":{{\"id\":\"PR_5\",\"body\":\"body 5\"}},\"pr5\":{{\"id\":\"PR_6\",\"body\":\"body 6\"}},\"pr6\":{{\"id\":\"PR_7\",\"body\":\"body 7\"}},\"pr7\":{{\"id\":\"PR_8\",\"body\":\"body 8\"}},\"pr8\":{{\"id\":\"PR_9\",\"body\":\"body 9\"}},\"pr9\":{{\"id\":\"PR_10\",\"body\":\"body 10\"}}}}}}}}' ;;\nesac\n",
+            log_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+
+        let bodies = fetch_pr_bodies_graphql(&(1..=11).collect::<Vec<_>>()).unwrap();
+
+        assert_eq!(bodies.len(), 11);
+        for number in 1..=11 {
+            assert_eq!(bodies[&number].id, format!("PR_{number}"));
+            assert_eq!(bodies[&number].body, format!("body {number}"));
+        }
+        assert_eq!(fs::read_to_string(log_path).unwrap().lines().count(), 2);
+    }
+
+    #[test]
+    fn fetch_pr_issue_comment_bodies_graphql_reads_all_pages() {
+        let _lock = lock_cwd();
+        let repo = init_repo();
+        crate::test_support::git(
+            repo.path(),
+            [
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/spr-test.git",
+            ]
+            .as_slice(),
+        );
+        let _guard = DirGuard::change_to(repo.path());
+        let data_dir = tempfile::tempdir().unwrap();
+        let log_path = data_dir.path().join("gh.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$*\" in\n  *\"cursor=page-2\"*) echo '{{\"data\":{{\"repository\":{{\"pullRequest\":{{\"comments\":{{\"pageInfo\":{{\"hasNextPage\":false,\"endCursor\":null}},\"nodes\":[{{\"body\":\"second\"}}]}}}}}}}}}}' ;;\n  *) echo '{{\"data\":{{\"repository\":{{\"pullRequest\":{{\"comments\":{{\"pageInfo\":{{\"hasNextPage\":true,\"endCursor\":\"page-2\"}},\"nodes\":[{{\"body\":\"first\"}}]}}}}}}}}}}' ;;\nesac\n",
+            log_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+
+        let bodies = fetch_pr_issue_comment_bodies_graphql(17).unwrap();
+
+        assert_eq!(bodies, vec!["first", "second"]);
+        assert_eq!(fs::read_to_string(log_path).unwrap().lines().count(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Large stacked-PR operations now keep GitHub GraphQL requests small and recover
cleanly when a split landing is interrupted. Read queries use bounded chunks
and recursively split again when GitHub reports a resource-limit error.
Landing merges the selected pull request separately, then comments on and
closes older pull requests in batches of three.

If cleanup fails after the selected pull request has already merged, rerunning
the same land command resumes cleanup instead of failing to reconstruct the
open segment. Recovery closes only older pull requests that remain open and
avoids duplicating the deterministic cleanup comment. Read and update retries
also share one resource-limit classifier so accepted GitHub error spellings
cannot drift between paths.

Example:
An 18-item read that exceeds GitHub's limit is retried as two 9-item reads,
with further splitting only if a smaller read still fails. If landing merges
pull request 3 but closing pull requests 1 and 2 is interrupted, the retry
skips the completed merge and finishes the remaining cleanup.

Fixes #104

<!-- spr-stack:start -->
**Stack**:
-   #150
-   #149
-   #152
-   #148
-   #147
-   #146
- ➡ #145

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->