### PR TITLE
update: add explicit per-PR validation receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,19 @@ dirty_worktree: halt
 # case-only variants, had a recently merged or closed PR within the configured
 # window. Set to 0 to disable the guard.
 branch_reuse_guard_days: 180
+
+# How `spr update` handles pre-push validation.
+# - `legacy` (default): preserve Git's normal batched pre-push hook execution
+# - `required`: require matching `spr validate` receipts, then push with
+#   `--no-verify` to avoid rerunning hooks
+update_validation: legacy
 ```
 
 Precedence for defaults:
 
 - CLI flag > repo YAML > home YAML > git discovery (`origin/HEAD`)
 - Base has no built-in fallback; if discovery fails, set `base` explicitly
-- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `local_pr_branches = off`, `restack_conflict = halt`, `dirty_worktree = halt`
+- Built-in defaults still apply for non-base keys: `prefix = "${USER}-spr/"`, `land = flatten`, `ignore_tag = "ignore"`, `pr_description_mode = overwrite`, `list_order = recent_on_bottom`, `local_pr_branches = off`, `restack_conflict = halt`, `dirty_worktree = halt`, `update_validation = legacy`
 
 Global flags
 ------------
@@ -153,7 +159,7 @@ Global flags
 - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
 - `--local-pr-branches <off|update-existing|create-or-update>`: override local per-PR branch synchronization for this run
-- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: target range used by `update`, `prep`, and `land` (`0` means all)
+- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: target range used by `update`, `validate`, `prep`, and `land` (`0` means all)
 - `--exact <I|name|pr:<label>|branch:<branch-name>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
 
@@ -180,6 +186,7 @@ Key options:
 - `--no-pr`: only (re)create branches; skip PR creation/updates; this path stays Git-only in `--json` mode
 - `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
 - `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
+- `--skip-validation`: bypass receipt enforcement and push with `--no-verify`, intentionally skipping Git pre-push hooks
 - `--json`: write exactly one update summary object to stdout
 - `--until <N|0|name|pr:<label>|branch:<branch-name>>`: update only the lower prefix through one PR boundary (`0` means all)
 
@@ -200,6 +207,40 @@ Behavior:
   - When `pr_description_mode` is `stack_only`, only the stack block (between markers) is updated; the rest of the body is preserved
   - After publishing branch heads, reconciles each PR base directly to the local stack chain
 - When `local_pr_branches` is enabled, synchronizes local branches named exactly like each group's resolved concrete branch after the update succeeds. `update-existing` only moves existing local branches; `create-or-update` also creates missing ones.
+- In the default `update_validation: legacy` mode, retains Git's normal batched pre-push behavior. A pre-commit-managed hook may select only one cumulative ref from each push batch.
+- In `update_validation: required` mode, requires matching successful `spr validate` receipts for every selected PR boundary before changing remote branches, then pushes with `--no-verify`.
+- `--skip-validation` bypasses both receipt enforcement and Git pre-push hooks.
+
+### spr validate
+
+Run configured Git pre-push hooks at every selected publishable PR boundary and record reusable
+local receipts for the exact PR-local ranges.
+
+Aliases:
+
+- `v`
+
+Behavior:
+
+- Validates the full publishable prefix by default after applying the same ignored-block rule as `spr update`.
+- Honors global `--until <N|0|name|pr:<label>|branch:<branch-name>>` to validate only the lower prefix through one PR boundary.
+- Reuses one detached temporary worktree and checks out the final commit in each PR group, bottom → top.
+- Runs the configured `pre-push` hook with a synthetic PR-local range: merge-base → PR 1 tip, then previous PR tip → current PR tip.
+- Reuses matching receipts for unchanged PR-local ranges and runs hooks only for missing or stale boundaries. Extending a validated stack by one PR validates only the new boundary.
+- Stops at the first hook failure and leaves the temporary worktree in place for inspection.
+- Keeps receipts already recorded for successful lower boundaries when a later boundary fails, so retries resume incrementally.
+- Refuses to issue a receipt when a successful hook rewrites tracked files.
+- Records receipts under the repository common Git directory at `.git/spr/validation_receipts_v2/`.
+- Succeeds with a receipt when no pre-push hook is installed.
+- `--json` writes validated, recorded, and reused counts; ordered per-boundary receipt details; hook state; and success status.
+
+Incremental workflow:
+
+```bash
+spr v --until 9
+spr u pr --to 9
+spr v --until 10  # reuses boundaries 1..=9 and validates only boundary 10
+```
 
 ### spr restack
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,14 @@ Aliases:
 
 - `v`
 
+Key options:
+
+- `--from <REF>`: commit range upper bound when parsing tags (default `HEAD`)
+- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: validate only the lower prefix through one PR boundary
+
 Behavior:
 
