### PR TITLE
update: skip metadata refresh at detached checkpoints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,19 +122,25 @@ fn set_dry_run_env(execution_mode: ExecutionMode, assume_existing_prs: bool) {
     }
 }
 
+const DETACHED_METADATA_REFRESH_WARNING: &str = "Skipping stack metadata refresh because HEAD is detached. Rerun `spr update` after completing the active Git operation.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MetadataRefreshOutcome {
+    Refreshed,
+    SkippedDetached,
+}
+
 fn refresh_metadata_after_update(
     context: &crate::stack_metadata::RefreshMetadataContext,
-) -> Result<()> {
+) -> Result<MetadataRefreshOutcome> {
     if !crate::stack_metadata::refresh_metadata_for_current_checkout_if_attached(
         &context.base,
         &context.prefix,
         &context.ignore_tag,
     )? {
-        tracing::warn!(
-            "Skipping stack metadata refresh because HEAD is detached. Rerun `spr update` after completing the active Git operation."
-        );
+        return Ok(MetadataRefreshOutcome::SkippedDetached);
     }
-    Ok(())
+    Ok(MetadataRefreshOutcome::Refreshed)
 }
 
 /// Change to the requested working directory before config discovery or repo-scoped commands.
@@ -483,7 +489,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         branch_reuse_guard_days,
                         local_pr_branch_policy,
                     )?;
