### PR TITLE
update: remove partial-commit publish extents

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Key options:
   - `pr --to <N|name|pr:<label>|branch:<branch-name>>`: canonical selector for limiting updates to the first N PRs from the bottom
   - `pr --n <N>`: legacy numeric-only form
   - `pr <N>`: backward-compatible positional numeric form
-  - `commits --n <N>`: limit to first N commits (untested)
 
 Behavior:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,8 +17,6 @@ pub enum Extent {
         #[arg(value_name = "N", hide = true, conflicts_with_all = ["to", "n"])]
         legacy_n: Option<usize>,
     },
-    /// Update only the first N commits from base..from (push partial groups if needed)
-    Commits { n: usize },
 }
 
 #[derive(Clone, Debug)]
@@ -354,6 +352,15 @@ mod tests {
             } => assert!(allow_replayed_duplicates),
             other => panic!("unexpected command: {:?}", other),
         }
+    }
+
+    #[test]
+    fn update_commit_extent_is_rejected() {
+        let err = Cli::try_parse_from(["spr", "update", "commits", "2"]).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("unrecognized subcommand 'commits'"));
     }
 
     #[test]

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -5,33 +5,11 @@ use crate::parsing::Group;
 #[derive(Clone, Copy)]
 pub enum Limit {
     ByPr(usize),
-    ByCommits(usize),
 }
 
-pub fn apply_limit_groups(mut groups: Vec<Group>, limit: Option<Limit>) -> Result<Vec<Group>> {
+pub fn apply_limit_groups(groups: Vec<Group>, limit: Option<Limit>) -> Result<Vec<Group>> {
     match limit {
         None => Ok(groups),
         Some(Limit::ByPr(n)) => Ok(groups.into_iter().take(n).collect()),
-        Some(Limit::ByCommits(mut n)) => {
-            let mut out = vec![];
-            for mut g in groups.drain(..) {
-                if n == 0 {
-                    break;
-                }
-                let len = g.commits.len();
-                if len <= n {
-                    out.push(g);
-                    n -= len;
-                } else {
-                    g.commits.truncate(n);
-                    if !g.subjects.is_empty() {
-                        g.subjects.truncate(g.commits.len().min(g.subjects.len()));
-                    }
-                    out.push(g);
-                    n = 0;
-                }
-            }
-            Ok(out)
-        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,19 +486,12 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     match extent {
                         crate::cli::Extent::Pr { to, n, legacy_n } => {
                             let limit = resolve_update_pr_limit(&groups, to, n, legacy_n)?;
-                            let count = match limit {
-                                crate::limit::Limit::ByPr(count) => count,
-                                crate::limit::Limit::ByCommits(_) => unreachable!(),
-                            };
+                            let crate::limit::Limit::ByPr(count) = limit;
                             (
                                 Some(limit),
                                 crate::update_output::ResolvedUpdateLimit::ByPr { count },
                             )
                         }
-                        crate::cli::Extent::Commits { n } => (
-                            Some(crate::limit::Limit::ByCommits(n)),
-                            crate::update_output::ResolvedUpdateLimit::ByCommits { count: n },
-                        ),
                     }
                 } else {
                     (None, crate::update_output::ResolvedUpdateLimit::All)
@@ -3243,47 +3236,6 @@ mod tests {
                 assert_eq!(output.data.extent, ResolvedUpdateLimit::ByPr { count: 1 });
                 assert_eq!(output.data.groups.len(), 1);
                 assert_eq!(output.data.groups[0].stable_handle, "pr:alpha");
-            }
-            other => panic!("unexpected command output: {:?}", other),
-        }
-    }
-
-    #[test]
-    fn update_json_commit_extent_reports_resolved_commit_limit() {
-        let _lock = lock_cwd();
-        let dir = init_update_stack_repo();
-        let repo = dir.path().join("repo");
-        let _guard = DirGuard::change_to(&repo);
-        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
-        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
-        let cli = crate::cli::Cli::try_parse_from([
-            "spr",
-            "--cd",
-            repo.to_str().unwrap(),
-            "--base",
-            "main",
-            "--prefix",
-            "dank-spr/",
-            "update",
-            "--dry-run",
-            "--json",
-            "--no-pr",
-            "commits",
-            "2",
-        ])
-        .unwrap();
-
-        let output = run_cli(cli, OutputFormat::Json).unwrap();
-
-        match output {
-            CommandOutput::Update(output) => {
-                assert_eq!(
-                    output.data.extent,
-                    ResolvedUpdateLimit::ByCommits { count: 2 }
-                );
-                assert_eq!(output.data.groups.len(), 1);
-                assert_eq!(output.data.groups[0].stable_handle, "pr:alpha");
-                assert_eq!(output.data.groups[0].target_sha.len(), 40);
             }
             other => panic!("unexpected command output: {:?}", other),
         }

--- a/src/update_output.rs
+++ b/src/update_output.rs
@@ -39,7 +39,6 @@ pub struct UpdateOptions {
 pub enum ResolvedUpdateLimit {
     All,
     ByPr { count: usize },
-    ByCommits { count: usize },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
`spr update` no longer supports publishing an arbitrary commit count. Update
limits now stop only at pull-request boundaries, so a remote branch cannot be
left pointing at an intermediate commit inside one pull request. This also
keeps validation receipts aligned with the states they attest.

Example:
If the first pull request contains commits A1 and A2, the removed commit-count
mode could publish only A1. Use a pull-request prefix limit to publish through
that pull request as a complete unit.

<!-- spr-stack:start -->
**Stack**:
-   #153
-   #150
-   #149
- ➡ #152

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->