+- Accepts `--from <REF>` to validate the same source-ref stack slice accepted by `spr update --from <REF>` (default `HEAD`).
 - Validates the full publishable prefix by default after applying the same ignored-block rule as `spr update`.
 - Honors global `--until <N|0|name|pr:<label>|branch:<branch-name>>` to validate only the lower prefix through one PR boundary.
 - Reuses one detached temporary worktree and checks out the final commit in each PR group, bottom → top.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,7 +104,11 @@ pub enum Cmd {
 
     /// Run configured pre-push hooks at every publishable PR boundary and record a receipt
     #[command(alias = "v")]
-    Validate,
+    Validate {
+        /// Source ref to read commits from, matching `spr update --from`
+        #[arg(long, default_value = "HEAD")]
+        from: String,
+    },
 
     /// Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base
     #[command(
@@ -317,7 +321,7 @@ pub struct Cli {
     /// Sync local per-PR branches named like each group's resolved concrete branch
     #[arg(long, global = true, value_enum)]
     pub local_pr_branches: Option<crate::config::LocalPrBranchSyncPolicy>,
-    /// Global until (used by update/prep/land). Accepts 0, a local PR number, or a group selector
+    /// Global until (used by update/validate/prep/land). Accepts 0, a local PR number, or a group selector
     #[arg(
         long,
         global = true,
@@ -430,14 +434,28 @@ mod tests {
     fn validate_command_parses() {
         let cli = Cli::try_parse_from(["spr", "validate"]).unwrap();
 
-        assert!(matches!(cli.cmd, Cmd::Validate));
+        assert!(matches!(cli.cmd, Cmd::Validate { ref from } if from == "HEAD"));
     }
 
     #[test]
     fn validate_alias_parses() {
         let cli = Cli::try_parse_from(["spr", "v"]).unwrap();
 
-        assert!(matches!(cli.cmd, Cmd::Validate));
+        assert!(matches!(cli.cmd, Cmd::Validate { ref from } if from == "HEAD"));
+    }
+
+    #[test]
+    fn validate_from_ref_parses() {
+        let cli = Cli::try_parse_from(["spr", "validate", "--from", "old-stack"]).unwrap();
+
+        assert!(matches!(cli.cmd, Cmd::Validate { ref from } if from == "old-stack"));
+    }
+
+    #[test]
+    fn global_until_help_mentions_validate() {
+        let help = Cli::command().render_long_help().to_string();
+
+        assert!(help.contains("used by update/validate/prep/land"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,9 +94,17 @@ pub enum Cmd {
         #[arg(long)]
         allow_branch_reuse: bool,
 
+        /// Skip receipt enforcement and Git pre-push hooks
+        #[arg(long)]
+        skip_validation: bool,
+
         #[command(flatten)]
         dry_run: DryRunArgs,
     },
+
+    /// Run configured pre-push hooks at every publishable PR boundary and record a receipt
+    #[command(alias = "v")]
+    Validate,
 
     /// Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base
     #[command(
@@ -415,6 +423,32 @@ mod tests {
 
             assert_eq!(cli.until, Some(expected));
             assert!(matches!(cli.cmd, Cmd::Update { .. }));
+        }
+    }
+
+    #[test]
+    fn validate_command_parses() {
+        let cli = Cli::try_parse_from(["spr", "validate"]).unwrap();
+
+        assert!(matches!(cli.cmd, Cmd::Validate));
+    }
+
+    #[test]
+    fn validate_alias_parses() {
+        let cli = Cli::try_parse_from(["spr", "v"]).unwrap();
+
+        assert!(matches!(cli.cmd, Cmd::Validate));
+    }
+
+    #[test]
+    fn update_skip_validation_flag_parses() {
+        let cli = Cli::try_parse_from(["spr", "update", "--skip-validation"]).unwrap();
+
+        match cli.cmd {
+            Cmd::Update {
+                skip_validation, ..
+            } => assert!(skip_validation),
+            other => panic!("unexpected command: {:?}", other),
         }
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,4 +39,7 @@ pub use rewrite_resume::{
     resume_context, resume_rewrite, RewriteCommandKind, RewriteCommandOutcome,
     RewriteDestinationKind, RewriteSuspendedState,
 };
-pub use update::{build_from_groups, build_from_groups_with_summary};
+pub use update::{
+    build_from_groups_with_summary, build_from_groups_with_summary_with_validation,
+    build_from_groups_with_validation, UpdatePushValidation,
+};

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -40,6 +40,6 @@ pub use rewrite_resume::{
     RewriteDestinationKind, RewriteSuspendedState,
 };
 pub use update::{
-    build_from_groups_with_summary, build_from_groups_with_summary_with_validation,
-    build_from_groups_with_validation, UpdatePushValidation,
+    build_from_groups_with_summary_with_validation, build_from_groups_with_validation,
+    UpdatePushValidation,
 };

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -26,6 +26,7 @@ pub struct PrepExecutionOptions {
     pub local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy,
     pub selection: crate::cli::PrepSelection,
     pub execution_mode: ExecutionMode,
+    pub update_validation: crate::config::UpdateValidationPolicy,
 }
 
 fn resolve_prep_window(
@@ -203,6 +204,7 @@ pub fn prep_squash(
         local_pr_branch_policy,
         selection,
         execution_mode,
+        update_validation,
     } = options;
     let dry_run = execution_mode == ExecutionMode::DryRun;
     let (merge_base, groups) = derive_local_groups(base, ignore_tag)?;
@@ -389,11 +391,22 @@ pub fn prep_squash(
     )?;
 
     let (limit, next_idx_opt, resolved_extent) = limit_and_next_idx(&groups, &selection)?;
-    let (_merge_base, leading_ignored, updated_groups) =
+    let (updated_merge_base, leading_ignored, updated_groups) =
         derive_groups_between_with_ignored(base, &parent_sha, ignore_tag)?;
     let (updated_groups, skipped_handles) =
         split_groups_for_update(&leading_ignored, updated_groups);
-    let update_execution = crate::commands::build_from_groups_with_summary(
+    let push_validation = if update_validation == crate::config::UpdateValidationPolicy::Required {
+        crate::commands::UpdatePushValidation::Required(crate::validation::build_descriptors(
+            base,
+            prefix,
+            ignore_tag,
+            &updated_merge_base,
+            &crate::limit::apply_limit_groups(updated_groups.clone(), limit)?,
+        )?)
+    } else {
+        crate::commands::UpdatePushValidation::Legacy
+    };
+    let update_execution = crate::commands::build_from_groups_with_summary_with_validation(
         base,
         prefix,
         &skipped_handles,
@@ -406,6 +419,7 @@ pub fn prep_squash(
         true,
         0,
         local_pr_branch_policy,
+        push_validation,
     )?;
     let update_summary = UpdateSummaryData::from_execution(
         UpdateRepoContext {
@@ -419,7 +433,7 @@ pub fn prep_squash(
             no_pr: false,
             pr_description_mode,
             local_pr_branches: local_pr_branch_policy,
-            update_validation: crate::config::UpdateValidationPolicy::Legacy,
+            update_validation,
             skip_validation: false,
         },
         resolved_extent,
@@ -608,6 +622,7 @@ mod tests {
                 local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy::Off,
                 selection: PrepSelection::All,
                 execution_mode: ExecutionMode::DryRun,
+                update_validation: crate::config::UpdateValidationPolicy::Legacy,
             },
         )
         .unwrap_err();

--- a/src/commands/prep.rs
+++ b/src/commands/prep.rs
@@ -419,6 +419,8 @@ pub fn prep_squash(
             no_pr: false,
             pr_description_mode,
             local_pr_branches: local_pr_branch_policy,
+            update_validation: crate::config::UpdateValidationPolicy::Legacy,
+            skip_validation: false,
         },
         resolved_extent,
         update_execution,

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -28,9 +28,23 @@ use crate::update_output::{
     SkippedUpdateGroupData, UpdateEditAction, UpdateExecutionData, UpdateGroupData, UpdatePrAction,
     UpdatePushAction, UpdateSkippedReason,
 };
+use crate::validation::ValidationDescriptor;
 
 #[cfg(test)]
 use crate::parsing::{derive_groups_between_with_ignored, split_groups_for_update};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdatePushValidation {
+    Legacy,
+    Required(Vec<ValidationDescriptor>),
+    Skip,
+}
+
+impl UpdatePushValidation {
+    fn skips_push_hooks(&self) -> bool {
+        matches!(self, Self::Required(_) | Self::Skip)
+    }
+}
 
 /// Replace the existing spr stack block with `new_block`, or append it if missing.
 ///
@@ -569,6 +583,7 @@ fn build_from_groups_internal(
     allow_branch_reuse: bool,
     branch_reuse_guard_days: u32,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    push_validation: UpdatePushValidation,
     render_progress: bool,
 ) -> Result<UpdateExecutionData> {
     let dry_run = execution_mode == ExecutionMode::DryRun;
@@ -757,8 +772,42 @@ fn build_from_groups_internal(
             )
         })
         .collect();
+    let force_refspecs: Vec<String> = planned
+        .iter()
+        .filter(|planned_push| planned_push.kind == PushKind::Force)
+        .map(|planned_push| {
+            format!(
+                "{}:refs/heads/{}",
+                planned_push.target_sha, planned_push.branch
+            )
+        })
+        .collect();
+    if (!ff_refspecs.is_empty() || !force_refspecs.is_empty())
+        && execution_mode == ExecutionMode::Apply
+    {
+        match &push_validation {
+            UpdatePushValidation::Legacy => {}
+            UpdatePushValidation::Required(descriptors) => {
+                let receipt_paths = crate::validation::require_matching_receipts(descriptors)?;
+                info!(
+                    "Using {} per-PR validation receipt(s); skipping push-time hooks",
+                    receipt_paths.len()
+                );
+            }
+            UpdatePushValidation::Skip => {
+                warn!(
+                    "Skipping validation receipt enforcement and Git pre-push hooks because --skip-validation was requested"
+                );
+            }
+        }
+    }
+    let push_skips_hooks = push_validation.skips_push_hooks();
     if !ff_refspecs.is_empty() {
-        let mut argv: Vec<String> = vec!["push".into(), "origin".into()];
+        let mut argv: Vec<String> = vec!["push".into()];
+        if push_skips_hooks {
+            argv.push("--no-verify".into());
+        }
+        argv.push("origin".into());
         argv.extend(ff_refspecs.clone());
         let args: Vec<&str> = argv.iter().map(|item| item.as_str()).collect();
         if render_progress {
@@ -778,16 +827,6 @@ fn build_from_groups_internal(
         }
     }
 
-    let force_refspecs: Vec<String> = planned
-        .iter()
-        .filter(|planned_push| planned_push.kind == PushKind::Force)
-        .map(|planned_push| {
-            format!(
-                "{}:refs/heads/{}",
-                planned_push.target_sha, planned_push.branch
-            )
-        })
-        .collect();
     if !force_refspecs.is_empty() {
         let force_leases: Vec<String> = planned
             .iter()
@@ -801,7 +840,11 @@ fn build_from_groups_internal(
                 })
             })
             .collect();
-        let mut argv: Vec<String> = vec!["push".into(), "origin".into()];
+        let mut argv: Vec<String> = vec!["push".into()];
+        if push_skips_hooks {
+            argv.push("--no-verify".into());
+        }
+        argv.push("origin".into());
         if force_leases.is_empty() {
             argv.push("--force-with-lease".into());
         } else {
@@ -1138,6 +1181,39 @@ pub fn build_from_groups_with_summary(
     branch_reuse_guard_days: u32,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<UpdateExecutionData> {
+    build_from_groups_with_summary_with_validation(
+        base,
+        prefix,
+        skipped_handles,
+        no_pr,
+        execution_mode,
+        pr_description_mode,
+        limit,
+        groups,
+        list_order,
+        allow_branch_reuse,
+        branch_reuse_guard_days,
+        local_pr_branch_policy,
+        UpdatePushValidation::Legacy,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_from_groups_with_summary_with_validation(
+    base: &str,
+    prefix: &str,
+    skipped_handles: &[String],
+    no_pr: bool,
+    execution_mode: ExecutionMode,
+    pr_description_mode: PrDescriptionMode,
+    limit: Option<Limit>,
+    groups: Vec<Group>,
+    list_order: ListOrder,
+    allow_branch_reuse: bool,
+    branch_reuse_guard_days: u32,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    push_validation: UpdatePushValidation,
+) -> Result<UpdateExecutionData> {
     build_from_groups_internal(
         base,
         prefix,
@@ -1151,11 +1227,13 @@ pub fn build_from_groups_with_summary(
         allow_branch_reuse,
         branch_reuse_guard_days,
         local_pr_branch_policy,
+        push_validation,
         false,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub fn build_from_groups(
     base: &str,
     prefix: &str,
@@ -1170,6 +1248,39 @@ pub fn build_from_groups(
     branch_reuse_guard_days: u32,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
 ) -> Result<()> {
+    build_from_groups_with_validation(
+        base,
+        prefix,
+        skipped_handles,
+        no_pr,
+        execution_mode,
+        pr_description_mode,
+        limit,
+        groups,
+        list_order,
+        allow_branch_reuse,
+        branch_reuse_guard_days,
+        local_pr_branch_policy,
+        UpdatePushValidation::Legacy,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_from_groups_with_validation(
+    base: &str,
+    prefix: &str,
+    skipped_handles: &[String],
+    no_pr: bool,
+    execution_mode: ExecutionMode,
+    pr_description_mode: PrDescriptionMode,
+    limit: Option<Limit>,
+    groups: Vec<Group>,
+    list_order: ListOrder,
+    allow_branch_reuse: bool,
+    branch_reuse_guard_days: u32,
+    local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    push_validation: UpdatePushValidation,
+) -> Result<()> {
     build_from_groups_internal(
         base,
         prefix,
@@ -1183,6 +1294,7 @@ pub fn build_from_groups(
         allow_branch_reuse,
         branch_reuse_guard_days,
         local_pr_branch_policy,
+        push_validation,
         true,
     )?;
     Ok(())

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -535,7 +535,7 @@ fn run_update_mutations(
     Ok(())
 }
 
-fn ignored_boundary_warning(skipped_handles: &[String]) -> String {
+pub(crate) fn ignored_boundary_warning(skipped_handles: &[String]) -> String {
     format!(
         "Skipping PR groups above the ignored block. GitHub PRs above an ignored block include the ignored commits, which defeats the point of `pr:ignore`. These groups stay local-only: {}",
         skipped_handles.join(", ")
@@ -1164,38 +1164,6 @@ fn build_from_groups_internal(
         groups,
         local_pr_branch_actions,
     })
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn build_from_groups_with_summary(
-    base: &str,
-    prefix: &str,
-    skipped_handles: &[String],
-    no_pr: bool,
-    execution_mode: ExecutionMode,
-    pr_description_mode: PrDescriptionMode,
-    limit: Option<Limit>,
-    groups: Vec<Group>,
-    list_order: ListOrder,
-    allow_branch_reuse: bool,
-    branch_reuse_guard_days: u32,
-    local_pr_branch_policy: LocalPrBranchSyncPolicy,
-) -> Result<UpdateExecutionData> {
-    build_from_groups_with_summary_with_validation(
-        base,
-        prefix,
-        skipped_handles,
-        no_pr,
-        execution_mode,
-        pr_description_mode,
-        limit,
-        groups,
-        list_order,
-        allow_branch_reuse,
-        branch_reuse_guard_days,
-        local_pr_branch_policy,
-        UpdatePushValidation::Legacy,
-    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,16 @@ pub enum DirtyWorktreePolicy {
     Halt,
 }
 
+/// How `spr update` handles pre-push validation.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateValidationPolicy {
+    /// Preserve Git's normal pre-push hook behavior.
+    Legacy,
+    /// Require matching `spr validate` receipts and skip push-time hooks.
+    Required,
+}
+
 /// Output ordering for list-style displays.
 ///
 /// The local stack order remains bottom-up and continues to define local PR numbers and
@@ -130,6 +140,8 @@ pub struct FileConfig {
     ///
     /// `0` effectively disables the guard for past terminal PRs.
     pub branch_reuse_guard_days: Option<u32>,
+    /// How `spr update` handles explicit per-PR validation receipts.
+    pub update_validation: Option<UpdateValidationPolicy>,
 }
 
 #[derive(Debug, Clone)]
@@ -154,6 +166,8 @@ pub struct Config {
     ///
     /// `0` effectively disables the guard for past terminal PRs.
     pub branch_reuse_guard_days: u32,
+    /// How `spr update` handles explicit per-PR validation receipts.
+    pub update_validation: UpdateValidationPolicy,
 }
 
 /// Normalize a configured branch prefix and reject values outside the ASCII-only conflict domain.
@@ -193,6 +207,7 @@ fn default_config() -> Config {
         restack_conflict: RestackConflictPolicy::Halt,
         dirty_worktree: DirtyWorktreePolicy::Halt,
         branch_reuse_guard_days: 180,
+        update_validation: UpdateValidationPolicy::Legacy,
     }
 }
 
@@ -227,6 +242,9 @@ fn apply_overrides(config: &Config, overrides: FileConfig) -> Config {
     }
     if let Some(branch_reuse_guard_days) = overrides.branch_reuse_guard_days {
         merged.branch_reuse_guard_days = branch_reuse_guard_days;
+    }
+    if let Some(update_validation) = overrides.update_validation {
+        merged.update_validation = update_validation;
     }
     merged
 }
@@ -268,7 +286,7 @@ mod tests {
     use super::{
         apply_overrides, default_config, load_config, normalize_config, normalize_prefix,
         read_config_file, DirtyWorktreePolicy, FileConfig, LocalPrBranchSyncPolicy,
-        PrDescriptionMode, RestackConflictPolicy,
+        PrDescriptionMode, RestackConflictPolicy, UpdateValidationPolicy,
     };
     use crate::test_support::{git, init_repo, lock_cwd, DirGuard};
     use std::env;
@@ -468,6 +486,48 @@ restack_conflict: rollback
     }
 
     #[test]
+    fn default_config_preserves_legacy_update_validation() {
+        let cfg = default_config();
+
+        assert_eq!(cfg.update_validation, UpdateValidationPolicy::Legacy);
+    }
+
+    #[test]
+    fn read_config_file_parses_required_update_validation() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".spr_multicommit_cfg.yml");
+        fs::write(&path, "update_validation: required\n").unwrap();
+
+        let cfg = read_config_file(&path).unwrap().unwrap();
+        assert_eq!(
+            cfg.update_validation,
+            Some(UpdateValidationPolicy::Required)
+        );
+    }
+
+    #[test]
+    fn apply_overrides_updates_validation_policy() {
+        let merged = apply_overrides(
+            &default_config(),
+            FileConfig {
+                base: None,
+                prefix: None,
+                land: None,
+                ignore_tag: None,
+                pr_description_mode: None,
+                list_order: None,
+                local_pr_branches: None,
+                restack_conflict: None,
+                dirty_worktree: None,
+                branch_reuse_guard_days: None,
+                update_validation: Some(UpdateValidationPolicy::Required),
+            },
+        );
+
+        assert_eq!(merged.update_validation, UpdateValidationPolicy::Required);
+    }
+
+    #[test]
     fn read_config_file_parses_local_pr_branch_sync_policy() {
         let dir = tempdir().unwrap();
         let mut path = dir.path().to_path_buf();
@@ -512,6 +572,7 @@ restack_conflict: rollback
                 restack_conflict: None,
                 dirty_worktree: None,
                 branch_reuse_guard_days: Some(30),
+                update_validation: None,
             },
         );
 
@@ -533,6 +594,7 @@ restack_conflict: rollback
                 restack_conflict: None,
                 dirty_worktree: None,
                 branch_reuse_guard_days: None,
+                update_validation: None,
             },
         );
 

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -29,6 +29,7 @@ pub enum JsonCommand {
     Status,
     SyncLocalBranches,
     Update,
+    Validate,
     Prep,
     RelinkPrs,
     Cleanup,
@@ -328,6 +329,8 @@ pub fn command_for_raw_args(args: &[OsString]) -> JsonCommand {
                 return JsonCommand::SyncLocalBranches;
             } else if arg == "update" || arg == "u" {
                 return JsonCommand::Update;
+            } else if arg == "validate" || arg == "v" {
+                return JsonCommand::Validate;
             } else if arg == "prep" {
                 return JsonCommand::Prep;
             } else if arg == "relink-prs" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
             .map(crate::commands::looks_like_pr_url)
             .unwrap_or(false),
         crate::cli::Cmd::Update { no_pr, .. } => !*no_pr,
-        crate::cli::Cmd::Validate => false,
+        crate::cli::Cmd::Validate { .. } => false,
         crate::cli::Cmd::List { .. }
         | crate::cli::Cmd::Status
         | crate::cli::Cmd::Prep { .. }
@@ -564,12 +564,12 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 }
             }
         }
-        crate::cli::Cmd::Validate => {
+        crate::cli::Cmd::Validate { from } => {
             let until = cli
                 .until
                 .unwrap_or(crate::selectors::InclusiveSelector::All);
             let summary =
-                crate::validation::validate_current_stack(&base, &prefix, &ignore_tag, &until)?;
+                crate::validation::validate_stack(&base, &prefix, &ignore_tag, &from, &until)?;
             if output_format == crate::cli::OutputFormat::Json {
                 Ok(CommandOutput::Validate(crate::validation_output::summary(
                     summary,
@@ -792,6 +792,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     local_pr_branch_policy,
                     selection,
                     execution_mode,
+                    update_validation,
                 },
             )?;
             if output_format == crate::cli::OutputFormat::Json {
@@ -1257,7 +1258,7 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
         crate::cli::Cmd::FixPr { .. } => crate::machine_output::MachineCommand::FixPr,
         crate::cli::Cmd::Move { .. } => crate::machine_output::MachineCommand::Move,
         crate::cli::Cmd::Update { .. } => crate::machine_output::MachineCommand::Update,
-        crate::cli::Cmd::Validate => crate::machine_output::MachineCommand::Validate,
+        crate::cli::Cmd::Validate { .. } => crate::machine_output::MachineCommand::Validate,
         crate::cli::Cmd::Prep { .. } => crate::machine_output::MachineCommand::Prep,
         crate::cli::Cmd::List { what, .. } => match what {
             crate::cli::ListWhat::Pr => crate::machine_output::MachineCommand::ListPr,
@@ -1470,7 +1471,9 @@ mod tests {
 
     #[test]
     fn validate_stays_local_only_for_tool_checks() {
-        assert!(!command_requires_gh(&crate::cli::Cmd::Validate));
+        assert!(!command_requires_gh(&crate::cli::Cmd::Validate {
+            from: "HEAD".to_string(),
+        }));
     }
 
     #[test]
@@ -1537,6 +1540,7 @@ mod tests {
             ["config", "user.email", "spr@example.com"].as_slice(),
         );
         git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        git(&repo, ["config", "core.hooksPath", ".git/hooks"].as_slice());
         write_file(&repo, "README.md", "init\n");
         git(&repo, ["add", "README.md"].as_slice());
         git(&repo, ["commit", "-m", "init"].as_slice());
@@ -1921,7 +1925,7 @@ mod tests {
     }
 
     #[test]
-    fn required_update_pr_limit_uses_only_selected_validation_receipts() {
+    fn required_update_until_uses_only_selected_validation_receipts() {
         let _lock = lock_cwd();
         let _restore = CurrentDirGuard::capture();
         let dir = init_update_stack_repo();
@@ -1955,11 +1959,10 @@ mod tests {
             "main",
             "--prefix",
             "dank-spr/",
+            "--until",
+            "pr:alpha",
             "update",
             "--no-pr",
-            "pr",
-            "--to",
-            "alpha",
         ])
         .unwrap();
         run_cli(partial_update_cli, OutputFormat::Human).unwrap();
@@ -1989,6 +1992,71 @@ mod tests {
         );
         assert!(!alpha_remote.trim().is_empty());
         assert!(beta_remote.trim().is_empty());
+    }
+
+    #[test]
+    fn required_update_from_ref_accepts_matching_validate_from_receipts() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        git(&repo, ["branch", "old-stack", "HEAD"].as_slice());
+        commit_file(&repo, "gamma.txt", "gamma-1\n", "feat: gamma pr:gamma");
+        fs::write(
+            dir.path().join(".spr_multicommit_cfg.yml"),
+            "update_validation: required\n",
+        )
+        .unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let validate_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "v",
+            "--from",
+            "old-stack",
+        ])
+        .unwrap();
+        run_cli(validate_cli, OutputFormat::Human).unwrap();
+
+        let update_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "update",
+            "--from",
+            "old-stack",
+            "--no-pr",
+        ])
+        .unwrap();
+        run_cli(update_cli, OutputFormat::Human).unwrap();
+
+        assert!(!git(
+            &repo,
+            ["ls-remote", "--heads", "origin", "dank-spr/alpha"].as_slice(),
+        )
+        .trim()
+        .is_empty());
+        assert!(!git(
+            &repo,
+            ["ls-remote", "--heads", "origin", "dank-spr/beta"].as_slice(),
+        )
+        .trim()
+        .is_empty());
+        assert!(git(
+            &repo,
+            ["ls-remote", "--heads", "origin", "dank-spr/gamma"].as_slice(),
+        )
+        .trim()
+        .is_empty());
     }
 
     #[test]
@@ -2216,6 +2284,53 @@ mod tests {
                 other => panic!("unexpected maintenance payload: {:?}", other),
             },
             other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn required_validation_blocks_prep_publication_after_local_rewrite() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        fs::write(
+            dir.path().join(".spr_multicommit_cfg.yml"),
+            "update_validation: required\n",
+        )
+        .unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let origin_url = format!("file://{}", dir.path().join("origin.git").display());
+        git(
+            &repo,
+            ["remote", "set-url", "origin", origin_url.as_str()].as_slice(),
+        );
+        let original_head = rev_parse(&repo, "HEAD");
+        let log_path = repo.join("gh.log");
+        let script = prep_json_gh_script(&log_path);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "prep",
+            "--json",
+        ])
+        .unwrap();
+
+        let error = run_cli(cli, OutputFormat::Json).unwrap_err();
+
+        assert!(format!("{error:#}").contains("missing or stale"));
+        assert_ne!(rev_parse(&repo, "HEAD"), original_head);
+        for branch in ["dank-spr/alpha", "dank-spr/beta"] {
+            assert!(
+                git(&repo, ["ls-remote", "--heads", "origin", branch].as_slice())
+                    .trim()
+                    .is_empty()
+            );
         }
     }
 
@@ -2926,6 +3041,11 @@ mod tests {
                     data.options.local_pr_branches,
                     crate::config::LocalPrBranchSyncPolicy::Off
                 );
+                assert_eq!(
+                    data.options.update_validation,
+                    crate::config::UpdateValidationPolicy::Legacy
+                );
+                assert!(!data.options.skip_validation);
                 assert_eq!(data.extent, ResolvedUpdateLimit::All);
                 assert!(data.warnings.is_empty());
                 assert!(data.skipped_groups.is_empty());
@@ -3007,6 +3127,52 @@ mod tests {
                 assert!(!local_branch_exists(&repo, "dank-spr/beta"));
             }
             other => panic!("unexpected command output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_json_reports_required_validation_and_skip_override() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        fs::write(
+            dir.path().join(".spr_multicommit_cfg.yml"),
+            "update_validation: required\n",
+        )
+        .unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let (_wrapper_dir, _path_guard) = install_failing_gh_wrapper();
+
+        for (extra_args, expected_skip) in [(&[][..], false), (&["--skip-validation"][..], true)] {
+            let mut args = vec![
+                "spr",
+                "--cd",
+                repo.to_str().unwrap(),
+                "--base",
+                "main",
+                "--prefix",
+                "dank-spr/",
+                "update",
+                "--dry-run",
+                "--json",
+                "--no-pr",
+            ];
+            args.extend_from_slice(extra_args);
+            let cli = crate::cli::Cli::try_parse_from(args).unwrap();
+
+            let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+            match output {
+                CommandOutput::Update(output) => {
+                    assert_eq!(
+                        output.data.options.update_validation,
+                        crate::config::UpdateValidationPolicy::Required
+                    );
+                    assert_eq!(output.data.options.skip_validation, expected_skip);
+                }
+                other => panic!("unexpected command output: {:?}", other),
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ mod summary_output;
 #[cfg(test)]
 mod test_support;
 mod update_output;
+mod validation;
+mod validation_output;
 
 fn resolve_update_until_limit(
     groups: &[crate::parsing::Group],
@@ -68,6 +70,7 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
             .map(crate::commands::looks_like_pr_url)
             .unwrap_or(false),
         crate::cli::Cmd::Update { no_pr, .. } => !*no_pr,
+        crate::cli::Cmd::Validate => false,
         crate::cli::Cmd::List { .. }
         | crate::cli::Cmd::Status
         | crate::cli::Cmd::Prep { .. }
@@ -89,6 +92,7 @@ enum CommandOutput {
     RestackPreview(crate::restack_output::RestackPreviewOutput),
     ResolveStack(crate::commands::ResolveStackOutput),
     Update(crate::update_output::UpdateOutput),
+    Validate(crate::validation_output::ValidationOutput),
     Maintenance(Box<crate::maintenance_output::MaintenanceOutput>),
     Error(crate::json_output::ErrorOutput),
 }
@@ -438,6 +442,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
     let dirty_worktree_policy = cfg.dirty_worktree;
     let list_order = cfg.list_order;
     let branch_reuse_guard_days = cfg.branch_reuse_guard_days;
+    let update_validation = cfg.update_validation;
     let local_pr_branch_policy = cli.local_pr_branches.unwrap_or(cfg.local_pr_branches);
     match cli.cmd {
         crate::cli::Cmd::Update {
@@ -447,6 +452,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             assume_existing_prs,
             pr_description_mode: pr_description_mode_override,
             allow_branch_reuse,
+            skip_validation,
             dry_run,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
@@ -457,7 +463,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     "`spr update --restack` is deprecated. Use `spr restack --after N` instead."
                 ))
             } else {
-                let (_merge_base, leading_ignored, all_groups) =
+                let (merge_base, leading_ignored, all_groups) =
                     crate::parsing::derive_groups_between_with_ignored(&base, &from, &ignore_tag)?;
                 if all_groups.is_empty() {
                     return Err(anyhow::anyhow!(
@@ -471,21 +477,38 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 crate::branch_names::group_branch_identities(&groups, &prefix)?;
                 let (limit, resolved_extent) =
                     resolve_update_until_limit(&groups, cli.until.as_ref())?;
+                let update_validation = if skip_validation {
+                    crate::commands::UpdatePushValidation::Skip
+                } else if update_validation == crate::config::UpdateValidationPolicy::Required {
+                    crate::commands::UpdatePushValidation::Required(
+                        crate::validation::build_descriptors(
+                            &base,
+                            &prefix,
+                            &ignore_tag,
+                            &merge_base,
+                            &crate::limit::apply_limit_groups(groups.clone(), limit)?,
+                        )?,
+                    )
+                } else {
+                    crate::commands::UpdatePushValidation::Legacy
+                };
                 if output_format == crate::cli::OutputFormat::Json {
-                    let execution = crate::commands::build_from_groups_with_summary(
-                        &base,
-                        &prefix,
-                        &skipped_handles,
-                        no_pr,
-                        execution_mode,
-                        pr_description_mode,
-                        limit,
-                        groups,
-                        list_order,
-                        allow_branch_reuse,
-                        branch_reuse_guard_days,
-                        local_pr_branch_policy,
-                    )?;
+                    let execution =
+                        crate::commands::build_from_groups_with_summary_with_validation(
+                            &base,
+                            &prefix,
+                            &skipped_handles,
+                            no_pr,
+                            execution_mode,
+                            pr_description_mode,
+                            limit,
+                            groups,
+                            list_order,
+                            allow_branch_reuse,
+                            branch_reuse_guard_days,
+                            local_pr_branch_policy,
+                            update_validation,
+                        )?;
                     let mut summary = crate::update_output::UpdateSummaryData::from_execution(
                         crate::update_output::UpdateRepoContext {
                             base: base.clone(),
@@ -498,6 +521,8 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                             no_pr,
                             pr_description_mode,
                             local_pr_branches: local_pr_branch_policy,
+                            update_validation: cfg.update_validation,
+                            skip_validation,
                         },
                         resolved_extent,
                         execution,
@@ -514,7 +539,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         summary,
                     )))
                 } else {
-                    crate::commands::build_from_groups(
+                    crate::commands::build_from_groups_with_validation(
                         &base,
                         &prefix,
                         &skipped_handles,
@@ -527,6 +552,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                         allow_branch_reuse,
                         branch_reuse_guard_days,
                         local_pr_branch_policy,
+                        update_validation,
                     )?;
                     if execution_mode == ExecutionMode::Apply
                         && refresh_metadata_after_update(&metadata_refresh_context)?
@@ -536,6 +562,21 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     }
                     Ok(CommandOutput::None)
                 }
+            }
+        }
+        crate::cli::Cmd::Validate => {
+            let until = cli
+                .until
+                .unwrap_or(crate::selectors::InclusiveSelector::All);
+            let summary =
+                crate::validation::validate_current_stack(&base, &prefix, &ignore_tag, &until)?;
+            if output_format == crate::cli::OutputFormat::Json {
+                Ok(CommandOutput::Validate(crate::validation_output::summary(
+                    summary,
+                )))
+            } else {
+                crate::validation::print_validation_summary(&summary);
+                Ok(CommandOutput::None)
             }
         }
         crate::cli::Cmd::Restack {
@@ -1167,6 +1208,11 @@ fn main() {
                     exit_with_json(&output, output.exit_code());
                 }
             }
+            CommandOutput::Validate(output) => {
+                if output_format == crate::cli::OutputFormat::Json {
+                    exit_with_json(&output, output.exit_code());
+                }
+            }
             CommandOutput::Maintenance(output) => {
                 if output_format == crate::cli::OutputFormat::Json {
                     exit_with_json(&output, output.exit_code());
@@ -1211,6 +1257,7 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
         crate::cli::Cmd::FixPr { .. } => crate::machine_output::MachineCommand::FixPr,
         crate::cli::Cmd::Move { .. } => crate::machine_output::MachineCommand::Move,
         crate::cli::Cmd::Update { .. } => crate::machine_output::MachineCommand::Update,
+        crate::cli::Cmd::Validate => crate::machine_output::MachineCommand::Validate,
         crate::cli::Cmd::Prep { .. } => crate::machine_output::MachineCommand::Prep,
         crate::cli::Cmd::List { what, .. } => match what {
             crate::cli::ListWhat::Pr => crate::machine_output::MachineCommand::ListPr,
@@ -1422,6 +1469,11 @@ mod tests {
     }
 
     #[test]
+    fn validate_stays_local_only_for_tool_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::Validate));
+    }
+
+    #[test]
     fn update_without_no_pr_requires_github_cli() {
         assert!(command_requires_gh(&crate::cli::Cmd::Update {
             from: "HEAD".to_string(),
@@ -1430,6 +1482,7 @@ mod tests {
             assume_existing_prs: false,
             pr_description_mode: None,
             allow_branch_reuse: false,
+            skip_validation: false,
             dry_run: DryRunArgs::default(),
         }));
     }
@@ -1443,6 +1496,7 @@ mod tests {
             assume_existing_prs: false,
             pr_description_mode: None,
             allow_branch_reuse: false,
+            skip_validation: false,
             dry_run: DryRunArgs::default(),
         }));
     }
@@ -1730,6 +1784,28 @@ mod tests {
     }
 
     #[test]
+    fn json_command_for_raw_args_detects_validate() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("validate"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(json_command_for_raw_args(&args), JsonCommand::Validate);
+    }
+
+    #[test]
+    fn json_command_for_raw_args_detects_validate_alias() {
+        let args = vec![
+            OsString::from("spr"),
+            OsString::from("v"),
+            OsString::from("--json"),
+        ];
+
+        assert_eq!(json_command_for_raw_args(&args), JsonCommand::Validate);
+    }
+
+    #[test]
     fn json_command_for_raw_args_detects_drop_merged_prefix() {
         let args = vec![
             OsString::from("spr"),
@@ -1805,6 +1881,114 @@ mod tests {
             .expect("json parse failure should serialize");
 
         assert_eq!(output.command, JsonCommand::Update);
+    }
+
+    #[test]
+    fn validate_json_reports_receipt_summary() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let dir = init_update_stack_repo();
+        std::env::set_current_dir(dir.path().join("repo")).unwrap();
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr", "--base", "main", "--prefix", "spr/", "validate",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::Validate(output) => {
+                assert_eq!(output.command, JsonCommand::Validate);
+                assert!(output.data.success);
+                assert_eq!(output.data.validated_group_count, 2);
+                assert_eq!(output.data.recorded_group_count, 2);
+                assert_eq!(output.data.reused_group_count, 0);
+                assert!(!output.data.pre_push_hook_present);
+                assert_eq!(output.data.receipts.len(), 2);
+                assert_eq!(output.data.receipts[0].stable_handle, "pr:alpha");
+                assert_eq!(output.data.receipts[1].stable_handle, "pr:beta");
+                assert!(output.data.receipts.iter().all(|receipt| {
+                    receipt.action == crate::validation::ValidationReceiptAction::Recorded
+                }));
+                assert!(output
+                    .data
+                    .receipts
+                    .iter()
+                    .all(|receipt| Path::new(&receipt.path).is_file()));
+            }
+            other => panic!("unexpected output: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn required_update_pr_limit_uses_only_selected_validation_receipts() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        fs::write(
+            dir.path().join(".spr_multicommit_cfg.yml"),
+            "update_validation: required\n",
+        )
+        .unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let validate_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "--until",
+            "1",
+            "v",
+        ])
+        .unwrap();
+        run_cli(validate_cli, OutputFormat::Human).unwrap();
+
+        let partial_update_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "update",
+            "--no-pr",
+            "pr",
+            "--to",
+            "alpha",
+        ])
+        .unwrap();
+        run_cli(partial_update_cli, OutputFormat::Human).unwrap();
+
+        let full_update_cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "update",
+            "--no-pr",
+        ])
+        .unwrap();
+        let err = run_cli(full_update_cli, OutputFormat::Human).unwrap_err();
+
+        assert!(format!("{err:#}").contains("pr:beta"));
+        let alpha_remote = git(
+            &repo,
+            ["ls-remote", "--heads", "origin", "dank-spr/alpha"].as_slice(),
+        );
+        let beta_remote = git(
+            &repo,
+            ["ls-remote", "--heads", "origin", "dank-spr/beta"].as_slice(),
+        );
+        assert!(!alpha_remote.trim().is_empty());
+        assert!(beta_remote.trim().is_empty());
     }
 
     #[test]

--- a/src/update_output.rs
+++ b/src/update_output.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::config::{LocalPrBranchSyncPolicy, PrDescriptionMode};
+use crate::config::{LocalPrBranchSyncPolicy, PrDescriptionMode, UpdateValidationPolicy};
 use crate::json_output::JsonCommand;
 use crate::local_pr_branches::LocalPrBranchAction;
 use crate::summary_output::SummaryOutput;
@@ -32,6 +32,8 @@ pub struct UpdateOptions {
     pub no_pr: bool,
     pub pr_description_mode: PrDescriptionMode,
     pub local_pr_branches: LocalPrBranchSyncPolicy,
+    pub update_validation: UpdateValidationPolicy,
+    pub skip_validation: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::branch_names::group_branch_identities;
 use crate::git::{git_common_dir, git_rev_parse, git_ro, repo_root};
-use crate::parsing::{derive_local_groups_with_ignored, split_groups_for_update, Group};
+use crate::parsing::{derive_groups_between_with_ignored, split_groups_for_update, Group};
 use crate::selectors::{resolve_inclusive_count, InclusiveSelector};
 
 const VALIDATION_PROTOCOL_VERSION: u32 = 2;
@@ -142,11 +142,21 @@ fn now_rfc3339() -> Result<String> {
 }
 
 fn origin_push_url() -> Result<String> {
-    Ok(
-        git_ro(["remote", "get-url", "--push", "origin"].as_slice())?
-            .trim()
-            .to_string(),
-    )
+    let output = git_ro(["remote", "get-url", "--push", "--all", "origin"].as_slice())?;
+    let urls = output
+        .lines()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .collect::<Vec<_>>();
+    match urls.as_slice() {
+        [url] => Ok((*url).to_string()),
+        [] => bail!("origin has no configured push URL"),
+        _ => bail!(
+            "validation receipts require exactly one origin push URL, but found {}: {}",
+            urls.len(),
+            urls.join(", ")
+        ),
+    }
 }
 
 fn pre_push_hook_fingerprint(repo_root: &Path) -> Result<HookFingerprint> {
@@ -315,6 +325,7 @@ fn hook_input_path() -> PathBuf {
 
 fn run_pre_push_hook(
     worktree: &Path,
+    pre_push_hook: &HookFingerprint,
     origin_push_url: &str,
     branch: &str,
     previous_tip: &str,
@@ -327,9 +338,14 @@ fn run_pre_push_hook(
         format!("{ref_name} {current_tip} {ref_name} {previous_tip}\n"),
     )
     .with_context(|| format!("failed to write hook input {}", input_path.display()))?;
-    let output = Command::new("git")
+    let hooks_path = Path::new(&pre_push_hook.path)
+        .parent()
+        .ok_or_else(|| anyhow!("pre-push hook path {} has no parent", pre_push_hook.path))?;
+    let status = Command::new("git")
         .current_dir(worktree)
         .args([
+            "-c",
+            &format!("core.hooksPath={}", hooks_path.display()),
             "hook",
             "run",
             "--ignore-missing",
@@ -339,12 +355,10 @@ fn run_pre_push_hook(
             "origin",
             origin_push_url,
         ])
-        .output()
+        .status()
         .context("failed to spawn git hook run pre-push")?;
     let _ = fs::remove_file(&input_path);
-    eprint!("{}", String::from_utf8_lossy(&output.stdout));
-    eprint!("{}", String::from_utf8_lossy(&output.stderr));
-    if !output.status.success() {
+    if !status.success() {
         bail!("pre-push hook failed");
     }
     Ok(())
@@ -370,14 +384,25 @@ fn cleanup_worktree(worktree: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 pub fn validate_current_stack(
     base: &str,
     prefix: &str,
     ignore_tag: &str,
     until: &InclusiveSelector,
 ) -> Result<ValidationSummaryData> {
+    validate_stack(base, prefix, ignore_tag, "HEAD", until)
+}
+
+pub fn validate_stack(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    from: &str,
+    until: &InclusiveSelector,
+) -> Result<ValidationSummaryData> {
     let (merge_base, leading_ignored, all_groups) =
-        derive_local_groups_with_ignored(base, ignore_tag)?;
+        derive_groups_between_with_ignored(base, from, ignore_tag)?;
     let (mut groups, skipped_groups) = split_groups_for_update(&leading_ignored, all_groups);
     let group_count = resolve_inclusive_count(&groups, until)?;
     groups.truncate(group_count);
@@ -424,9 +449,10 @@ pub fn validate_current_stack(
                     &worktree,
                     ["checkout", "--detach", "--force", &descriptor.tip_sha].as_slice(),
                 )?;
-                run_git_in(&worktree, ["clean", "-fd"].as_slice())?;
+                run_git_in(&worktree, ["clean", "-fdx"].as_slice())?;
                 run_pre_push_hook(
                     &worktree,
+                    &descriptor.pre_push_hook,
                     &descriptor.origin_push_url,
                     &descriptor.head_branch,
                     &descriptor.previous_tip_sha,
@@ -507,26 +533,49 @@ pub fn validate_current_stack(
 }
 
 pub fn print_validation_summary(summary: &ValidationSummaryData) {
-    println!(
-        "Validated {} local PR boundary/boundaries ({} recorded, {} reused)",
-        summary.validated_group_count, summary.recorded_group_count, summary.reused_group_count
-    );
-    if summary.pre_push_hook_present {
-        for receipt in &summary.receipts {
-            if receipt.action == ValidationReceiptAction::Recorded {
-                println!("Recorded validation receipt: {}", receipt.path);
-            }
+    println!("{}", validation_status_line(summary));
+    if !summary.pre_push_hook_executable {
+        if summary.pre_push_hook_present {
+            println!("The configured pre-push hook is not executable");
+        } else {
+            println!("No pre-push hook is installed");
         }
-    } else {
-        println!("No executable pre-push hook is installed");
     }
+    for receipt in &summary.receipts {
+        if receipt.action == ValidationReceiptAction::Recorded {
+            println!("Recorded validation receipt: {}", receipt.path);
+        }
+    }
+    if !summary.skipped_groups.is_empty() {
+        eprintln!("{}", validation_skipped_groups_warning(summary).unwrap());
+    }
+}
+
+fn validation_status_line(summary: &ValidationSummaryData) -> String {
+    if summary.pre_push_hook_executable {
+        format!(
+            "Validated {} local PR boundary/boundaries ({} recorded, {} reused)",
+            summary.validated_group_count, summary.recorded_group_count, summary.reused_group_count
+        )
+    } else {
+        format!(
+            "Recorded receipts for {} local PR boundary/boundaries without running a pre-push hook ({} recorded, {} reused)",
+            summary.validated_group_count, summary.recorded_group_count, summary.reused_group_count
+        )
+    }
+}
+
+fn validation_skipped_groups_warning(summary: &ValidationSummaryData) -> Option<String> {
+    (!summary.skipped_groups.is_empty())
+        .then(|| crate::commands::update::ignored_boundary_warning(&summary.skipped_groups))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_descriptors, require_matching_receipts, validate_current_stack,
-        ValidationReceiptAction, ValidationSummaryData,
+        build_descriptors, require_matching_receipts, validate_current_stack, validate_stack,
+        validation_skipped_groups_warning, validation_status_line, ValidationReceiptAction,
+        ValidationSummaryData,
     };
     use crate::commands::{build_from_groups_with_validation, UpdatePushValidation};
     use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
@@ -558,6 +607,7 @@ mod tests {
             ["config", "user.email", "spr@example.com"].as_slice(),
         );
         git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        git(&repo, ["config", "core.hooksPath", ".git/hooks"].as_slice());
         write_file(&repo, "README.md", "init\n");
         git(&repo, ["add", "README.md"].as_slice());
         git(&repo, ["commit", "-m", "init"].as_slice());
@@ -672,6 +722,23 @@ mod tests {
         commit_file(&repo.repo, "gamma.txt", "gamma tip\n", "gamma pr:gamma")
     }
 
+    fn validation_summary(
+        pre_push_hook_present: bool,
+        pre_push_hook_executable: bool,
+        skipped_groups: Vec<String>,
+    ) -> ValidationSummaryData {
+        ValidationSummaryData {
+            success: true,
+            validated_group_count: 2,
+            recorded_group_count: 2,
+            reused_group_count: 0,
+            skipped_groups,
+            receipts: Vec::new(),
+            pre_push_hook_present,
+            pre_push_hook_executable,
+        }
+    }
+
     #[test]
     fn validates_each_pr_tip_with_pr_local_ranges_and_historical_contents() {
         let _cwd_lock = lock_cwd();
@@ -725,6 +792,83 @@ mod tests {
     }
 
     #[test]
+    fn validation_fixture_overrides_machine_global_hooks_path() {
+        let repo = init_validation_repo();
+
+        assert_eq!(
+            git(
+                &repo.repo,
+                ["config", "--local", "--get", "core.hooksPath"].as_slice()
+            )
+            .trim(),
+            ".git/hooks"
+        );
+    }
+
+    #[test]
+    fn validate_from_ref_records_receipts_for_selected_source_stack() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        git(
+            &repo.repo,
+            ["branch", "old-stack", &repo.alpha_tip].as_slice(),
+        );
+
+        let summary = validate_stack(
+            "main",
+            "spr/",
+            "ignore",
+            "old-stack",
+            &InclusiveSelector::All,
+        )
+        .unwrap();
+
+        assert_eq!(summary.validated_group_count, 1);
+        assert_eq!(summary.receipts[0].stable_handle, "pr:alpha");
+        assert_eq!(summary.receipts[0].tip_sha, repo.alpha_tip);
+    }
+
+    #[test]
+    fn relative_hooks_path_executes_the_fingerprinted_hook_for_every_boundary() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        git(&repo.repo, ["checkout", "main"].as_slice());
+        git(&repo.repo, ["checkout", "-b", "relative-hooks"].as_slice());
+        git(
+            &repo.repo,
+            ["config", "core.hooksPath", "hooksdir"].as_slice(),
+        );
+        let hook = repo.repo.join("hooksdir/pre-push");
+        fs::create_dir_all(hook.parent().unwrap()).unwrap();
+        fs::write(
+            &hook,
+            format!("#!/bin/sh\nprintf a >> '{}'\n", repo.log.display()),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&hook).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook, permissions).unwrap();
+        git(&repo.repo, ["add", "hooksdir/pre-push"].as_slice());
+        git(
+            &repo.repo,
+            ["commit", "-m", "alpha hook pr:alpha"].as_slice(),
+        );
+        fs::write(
+            &hook,
+            format!("#!/bin/sh\nprintf b >> '{}'\n", repo.log.display()),
+        )
+        .unwrap();
+        git(&repo.repo, ["add", "hooksdir/pre-push"].as_slice());
+        git(&repo.repo, ["commit", "-m", "beta hook pr:beta"].as_slice());
+
+        validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), "bb");
+    }
+
+    #[test]
     fn non_executable_hook_succeeds_and_writes_receipts_without_running_hook() {
         let _cwd_lock = lock_cwd();
         let repo = init_validation_repo();
@@ -743,6 +887,28 @@ mod tests {
         assert!(summary.pre_push_hook_present);
         assert!(!summary.pre_push_hook_executable);
         assert!(!repo.log.exists());
+    }
+
+    #[test]
+    fn non_executable_hook_summary_says_receipts_were_recorded_without_running_hook() {
+        let line = validation_status_line(&validation_summary(true, false, Vec::new()));
+
+        assert!(line.contains("Recorded receipts"));
+        assert!(line.contains("without running a pre-push hook"));
+        assert!(!line.starts_with("Validated"));
+    }
+
+    #[test]
+    fn validation_summary_warns_about_skipped_ignored_groups() {
+        let warning = validation_skipped_groups_warning(&validation_summary(
+            false,
+            false,
+            vec!["pr:beta".to_string()],
+        ))
+        .unwrap();
+
+        assert!(warning.contains("Skipping PR groups above the ignored block"));
+        assert!(warning.contains("pr:beta"));
     }
 
     #[test]
@@ -802,6 +968,54 @@ mod tests {
         assert_eq!(summary.receipts[2].stable_handle, "pr:gamma");
         assert_eq!(summary.receipts[2].tip_sha, gamma_tip);
         assert_eq!(summary.receipts[2].previous_tip_sha, repo.beta_tip);
+    }
+
+    #[test]
+    fn validation_removes_ignored_artifacts_between_boundaries() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        write_file(&repo.repo, ".gitignore", "boundary-cache\n");
+        git(&repo.repo, ["add", ".gitignore"].as_slice());
+        git(
+            &repo.repo,
+            ["commit", "-m", "ignore validation cache"].as_slice(),
+        );
+        install_hook(
+            &repo,
+            "read local_ref _ _ _\ncase \"$local_ref\" in\n  refs/heads/spr/alpha) touch boundary-cache ;;\n  refs/heads/spr/beta) [ ! -e boundary-cache ] || exit 1 ;;\nesac\nexit 0",
+        );
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_eq!(summary.recorded_group_count, 2);
+        assert!(summary.success);
+    }
+
+    #[test]
+    fn validation_rejects_multiple_origin_push_urls() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        git(
+            &repo.repo,
+            ["config", "--add", "remote.origin.pushurl", "first"].as_slice(),
+        );
+        git(
+            &repo.repo,
+            ["config", "--add", "remote.origin.pushurl", "second"].as_slice(),
+        );
+        let (merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored("main", "ignore").unwrap();
+        let (groups, _) = split_groups_for_update(&leading_ignored, groups);
+
+        let error = build_descriptors("main", "spr/", "ignore", &merge_base, &groups).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("require exactly one origin push URL"));
+        assert!(error.to_string().contains("first, second"));
     }
 
     #[test]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,1084 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::branch_names::group_branch_identities;
+use crate::git::{git_common_dir, git_rev_parse, git_ro, repo_root};
+use crate::parsing::{derive_local_groups_with_ignored, split_groups_for_update, Group};
+use crate::selectors::{resolve_inclusive_count, InclusiveSelector};
+
+const VALIDATION_PROTOCOL_VERSION: u32 = 2;
+const RECEIPT_DIR_NAME: &str = "validation_receipts_v2";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookFingerprint {
+    pub path: String,
+    pub present: bool,
+    pub executable: bool,
+    pub content_hash: Option<String>,
+}
+
+impl HookFingerprint {
+    fn effective(&self) -> bool {
+        self.present && self.executable
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationDescriptor {
+    pub protocol_version: u32,
+    pub base_ref: String,
+    pub base_sha: String,
+    pub merge_base: String,
+    pub prefix: String,
+    pub ignore_tag: String,
+    pub origin_push_url: String,
+    pub pre_push_hook: HookFingerprint,
+    pub stable_handle: String,
+    pub head_branch: String,
+    pub previous_tip_sha: String,
+    pub tip_sha: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationReceipt {
+    pub digest: String,
+    pub validated_at: String,
+    pub descriptor: ValidationDescriptor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ValidationSummaryData {
+    pub success: bool,
+    pub validated_group_count: usize,
+    pub recorded_group_count: usize,
+    pub reused_group_count: usize,
+    pub skipped_groups: Vec<String>,
+    pub receipts: Vec<ValidationReceiptSummaryData>,
+    pub pre_push_hook_present: bool,
+    pub pre_push_hook_executable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationReceiptAction {
+    Recorded,
+    Reused,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ValidationReceiptSummaryData {
+    pub local_pr_number: usize,
+    pub stable_handle: String,
+    pub head_branch: String,
+    pub previous_tip_sha: String,
+    pub tip_sha: String,
+    pub action: ValidationReceiptAction,
+    pub digest: String,
+    pub path: String,
+}
+
+fn run_git(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to spawn git {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn run_git_in(path: &Path, args: &[&str]) -> Result<String> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| anyhow!("non-UTF-8 worktree path {}", path.display()))?;
+    let mut argv = vec!["-C", path];
+    argv.extend_from_slice(args);
+    run_git(&argv)
+}
+
+fn hash_bytes(bytes: &[u8]) -> Result<String> {
+    let mut child = Command::new("git")
+        .args(["hash-object", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("failed to spawn git hash-object --stdin")?;
+    child
+        .stdin
+        .take()
+        .context("git hash-object stdin unavailable")?
+        .write_all(bytes)
+        .context("failed to write git hash-object stdin")?;
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for git hash-object")?;
+    if !output.status.success() {
+        bail!(
+            "git hash-object --stdin failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn now_rfc3339() -> Result<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format RFC3339 timestamp")
+}
+
+fn origin_push_url() -> Result<String> {
+    Ok(
+        git_ro(["remote", "get-url", "--push", "origin"].as_slice())?
+            .trim()
+            .to_string(),
+    )
+}
+
+fn pre_push_hook_fingerprint(repo_root: &Path) -> Result<HookFingerprint> {
+    let reported = git_ro(["rev-parse", "--git-path", "hooks/pre-push"].as_slice())?;
+    let reported = reported.trim();
+    let path = if Path::new(reported).is_absolute() {
+        PathBuf::from(reported)
+    } else {
+        repo_root.join(reported)
+    };
+    let present = path.is_file();
+    let executable = if present {
+        fs::metadata(&path)
+            .with_context(|| format!("failed to inspect hook {}", path.display()))?
+            .permissions()
+            .mode()
+            & 0o111
+            != 0
+    } else {
+        false
+    };
+    let content_hash = if present {
+        Some(hash_bytes(&fs::read(&path).with_context(|| {
+            format!("failed to read hook {}", path.display())
+        })?)?)
+    } else {
+        None
+    };
+    Ok(HookFingerprint {
+        path: path.display().to_string(),
+        present,
+        executable,
+        content_hash,
+    })
+}
+
+pub fn build_descriptors(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    merge_base: &str,
+    groups: &[Group],
+) -> Result<Vec<ValidationDescriptor>> {
+    let root = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
+    let base_sha = git_rev_parse(base)?;
+    let origin_push_url = origin_push_url()?;
+    let pre_push_hook = pre_push_hook_fingerprint(Path::new(&root))?;
+    let branch_identities = group_branch_identities(groups, prefix)?;
+    let mut previous_tip_sha = merge_base.to_string();
+    groups
+        .iter()
+        .zip(branch_identities)
+        .map(|(group, identity)| {
+            let tip_sha = group
+                .commits
+                .last()
+                .cloned()
+                .ok_or_else(|| anyhow!("group {} has no commits", group.selector_text()))?;
+            let descriptor = ValidationDescriptor {
+                protocol_version: VALIDATION_PROTOCOL_VERSION,
+                base_ref: base.to_string(),
+                base_sha: base_sha.clone(),
+                merge_base: merge_base.to_string(),
+                prefix: prefix.to_string(),
+                ignore_tag: ignore_tag.to_string(),
+                origin_push_url: origin_push_url.clone(),
+                pre_push_hook: pre_push_hook.clone(),
+                stable_handle: group.selector_text(),
+                head_branch: identity.exact,
+                previous_tip_sha: previous_tip_sha.clone(),
+                tip_sha: tip_sha.clone(),
+            };
+            previous_tip_sha = tip_sha;
+            Ok(descriptor)
+        })
+        .collect()
+}
+
+pub fn descriptor_digest(descriptor: &ValidationDescriptor) -> Result<String> {
+    hash_bytes(&serde_json::to_vec(descriptor).context("failed to encode validation descriptor")?)
+}
+
+pub fn receipt_path_for_digest(digest: &str) -> Result<PathBuf> {
+    Ok(git_common_dir()?
+        .join("spr")
+        .join(RECEIPT_DIR_NAME)
+        .join(format!("{digest}.json")))
+}
+
+fn matching_receipt_path(descriptor: &ValidationDescriptor) -> Result<Option<PathBuf>> {
+    let digest = descriptor_digest(descriptor)?;
+    let path = receipt_path_for_digest(&digest)?;
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read validation receipt {}", path.display()));
+        }
+    };
+    let receipt: ValidationReceipt = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse validation receipt {}", path.display()))?;
+    if receipt.digest != digest || receipt.descriptor != *descriptor {
+        return Ok(None);
+    }
+    Ok(Some(path))
+}
+
+pub fn require_matching_receipts(descriptors: &[ValidationDescriptor]) -> Result<Vec<PathBuf>> {
+    descriptors
+        .iter()
+        .map(|descriptor| {
+            let digest = descriptor_digest(descriptor)?;
+            let expected_path = receipt_path_for_digest(&digest)?;
+            matching_receipt_path(descriptor)?.ok_or_else(|| {
+                anyhow!(
+                    "missing or stale `spr validate` receipt for {}; run `spr validate` or rerun `spr update --skip-validation` to bypass validation ({})",
+                    descriptor.stable_handle,
+                    expected_path.display()
+                )
+            })
+        })
+        .collect()
+}
+
+fn write_receipt(descriptor: ValidationDescriptor) -> Result<(String, PathBuf)> {
+    let digest = descriptor_digest(&descriptor)?;
+    let path = receipt_path_for_digest(&digest)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("validation receipt path {} has no parent", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create validation receipt directory {}",
+            parent.display()
+        )
+    })?;
+    let receipt = ValidationReceipt {
+        digest: digest.clone(),
+        validated_at: now_rfc3339()?,
+        descriptor,
+    };
+    let temp_path = parent.join(format!(".{digest}.{}.tmp", Uuid::new_v4()));
+    fs::write(
+        &temp_path,
+        serde_json::to_vec_pretty(&receipt).context("failed to encode validation receipt")?,
+    )
+    .with_context(|| format!("failed to write validation receipt {}", temp_path.display()))?;
+    fs::rename(&temp_path, &path).with_context(|| {
+        format!(
+            "failed to rename validation receipt {} to {}",
+            temp_path.display(),
+            path.display()
+        )
+    })?;
+    Ok((digest, path))
+}
+
+fn worktree_path() -> PathBuf {
+    std::env::temp_dir().join(format!("spr-validate-{}", Uuid::new_v4()))
+}
+
+fn hook_input_path() -> PathBuf {
+    std::env::temp_dir().join(format!("spr-validate-hook-input-{}", Uuid::new_v4()))
+}
+
+fn run_pre_push_hook(
+    worktree: &Path,
+    origin_push_url: &str,
+    branch: &str,
+    previous_tip: &str,
+    current_tip: &str,
+) -> Result<()> {
+    let input_path = hook_input_path();
+    let ref_name = format!("refs/heads/{branch}");
+    fs::write(
+        &input_path,
+        format!("{ref_name} {current_tip} {ref_name} {previous_tip}\n"),
+    )
+    .with_context(|| format!("failed to write hook input {}", input_path.display()))?;
+    let output = Command::new("git")
+        .current_dir(worktree)
+        .args([
+            "hook",
+            "run",
+            "--ignore-missing",
+            &format!("--to-stdin={}", input_path.display()),
+            "pre-push",
+            "--",
+            "origin",
+            origin_push_url,
+        ])
+        .output()
+        .context("failed to spawn git hook run pre-push")?;
+    let _ = fs::remove_file(&input_path);
+    eprint!("{}", String::from_utf8_lossy(&output.stdout));
+    eprint!("{}", String::from_utf8_lossy(&output.stderr));
+    if !output.status.success() {
+        bail!("pre-push hook failed");
+    }
+    Ok(())
+}
+
+fn tracked_changes(worktree: &Path) -> Result<String> {
+    run_git_in(
+        worktree,
+        ["status", "--porcelain", "--untracked-files=no"].as_slice(),
+    )
+}
+
+fn cleanup_worktree(worktree: &Path) -> Result<()> {
+    run_git(
+        [
+            "worktree",
+            "remove",
+            "--force",
+            &worktree.display().to_string(),
+        ]
+        .as_slice(),
+    )?;
+    Ok(())
+}
+
+pub fn validate_current_stack(
+    base: &str,
+    prefix: &str,
+    ignore_tag: &str,
+    until: &InclusiveSelector,
+) -> Result<ValidationSummaryData> {
+    let (merge_base, leading_ignored, all_groups) =
+        derive_local_groups_with_ignored(base, ignore_tag)?;
+    let (mut groups, skipped_groups) = split_groups_for_update(&leading_ignored, all_groups);
+    let group_count = resolve_inclusive_count(&groups, until)?;
+    groups.truncate(group_count);
+    let descriptors = build_descriptors(base, prefix, ignore_tag, &merge_base, &groups)?;
+    let pre_push_hook = if let Some(descriptor) = descriptors.first() {
+        descriptor.pre_push_hook.clone()
+    } else {
+        let root = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
+        pre_push_hook_fingerprint(Path::new(&root))?
+    };
+    let missing_indices = descriptors
+        .iter()
+        .enumerate()
+        .filter_map(
+            |(index, descriptor)| match matching_receipt_path(descriptor) {
+                Ok(Some(_)) => None,
+                Ok(None) => Some(Ok(index)),
+                Err(err) => Some(Err(err)),
+            },
+        )
+        .collect::<Result<Vec<_>>>()?;
+    if pre_push_hook.effective() && !missing_indices.is_empty() {
+        let worktree = worktree_path();
+        run_git(
+            [
+                "worktree",
+                "add",
+                "--detach",
+                &worktree.display().to_string(),
+                &merge_base,
+            ]
+            .as_slice(),
+        )?;
+        let validation_result = (|| {
+            for group_idx in &missing_indices {
+                let descriptor = &descriptors[*group_idx];
+                info!(
+                    "Validating local PR #{} / {} at {}",
+                    group_idx + 1,
+                    descriptor.stable_handle,
+                    descriptor.tip_sha
+                );
+                run_git_in(
+                    &worktree,
+                    ["checkout", "--detach", "--force", &descriptor.tip_sha].as_slice(),
+                )?;
+                run_git_in(&worktree, ["clean", "-fd"].as_slice())?;
+                run_pre_push_hook(
+                    &worktree,
+                    &descriptor.origin_push_url,
+                    &descriptor.head_branch,
+                    &descriptor.previous_tip_sha,
+                    &descriptor.tip_sha,
+                )
+                .with_context(|| {
+                    format!(
+                        "validation failed for local PR #{} / {} in preserved worktree {}",
+                        group_idx + 1,
+                        descriptor.stable_handle,
+                        worktree.display()
+                    )
+                })?;
+                let changes = tracked_changes(&worktree)?;
+                if !changes.trim().is_empty() {
+                    bail!(
+                        "validation hook modified tracked files for local PR #{} / {}; inspect preserved worktree {}\n{}",
+                        group_idx + 1,
+                        descriptor.stable_handle,
+                        worktree.display(),
+                        changes
+                    );
+                }
+                write_receipt(descriptor.clone())?;
+            }
+            Ok(())
+        })();
+        validation_result?;
+        cleanup_worktree(&worktree)?;
+    }
+    if !pre_push_hook.effective() {
+        for group_idx in &missing_indices {
+            write_receipt(descriptors[*group_idx].clone())?;
+        }
+    }
+    let receipts = descriptors
+        .iter()
+        .enumerate()
+        .map(|(group_idx, descriptor)| {
+            let digest = descriptor_digest(descriptor)?;
+            let path = matching_receipt_path(descriptor)?.ok_or_else(|| {
+                anyhow!(
+                    "validation receipt for {} was not recorded",
+                    descriptor.stable_handle
+                )
+            })?;
+            Ok(ValidationReceiptSummaryData {
+                local_pr_number: group_idx + 1,
+                stable_handle: descriptor.stable_handle.clone(),
+                head_branch: descriptor.head_branch.clone(),
+                previous_tip_sha: descriptor.previous_tip_sha.clone(),
+                tip_sha: descriptor.tip_sha.clone(),
+                action: if missing_indices.contains(&group_idx) {
+                    ValidationReceiptAction::Recorded
+                } else {
+                    ValidationReceiptAction::Reused
+                },
+                digest,
+                path: path.display().to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let pre_push_hook_present = pre_push_hook.present;
+    let pre_push_hook_executable = pre_push_hook.executable;
+    let validated_group_count = descriptors.len();
+    let recorded_group_count = missing_indices.len();
+    let reused_group_count = validated_group_count - recorded_group_count;
+    Ok(ValidationSummaryData {
+        success: true,
+        validated_group_count,
+        recorded_group_count,
+        reused_group_count,
+        skipped_groups,
+        receipts,
+        pre_push_hook_present,
+        pre_push_hook_executable,
+    })
+}
+
+pub fn print_validation_summary(summary: &ValidationSummaryData) {
+    println!(
+        "Validated {} local PR boundary/boundaries ({} recorded, {} reused)",
+        summary.validated_group_count, summary.recorded_group_count, summary.reused_group_count
+    );
+    if summary.pre_push_hook_present {
+        for receipt in &summary.receipts {
+            if receipt.action == ValidationReceiptAction::Recorded {
+                println!("Recorded validation receipt: {}", receipt.path);
+            }
+        }
+    } else {
+        println!("No executable pre-push hook is installed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_descriptors, require_matching_receipts, validate_current_stack,
+        ValidationReceiptAction, ValidationSummaryData,
+    };
+    use crate::commands::{build_from_groups_with_validation, UpdatePushValidation};
+    use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
+    use crate::execution::ExecutionMode;
+    use crate::parsing::{derive_local_groups_with_ignored, split_groups_for_update};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector, InclusiveSelector};
+    use crate::test_support::{commit_file, git, lock_cwd, write_file, DirGuard};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    struct ValidationRepo {
+        _dir: TempDir,
+        repo: PathBuf,
+        log: PathBuf,
+        main_sha: String,
+        alpha_tip: String,
+        beta_tip: String,
+    }
+
+    fn init_validation_repo() -> ValidationRepo {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+        git(&repo, ["init", "-b", "main"].as_slice());
+        git(
+            &repo,
+            ["config", "user.email", "spr@example.com"].as_slice(),
+        );
+        git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+        write_file(&repo, "README.md", "init\n");
+        git(&repo, ["add", "README.md"].as_slice());
+        git(&repo, ["commit", "-m", "init"].as_slice());
+        let main_sha = git(&repo, ["rev-parse", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        let origin = dir.path().join("origin.git");
+        git(
+            &repo,
+            ["init", "--bare", origin.to_str().unwrap()].as_slice(),
+        );
+        git(
+            &repo,
+            ["remote", "add", "origin", origin.to_str().unwrap()].as_slice(),
+        );
+        git(&repo, ["push", "-u", "origin", "main"].as_slice());
+        git(&repo, ["checkout", "-b", "stack"].as_slice());
+        commit_file(&repo, "alpha.txt", "alpha seed\n", "alpha pr:alpha");
+        let alpha_tip = commit_file(&repo, "alpha.txt", "alpha tip\n", "alpha follow-up");
+        let beta_tip = commit_file(&repo, "beta.txt", "beta tip\n", "beta pr:beta");
+        ValidationRepo {
+            log: dir.path().join("hook.log"),
+            _dir: dir,
+            repo,
+            main_sha,
+            alpha_tip,
+            beta_tip,
+        }
+    }
+
+    fn install_hook(repo: &ValidationRepo, body: &str) {
+        let hook = repo.repo.join(".git/hooks/pre-push");
+        fs::write(&hook, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut permissions = fs::metadata(&hook).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook, permissions).unwrap();
+    }
+
+    fn descriptors(_repo: &ValidationRepo) -> Vec<super::ValidationDescriptor> {
+        let (merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored("main", "ignore").unwrap();
+        let (groups, _) = split_groups_for_update(&leading_ignored, groups);
+        build_descriptors("main", "spr/", "ignore", &merge_base, &groups).unwrap()
+    }
+
+    fn groups_and_descriptors(
+        repo: &ValidationRepo,
+    ) -> (Vec<crate::parsing::Group>, Vec<super::ValidationDescriptor>) {
+        let (merge_base, leading_ignored, groups) =
+            derive_local_groups_with_ignored("main", "ignore").unwrap();
+        let (groups, _) = split_groups_for_update(&leading_ignored, groups);
+        let descriptors =
+            build_descriptors("main", "spr/", "ignore", &merge_base, &groups).unwrap();
+        let _ = repo;
+        (groups, descriptors)
+    }
+
+    fn update_no_pr(
+        groups: Vec<crate::parsing::Group>,
+        push_validation: UpdatePushValidation,
+    ) -> anyhow::Result<()> {
+        build_from_groups_with_validation(
+            "main",
+            "spr/",
+            &[],
+            true,
+            ExecutionMode::Apply,
+            PrDescriptionMode::Overwrite,
+            None,
+            groups,
+            ListOrder::RecentOnTop,
+            true,
+            0,
+            LocalPrBranchSyncPolicy::Off,
+            push_validation,
+        )
+    }
+
+    fn remove_preserved_worktree(repo: &ValidationRepo) {
+        let worktrees = git(&repo.repo, ["worktree", "list", "--porcelain"].as_slice());
+        for line in worktrees.lines() {
+            if let Some(path) = line.strip_prefix("worktree /tmp/spr-validate-") {
+                let path = format!("/tmp/spr-validate-{path}");
+                git(
+                    &repo.repo,
+                    ["worktree", "remove", "--force", &path].as_slice(),
+                );
+            }
+        }
+    }
+
+    fn assert_receipt(summary: &ValidationSummaryData) {
+        assert!(summary.success);
+        assert!(!summary.receipts.is_empty());
+        for receipt in &summary.receipts {
+            assert!(Path::new(&receipt.path).is_file());
+            assert!(!receipt.digest.is_empty());
+        }
+    }
+
+    fn first_group() -> InclusiveSelector {
+        InclusiveSelector::Group(GroupSelector::LocalPr(1))
+    }
+
+    fn beta_group() -> InclusiveSelector {
+        InclusiveSelector::Group(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
+            "beta".to_string(),
+        )))
+    }
+
+    fn append_gamma(repo: &ValidationRepo) -> String {
+        commit_file(&repo.repo, "gamma.txt", "gamma tip\n", "gamma pr:gamma")
+    }
+
+    #[test]
+    fn validates_each_pr_tip_with_pr_local_ranges_and_historical_contents() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(
+            &repo,
+            &format!(
+                "printf 'alpha=' >> '{}'\ntr '\\n' ' ' < alpha.txt >> '{}' 2>/dev/null || true\nprintf '\\n' >> '{}'\ncat >> '{}'",
+                repo.log.display(),
+                repo.log.display(),
+                repo.log.display(),
+                repo.log.display()
+            ),
+        );
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_receipt(&summary);
+        assert_eq!(summary.validated_group_count, 2);
+        let log = fs::read_to_string(&repo.log).unwrap();
+        assert!(log.contains("alpha=alpha tip "));
+        assert!(log.contains(&format!(
+            "refs/heads/spr/alpha {} refs/heads/spr/alpha {}",
+            repo.alpha_tip, repo.main_sha
+        )));
+        assert!(log.contains(&format!(
+            "refs/heads/spr/beta {} refs/heads/spr/beta {}",
+            repo.beta_tip, repo.alpha_tip
+        )));
+    }
+
+    #[test]
+    fn missing_hook_succeeds_and_writes_receipt() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_receipt(&summary);
+        assert!(!summary.pre_push_hook_present);
+        assert_eq!(summary.recorded_group_count, 2);
+        assert_eq!(summary.reused_group_count, 0);
+        assert!(summary
+            .receipts
+            .iter()
+            .all(|receipt| receipt.path.contains("validation_receipts_v2")));
+    }
+
+    #[test]
+    fn non_executable_hook_succeeds_and_writes_receipts_without_running_hook() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        let hook = repo.repo.join(".git/hooks/pre-push");
+        fs::write(
+            &hook,
+            format!("#!/bin/sh\nprintf x >> '{}'\n", repo.log.display()),
+        )
+        .unwrap();
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_receipt(&summary);
+        assert!(summary.pre_push_hook_present);
+        assert!(!summary.pre_push_hook_executable);
+        assert!(!repo.log.exists());
+    }
+
+    #[test]
+    fn validate_until_limits_receipts_by_ordinal_and_stable_selector() {
+        let _cwd_lock = lock_cwd();
+        let ordinal_repo = init_validation_repo();
+        let _ordinal_cwd = DirGuard::change_to(&ordinal_repo.repo);
+
+        let ordinal_summary =
+            validate_current_stack("main", "spr/", "ignore", &first_group()).unwrap();
+
+        assert_eq!(ordinal_summary.validated_group_count, 1);
+        assert_eq!(ordinal_summary.receipts[0].stable_handle, "pr:alpha");
+        drop(_ordinal_cwd);
+
+        let selector_repo = init_validation_repo();
+        let _selector_cwd = DirGuard::change_to(&selector_repo.repo);
+        let selector_summary =
+            validate_current_stack("main", "spr/", "ignore", &beta_group()).unwrap();
+
+        assert_eq!(selector_summary.validated_group_count, 2);
+        assert_eq!(selector_summary.receipts[1].stable_handle, "pr:beta");
+    }
+
+    #[test]
+    fn appended_pr_records_only_new_boundary_and_reuses_lower_receipts() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(
+            &repo,
+            &format!("printf x >> '{}'\nexit 0", repo.log.display()),
+        );
+        validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), "xx");
+        let gamma_tip = append_gamma(&repo);
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), "xxx");
+        assert_eq!(summary.validated_group_count, 3);
+        assert_eq!(summary.recorded_group_count, 1);
+        assert_eq!(summary.reused_group_count, 2);
+        assert_eq!(
+            summary
+                .receipts
+                .iter()
+                .map(|receipt| receipt.action)
+                .collect::<Vec<_>>(),
+            vec![
+                ValidationReceiptAction::Reused,
+                ValidationReceiptAction::Reused,
+                ValidationReceiptAction::Recorded,
+            ]
+        );
+        assert_eq!(summary.receipts[2].stable_handle, "pr:gamma");
+        assert_eq!(summary.receipts[2].tip_sha, gamma_tip);
+        assert_eq!(summary.receipts[2].previous_tip_sha, repo.beta_tip);
+    }
+
+    #[test]
+    fn successful_boundaries_are_reused_after_later_failure() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        let allow_beta = repo.repo.parent().unwrap().join("allow-beta");
+        install_hook(
+            &repo,
+            &format!(
+                "read local_ref _ _ _\nprintf '%s\\n' \"$local_ref\" >> '{}'\nif [ \"$local_ref\" = refs/heads/spr/beta ] && [ ! -f '{}' ]; then exit 1; fi\nexit 0",
+                repo.log.display(),
+                allow_beta.display()
+            ),
+        );
+
+        let err =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap_err();
+        assert!(format!("{err:#}").contains("pr:beta"));
+        fs::write(&allow_beta, "").unwrap();
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&repo.log).unwrap(),
+            "refs/heads/spr/alpha\nrefs/heads/spr/beta\nrefs/heads/spr/beta\n"
+        );
+        assert_eq!(summary.recorded_group_count, 1);
+        assert_eq!(summary.reused_group_count, 1);
+        assert_eq!(summary.receipts[0].action, ValidationReceiptAction::Reused);
+        assert_eq!(
+            summary.receipts[1].action,
+            ValidationReceiptAction::Recorded
+        );
+        remove_preserved_worktree(&repo);
+    }
+
+    #[test]
+    fn hook_content_change_invalidates_receipt() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(&repo, "exit 0");
+        validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+        require_matching_receipts(&descriptors(&repo)).unwrap();
+        install_hook(&repo, "printf changed\\n >/dev/null\nexit 0");
+
+        let err = require_matching_receipts(&descriptors(&repo)).unwrap_err();
+
+        assert!(format!("{err:#}").contains("missing or stale"));
+    }
+
+    #[test]
+    fn descriptor_field_changes_invalidate_receipts() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+        let descriptors = descriptors(&repo);
+        let descriptor = descriptors[1].clone();
+        let mut changed_descriptors = Vec::new();
+
+        let mut changed = descriptor.clone();
+        changed.base_sha = "changed-base".to_string();
+        changed_descriptors.push(changed);
+        let mut changed = descriptor.clone();
+        changed.origin_push_url = "changed-url".to_string();
+        changed_descriptors.push(changed);
+        let mut changed = descriptor.clone();
+        changed.stable_handle = "pr:changed".to_string();
+        changed_descriptors.push(changed);
+        let mut changed = descriptor.clone();
+        changed.head_branch = "spr/changed".to_string();
+        changed_descriptors.push(changed);
+        let mut changed = descriptor.clone();
+        changed.previous_tip_sha = "changed-previous".to_string();
+        changed_descriptors.push(changed);
+        let mut changed = descriptor;
+        changed.tip_sha = "changed-tip".to_string();
+        changed_descriptors.push(changed);
+
+        for changed in changed_descriptors {
+            let err = require_matching_receipts(&[changed]).unwrap_err();
+            assert!(format!("{err:#}").contains("missing or stale"));
+        }
+    }
+
+    #[test]
+    fn failing_hook_stops_at_first_boundary_and_preserves_worktree() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(
+            &repo,
+            &format!("printf x >> '{}'\nexit 1", repo.log.display()),
+        );
+
+        let err =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap_err();
+
+        assert!(format!("{err:#}").contains("preserved worktree"));
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), "x");
+        remove_preserved_worktree(&repo);
+    }
+
+    #[test]
+    fn tracked_hook_edits_fail_and_preserve_worktree() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(&repo, "printf reformatted >> alpha.txt\nexit 0");
+
+        let err =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap_err();
+
+        assert!(format!("{err:#}").contains("modified tracked files"));
+        remove_preserved_worktree(&repo);
+    }
+
+    #[test]
+    fn required_update_blocks_before_push_without_receipt() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        let (groups, descriptors) = groups_and_descriptors(&repo);
+
+        let err = update_no_pr(groups, UpdatePushValidation::Required(descriptors)).unwrap_err();
+
+        assert!(format!("{err:#}").contains("missing or stale"));
+        assert!(git(
+            &repo.repo,
+            ["ls-remote", "--heads", "origin", "spr/alpha"].as_slice()
+        )
+        .trim()
+        .is_empty());
+    }
+
+    #[test]
+    fn required_update_uses_receipt_and_skips_push_hook() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(
+            &repo,
+            &format!("printf x >> '{}'\nexit 0", repo.log.display()),
+        );
+        validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+        let validated_hook_runs = fs::read_to_string(&repo.log).unwrap();
+        let (groups, descriptors) = groups_and_descriptors(&repo);
+
+        update_no_pr(groups, UpdatePushValidation::Required(descriptors)).unwrap();
+
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), validated_hook_runs);
+    }
+
+    #[test]
+    fn required_partial_prefix_update_uses_lower_receipt_without_higher_receipt() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        validate_current_stack("main", "spr/", "ignore", &first_group()).unwrap();
+        let (groups, descriptors) = groups_and_descriptors(&repo);
+
+        update_no_pr(
+            groups[..1].to_vec(),
+            UpdatePushValidation::Required(descriptors[..1].to_vec()),
+        )
+        .unwrap();
+
+        assert!(!git(
+            &repo.repo,
+            ["ls-remote", "--heads", "origin", "spr/alpha"].as_slice()
+        )
+        .trim()
+        .is_empty());
+        assert!(git(
+            &repo.repo,
+            ["ls-remote", "--heads", "origin", "spr/beta"].as_slice()
+        )
+        .trim()
+        .is_empty());
+    }
+
+    #[test]
+    fn required_full_update_rejects_missing_higher_receipt() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        validate_current_stack("main", "spr/", "ignore", &first_group()).unwrap();
+        let (groups, descriptors) = groups_and_descriptors(&repo);
+
+        let err = update_no_pr(groups, UpdatePushValidation::Required(descriptors)).unwrap_err();
+
+        assert!(format!("{err:#}").contains("pr:beta"));
+        assert!(git(
+            &repo.repo,
+            ["ls-remote", "--heads", "origin", "spr/alpha"].as_slice()
+        )
+        .trim()
+        .is_empty());
+    }
+
+    #[test]
+    fn legacy_update_preserves_push_hook_execution() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(&repo, "exit 1");
+        let (groups, _) = groups_and_descriptors(&repo);
+
+        let err = update_no_pr(groups, UpdatePushValidation::Legacy).unwrap_err();
+
+        assert!(format!("{err:#}").contains("git"));
+    }
+
+    #[test]
+    fn skipped_validation_bypasses_receipts_and_push_hooks() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        install_hook(&repo, "exit 1");
+        let (groups, _) = groups_and_descriptors(&repo);
+
+        update_no_pr(groups, UpdatePushValidation::Skip).unwrap();
+
+        assert!(!git(
+            &repo.repo,
+            ["ls-remote", "--heads", "origin", "spr/beta"].as_slice()
+        )
+        .trim()
+        .is_empty());
+    }
+
+    #[test]
+    fn required_update_without_branch_changes_does_not_need_receipt() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        let (groups, _) = groups_and_descriptors(&repo);
+        update_no_pr(groups, UpdatePushValidation::Skip).unwrap();
+        let (groups, descriptors) = groups_and_descriptors(&repo);
+
+        update_no_pr(groups, UpdatePushValidation::Required(descriptors)).unwrap();
+    }
+
+    #[test]
+    fn skipped_validation_bypasses_push_hooks_for_force_updates() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        let (groups, _) = groups_and_descriptors(&repo);
+        update_no_pr(groups, UpdatePushValidation::Skip).unwrap();
+        git(&repo.repo, ["reset", "--hard", "HEAD~1"].as_slice());
+        commit_file(
+            &repo.repo,
+            "beta.txt",
+            "rewritten beta\n",
+            "beta rewritten pr:beta",
+        );
+        install_hook(&repo, "exit 1");
+        let (groups, _) = groups_and_descriptors(&repo);
+
+        update_no_pr(groups, UpdatePushValidation::Skip).unwrap();
+
+        let remote_tip = git(
+            &repo.repo,
+            ["ls-remote", "--heads", "origin", "spr/beta"].as_slice(),
+        )
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .to_string();
+        let local_tip = git(&repo.repo, ["rev-parse", "HEAD"].as_slice())
+            .trim()
+            .to_string();
+        assert_eq!(remote_tip, local_tip);
+    }
+}

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -327,6 +327,13 @@ fn hook_input_path() -> PathBuf {
     std::env::temp_dir().join(format!("spr-validate-hook-input-{}", Uuid::new_v4()))
 }
 