-                    let summary = crate::update_output::UpdateSummaryData::from_execution(
+                    let mut summary = crate::update_output::UpdateSummaryData::from_execution(
                         crate::update_output::UpdateRepoContext {
                             base: base.clone(),
                             from,
@@ -499,8 +505,13 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         resolved_extent,
                         execution,
                     );
-                    if execution_mode == ExecutionMode::Apply {
-                        refresh_metadata_after_update(&metadata_refresh_context)?;
+                    if execution_mode == ExecutionMode::Apply
+                        && refresh_metadata_after_update(&metadata_refresh_context)?
+                            == MetadataRefreshOutcome::SkippedDetached
+                    {
+                        summary
+                            .warnings
+                            .push(DETACHED_METADATA_REFRESH_WARNING.to_string());
                     }
                     Ok(CommandOutput::Update(crate::update_output::summary(
                         summary,
@@ -520,8 +531,11 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         branch_reuse_guard_days,
                         local_pr_branch_policy,
                     )?;
-                    if execution_mode == ExecutionMode::Apply {
-                        refresh_metadata_after_update(&metadata_refresh_context)?;
+                    if execution_mode == ExecutionMode::Apply
+                        && refresh_metadata_after_update(&metadata_refresh_context)?
+                            == MetadataRefreshOutcome::SkippedDetached
+                    {
+                        eprintln!("{DETACHED_METADATA_REFRESH_WARNING}");
                     }
                     Ok(CommandOutput::None)
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,21 @@ fn set_dry_run_env(execution_mode: ExecutionMode, assume_existing_prs: bool) {
     }
 }
 
+fn refresh_metadata_after_update(
+    context: &crate::stack_metadata::RefreshMetadataContext,
+) -> Result<()> {
+    if !crate::stack_metadata::refresh_metadata_for_current_checkout_if_attached(
+        &context.base,
+        &context.prefix,
+        &context.ignore_tag,
+    )? {
+        tracing::warn!(
+            "Skipping stack metadata refresh because HEAD is detached. Rerun `spr update` after completing the active Git operation."
+        );
+    }
+    Ok(())
+}
+
 /// Change to the requested working directory before config discovery or repo-scoped commands.
 fn apply_working_directory_override(path: Option<&Path>) -> Result<()> {
     if let Some(path) = path {
@@ -485,11 +500,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         execution,
                     );
                     if execution_mode == ExecutionMode::Apply {
-                        crate::stack_metadata::refresh_metadata_for_current_checkout(
-                            &metadata_refresh_context.base,
-                            &metadata_refresh_context.prefix,
-                            &metadata_refresh_context.ignore_tag,
-                        )?;
+                        refresh_metadata_after_update(&metadata_refresh_context)?;
                     }
                     Ok(CommandOutput::Update(crate::update_output::summary(
                         summary,
@@ -510,11 +521,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         local_pr_branch_policy,
                     )?;
                     if execution_mode == ExecutionMode::Apply {
-                        crate::stack_metadata::refresh_metadata_for_current_checkout(
-                            &metadata_refresh_context.base,
-                            &metadata_refresh_context.prefix,
-                            &metadata_refresh_context.ignore_tag,
-                        )?;
+                        refresh_metadata_after_update(&metadata_refresh_context)?;
                     }
                     Ok(CommandOutput::None)
                 }

--- a/src/stack_metadata.rs
+++ b/src/stack_metadata.rs
@@ -679,6 +679,19 @@ pub fn refresh_metadata_for_current_checkout(
     write_metadata_atomically(&path, &metadata)
 }
 
+pub fn refresh_metadata_for_current_checkout_if_attached(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+) -> Result<bool> {
+    let repo_path = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
+    if current_branch_or_none(&repo_path)?.is_none() {
+        return Ok(false);
+    }
+    refresh_metadata_for_current_checkout(base, prefix, ignore_tag)?;
+    Ok(true)
+}
+
 pub fn refresh_metadata_for_branch(
     repo_path: &str,
     stack_branch: &str,
@@ -816,11 +829,13 @@ pub fn current_branch_or_none(repo_path: &str) -> Result<Option<String>> {
 mod tests {
     use super::{
         acquire_lock, apply_snapshot, load_metadata_from_path, metadata_lock_path,
-        ordered_known_branches, write_metadata_atomically, GroupSelectorText, PrBranchName,
-        PrBranchRecord, StackBranchName, StackId, StackMetadataFile, StackRecord, StackSnapshot,
+        ordered_known_branches, refresh_metadata_for_current_checkout_if_attached,
+        write_metadata_atomically, GroupSelectorText, PrBranchName, PrBranchRecord,
+        StackBranchName, StackId, StackMetadataFile, StackRecord, StackSnapshot,
         StackSnapshotGroup, TombstoneReason, LEGACY_STACK_METADATA_SCHEMA_VERSION,
         STACK_METADATA_SCHEMA_VERSION,
     };
+    use crate::test_support::{git, init_repo, lock_cwd, DirGuard};
     use std::collections::BTreeMap;
     use std::fs;
     use tempfile::TempDir;
@@ -860,6 +875,20 @@ mod tests {
 
         assert_eq!(known[0], preferred);
         assert_eq!(known.len(), 3);
+    }
+
+    #[test]
+    fn update_metadata_refresh_skips_detached_checkout() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path();
+        git(repo, ["checkout", "--detach", "HEAD"].as_slice());
+        let _guard = DirGuard::change_to(repo);
+
+        assert!(
+            !refresh_metadata_for_current_checkout_if_attached("main", "dank-spr/", "ignore")
+                .unwrap()
+        );
     }
 
     #[test]

--- a/tests/global_json.rs
+++ b/tests/global_json.rs
@@ -1,5 +1,8 @@
 use serde_json::Value;
+use std::fs;
+use std::path::Path;
 use std::process::Command;
+use tempfile::TempDir;
 
 fn run_spr(args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_spr"))
@@ -10,6 +13,76 @@ fn run_spr(args: &[&str]) -> std::process::Output {
 
 fn stdout_json(output: &std::process::Output) -> Value {
     serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn init_detached_update_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, ["init", "-b", "main"].as_slice());
+    git(
+        &repo,
+        ["config", "user.email", "spr@example.com"].as_slice(),
+    );
+    git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+    fs::write(repo.join("README.md"), "init\n").unwrap();
+    git(&repo, ["add", "README.md"].as_slice());
+    git(&repo, ["commit", "-m", "init"].as_slice());
+    let origin = dir.path().join("origin.git");
+    git(
+        &repo,
+        ["init", "--bare", origin.to_str().unwrap()].as_slice(),
+    );
+    git(
+        &repo,
+        ["remote", "add", "origin", origin.to_str().unwrap()].as_slice(),
+    );
+    git(&repo, ["push", "-u", "origin", "main"].as_slice());
+    git(&repo, ["checkout", "-b", "stack"].as_slice());
+    fs::write(repo.join("alpha.txt"), "alpha\n").unwrap();
+    git(&repo, ["add", "alpha.txt"].as_slice());
+    git(
+        &repo,
+        ["commit", "-m", "feat: alpha start pr:alpha"].as_slice(),
+    );
+    git(&repo, ["checkout", "--detach", "HEAD"].as_slice());
+    (dir, repo)
+}
+
+fn run_detached_update(repo: &Path, home: &Path, json: bool) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_spr"));
+    command
+        .env("HOME", home)
+        .args(["--cd", repo.to_str().unwrap(), "--base", "main"])
+        .args(["--prefix", "test-spr/", "update", "--no-pr"]);
+    if json {
+        command.arg("--json");
+    }
+    command.output().unwrap()
+}
+
+fn assert_alpha_remote_exists(repo: &Path) {
+    assert!(!git(
+        repo,
+        ["ls-remote", "--heads", "origin", "test-spr/alpha"].as_slice(),
+    )
+    .trim()
+    .is_empty());
 }
 
 #[test]
@@ -90,4 +163,35 @@ fn json_parse_error_outputs_error_object() {
         .as_str()
         .unwrap()
         .contains("definitely-not-a-command"));
+}
+
+#[test]
+fn detached_update_human_warns_after_pushing_branch() {
+    let (dir, repo) = init_detached_update_repo();
+
+    let output = run_detached_update(&repo, dir.path(), false);
+
+    assert!(output.status.success());
+    assert_alpha_remote_exists(&repo);
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("Skipping stack metadata refresh because HEAD is detached"));
+}
+
+#[test]
+fn detached_update_json_reports_warning_after_pushing_branch() {
+    let (dir, repo) = init_detached_update_repo();
+
+    let output = run_detached_update(&repo, dir.path(), true);
+
+    assert!(output.status.success());
+    assert_alpha_remote_exists(&repo);
+    let json = stdout_json(&output);
+    assert!(json["data"]["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .unwrap()
+            .contains("Skipping stack metadata refresh because HEAD is detached")));
 }


### PR DESCRIPTION
`spr update` no longer reports failure after successfully publishing remote
changes from a detached rebase checkpoint. When `HEAD` is detached, update
skips the local stack-metadata refresh and tells the user to rerun update after
the active Git operation completes. Callers that require an attached branch
remain strict.

The skipped-refresh result is explicit: human output prints the rerun notice
to stderr, and JSON output includes the same notice in its structured warnings
array. Automation can therefore distinguish a successful remote publication
from a fully refreshed local checkout.

Example:
While an interactive rebase is paused for editing, `spr u` can push the
updated pull-request refs without failing afterward because local metadata
cannot be attached to the temporary detached checkout. A JSON caller still
receives a warning that metadata refresh must be rerun later.

<!-- spr-stack:start -->
**Stack**:
-   #150
-   #149
-   #152
-   #148
-   #147
- ➡ #146
-   #145

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->