+fn git_local_env_vars() -> Result<Vec<String>> {
+    Ok(git_ro(["rev-parse", "--local-env-vars"].as_slice())?
+        .lines()
+        .map(str::to_string)
+        .collect())
+}
+
 fn run_pre_push_hook(
     worktree: &Path,
     pre_push_hook: &HookFingerprint,
@@ -335,6 +342,7 @@ fn run_pre_push_hook(
     previous_tip: &str,
     current_tip: &str,
 ) -> Result<()> {
+    let git_local_env_vars = git_local_env_vars()?;
     let input_path = hook_input_path();
     let ref_name = format!("refs/heads/{branch}");
     fs::write(
@@ -342,25 +350,17 @@ fn run_pre_push_hook(
         format!("{ref_name} {current_tip} {ref_name} {previous_tip}\n"),
     )
     .with_context(|| format!("failed to write hook input {}", input_path.display()))?;
-    let hooks_path = Path::new(&pre_push_hook.path)
-        .parent()
-        .ok_or_else(|| anyhow!("pre-push hook path {} has no parent", pre_push_hook.path))?;
-    let status = Command::new("git")
+    let input = fs::File::open(&input_path)
+        .with_context(|| format!("failed to open hook input {}", input_path.display()))?;
+    let mut command = Command::new(&pre_push_hook.path);
+    command
         .current_dir(worktree)
-        .args([
-            "-c",
-            &format!("core.hooksPath={}", hooks_path.display()),
-            "hook",
-            "run",
-            "--ignore-missing",
-            &format!("--to-stdin={}", input_path.display()),
-            "pre-push",
-            "--",
-            "origin",
-            origin_push_url,
-        ])
-        .status()
-        .context("failed to spawn git hook run pre-push")?;
+        .args(["origin", origin_push_url])
+        .stdin(Stdio::from(input));
+    for variable in git_local_env_vars {
+        command.env_remove(variable);
+    }
+    let status = command.status().context("failed to spawn pre-push hook")?;
     let _ = fs::remove_file(&input_path);
     if !status.success() {
         bail!("pre-push hook failed");
@@ -894,6 +894,29 @@ mod tests {
                 repo.repo.join(".git/hooks/pre-push").display().to_string()
             );
         }
+    }
+
+    #[test]
+    fn validation_hook_can_run_foreign_git_without_worktree_environment() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let _cwd = DirGuard::change_to(&repo.repo);
+        let foreign_repo = repo._dir.path().join("foreign-repo");
+        install_hook(
+            &repo,
+            &format!(
+                "test -z \"${{GIT_DIR+x}}\" || exit 41\ngit init '{}' >/dev/null 2>&1 || exit 42\nprintf x >> '{}'",
+                foreign_repo.display(),
+                repo.log.display()
+            ),
+        );
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert_receipt(&summary);
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), "xx");
+        assert!(foreign_repo.join(".git").is_dir());
     }
 
     #[test]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::branch_names::group_branch_identities;
-use crate::git::{git_common_dir, git_rev_parse, git_ro, repo_root};
+use crate::git::{git_common_dir, git_rev_parse, git_ro};
 use crate::parsing::{derive_groups_between_with_ignored, split_groups_for_update, Group};
 use crate::selectors::{resolve_inclusive_count, InclusiveSelector};
 
@@ -159,14 +159,19 @@ fn origin_push_url() -> Result<String> {
     }
 }
 
-fn pre_push_hook_fingerprint(repo_root: &Path) -> Result<HookFingerprint> {
-    let reported = git_ro(["rev-parse", "--git-path", "hooks/pre-push"].as_slice())?;
-    let reported = reported.trim();
-    let path = if Path::new(reported).is_absolute() {
-        PathBuf::from(reported)
-    } else {
-        repo_root.join(reported)
-    };
+fn pre_push_hook_fingerprint() -> Result<HookFingerprint> {
+    let path = PathBuf::from(
+        git_ro(
+            [
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                "hooks/pre-push",
+            ]
+            .as_slice(),
+        )?
+        .trim(),
+    );
     let present = path.is_file();
     let executable = if present {
         fs::metadata(&path)
@@ -200,10 +205,9 @@ pub fn build_descriptors(
     merge_base: &str,
     groups: &[Group],
 ) -> Result<Vec<ValidationDescriptor>> {
-    let root = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
     let base_sha = git_rev_parse(base)?;
     let origin_push_url = origin_push_url()?;
-    let pre_push_hook = pre_push_hook_fingerprint(Path::new(&root))?;
+    let pre_push_hook = pre_push_hook_fingerprint()?;
     let branch_identities = group_branch_identities(groups, prefix)?;
     let mut previous_tip_sha = merge_base.to_string();
     groups
@@ -410,8 +414,7 @@ pub fn validate_stack(
     let pre_push_hook = if let Some(descriptor) = descriptors.first() {
         descriptor.pre_push_hook.clone()
     } else {
-        let root = repo_root()?.ok_or_else(|| anyhow!("`spr` must run inside a git worktree"))?;
-        pre_push_hook_fingerprint(Path::new(&root))?
+        pre_push_hook_fingerprint()?
     };
     let missing_indices = descriptors
         .iter()
@@ -866,6 +869,31 @@ mod tests {
         validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
 
         assert_eq!(fs::read_to_string(&repo.log).unwrap(), "bb");
+    }
+
+    #[test]
+    fn nested_directory_uses_the_repository_pre_push_hook() {
+        let _cwd_lock = lock_cwd();
+        let repo = init_validation_repo();
+        let nested = repo.repo.join("deeply/nested/directory");
+        fs::create_dir_all(&nested).unwrap();
+        let _cwd = DirGuard::change_to(&nested);
+        install_hook(&repo, &format!("printf x >> '{}'", repo.log.display()));
+
+        let summary =
+            validate_current_stack("main", "spr/", "ignore", &InclusiveSelector::All).unwrap();
+
+        assert!(summary.pre_push_hook_present);
+        assert!(summary.pre_push_hook_executable);
+        assert_eq!(fs::read_to_string(&repo.log).unwrap(), "xx");
+        for receipt in summary.receipts {
+            let receipt: super::ValidationReceipt =
+                serde_json::from_slice(&fs::read(receipt.path).unwrap()).unwrap();
+            assert_eq!(
+                receipt.descriptor.pre_push_hook.path,
+                repo.repo.join(".git/hooks/pre-push").display().to_string()
+            );
+        }
     }
 
     #[test]

--- a/src/validation_output.rs
+++ b/src/validation_output.rs
@@ -1,0 +1,9 @@
+use crate::json_output::JsonCommand;
+use crate::summary_output::SummaryOutput;
+use crate::validation::ValidationSummaryData;
+
+pub type ValidationOutput = SummaryOutput<ValidationSummaryData>;
+
+pub fn summary(data: ValidationSummaryData) -> ValidationOutput {
+    SummaryOutput::new(JsonCommand::Validate, data)
+}


### PR DESCRIPTION
Add `spr validate` and its `spr v` shorthand to run pre-push validation at
each selected pull-request boundary before publishing. Required-validation
mode checks reusable v2 receipts for those exact boundaries and skips duplicate
push-time hooks. This catches middle-of-stack failures that a cumulative
batched push can hide, while avoiding repeated validation of unchanged lower
pull requests when the stack grows.

Example:
If pull request 2 introduces a hook failure and pull request 4 fixes it, a
single check at pull request 4 can miss the problem. `spr v` checks each
boundary independently. After `spr v --until 9`, extending the stack and
running `spr v --until 10` reuses boundaries 1 through 9 and validates only
boundary 10.

Legacy update behavior remains the default. Required mode gates selected
branch pushes on matching receipts, and `spr update --skip-validation` remains
an explicit bypass that also skips Git pre-push hooks.

<!-- spr-stack:start -->
**Stack**:
- ➡ #155
-   #156

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->