### PR TITLE
update: use global --until for publish prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Global flags
 - `--base, -b <BRANCH>`: root base branch (default from config)
 - `--prefix <PREFIX>`: per-PR branch prefix (default from config, normalized to a single trailing `/`)
 - `--local-pr-branches <off|update-existing|create-or-update>`: override local per-PR branch synchronization for this run
-- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: target range used by `prep` and `land` (`0` means all)
+- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: target range used by `update`, `prep`, and `land` (`0` means all)
 - `--exact <I|name|pr:<label>|branch:<branch-name>>`: used by `prep` to select exactly one PR group
 - `--verbose`: enable verbose logging of underlying git/gh commands
 
@@ -181,10 +181,7 @@ Key options:
 - `--pr-description-mode <overwrite|stack_only>`: override `pr_description_mode` for this update run
 - `--allow-branch-reuse`: bypass the recent closed-or-merged branch-name reuse guard
 - `--json`: write exactly one update summary object to stdout
-- Extent (optional subcommand):
-  - `pr --to <N|name|pr:<label>|branch:<branch-name>>`: canonical selector for limiting updates to the first N PRs from the bottom
-  - `pr --n <N>`: legacy numeric-only form
-  - `pr <N>`: backward-compatible positional numeric form
+- `--until <N|0|name|pr:<label>|branch:<branch-name>>`: update only the lower prefix through one PR boundary (`0` means all)
 
 Behavior:
 
@@ -788,7 +785,7 @@ Examples
 spr update
 
 # Update only through the stable beta group
-spr update pr --to beta
+spr update --until beta
 
 # Prep the stack through the stable beta group
 spr prep --until beta

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,22 +3,6 @@ use std::path::PathBuf;
 
 use crate::execution::ExecutionMode;
 
-#[derive(Subcommand, Debug, Clone)]
-pub enum Extent {
-    /// Update the first N PRs (bottom-up)
-    Pr {
-        /// Limit updates through this local PR number or group selector
-        #[arg(long, value_name = "N|name|pr:<label>|branch:<branch-name>", conflicts_with_all = ["n", "legacy_n"])]
-        to: Option<crate::selectors::GroupSelector>,
-        /// Legacy numeric-only limit
-        #[arg(long, value_name = "N", conflicts_with_all = ["to", "legacy_n"])]
-        n: Option<usize>,
-        /// Backward-compatible positional numeric limit
-        #[arg(value_name = "N", hide = true, conflicts_with_all = ["to", "n"])]
-        legacy_n: Option<usize>,
-    },
-}
-
 #[derive(Clone, Debug)]
 pub enum PrepSelection {
     Until(crate::selectors::InclusiveSelector),
@@ -112,10 +96,6 @@ pub enum Cmd {
 
         #[command(flatten)]
         dry_run: DryRunArgs,
-
-        /// Limit how much to update (optional sub-mode)
-        #[command(subcommand)]
-        extent: Option<Extent>,
     },
 
     /// Restack PRs by rebasing the top commits after the bottom N PR groups onto the latest base
@@ -329,7 +309,7 @@ pub struct Cli {
     /// Sync local per-PR branches named like each group's resolved concrete branch
     #[arg(long, global = true, value_enum)]
     pub local_pr_branches: Option<crate::config::LocalPrBranchSyncPolicy>,
-    /// Global until (used by prep/land). Accepts 0, a local PR number, or a group selector
+    /// Global until (used by update/prep/land). Accepts 0, a local PR number, or a group selector
     #[arg(
         long,
         global = true,
@@ -375,9 +355,67 @@ mod tests {
     fn update_commit_extent_is_rejected() {
         let err = Cli::try_parse_from(["spr", "update", "commits", "2"]).unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("unrecognized subcommand 'commits'"));
+        assert!(err.to_string().contains("unexpected argument 'commits'"));
+    }
+
+    #[test]
+    fn update_pr_extent_forms_are_rejected() {
+        for args in [
+            &["spr", "u", "pr", "--to", "2"][..],
+            &["spr", "u", "pr", "--n", "2"][..],
+            &["spr", "u", "pr", "2"][..],
+        ] {
+            let err = Cli::try_parse_from(args).unwrap_err();
+
+            assert!(
+                err.to_string().contains("unexpected argument 'pr'"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn update_until_selectors_parse() {
+        let cases = [
+            (
+                "2",
+                crate::selectors::InclusiveSelector::Group(
+                    crate::selectors::GroupSelector::LocalPr(2),
+                ),
+            ),
+            ("0", crate::selectors::InclusiveSelector::All),
+            (
+                "beta",
+                crate::selectors::InclusiveSelector::Group(crate::selectors::GroupSelector::Bare(
+                    "beta".to_string(),
+                )),
+            ),
+            (
+                "pr:beta",
+                crate::selectors::InclusiveSelector::Group(
+                    crate::selectors::GroupSelector::Explicit(
+                        crate::selectors::ExplicitGroupSelector::PrLabel("beta".to_string()),
+                    ),
+                ),
+            ),
+            (
+                "branch:feature/login",
+                crate::selectors::InclusiveSelector::Group(
+                    crate::selectors::GroupSelector::Explicit(
+                        crate::selectors::ExplicitGroupSelector::BranchName(
+                            "feature/login".to_string(),
+                        ),
+                    ),
+                ),
+            ),
+        ];
+
+        for (selector, expected) in cases {
+            let cli = Cli::try_parse_from(["spr", "u", "--until", selector]).unwrap();
+
+            assert_eq!(cli.until, Some(expected));
+            assert!(matches!(cli.cmd, Cmd::Update { .. }));
+        }
     }
 
     #[test]
@@ -646,19 +684,17 @@ mod tests {
     }
 
     #[test]
-    fn update_json_flag_parses_with_extent_subcommand() {
-        let cli = Cli::try_parse_from(["spr", "update", "--json", "pr", "1"]).unwrap();
+    fn update_json_flag_parses_with_until() {
+        let cli = Cli::try_parse_from(["spr", "update", "--json", "--until", "1"]).unwrap();
 
-        match cli.cmd {
-            Cmd::Update {
-                extent: Some(super::Extent::Pr { legacy_n, .. }),
-                ..
-            } => {
-                assert_eq!(cli.output.format(), OutputFormat::Json);
-                assert_eq!(legacy_n, Some(1));
-            }
-            other => panic!("unexpected command: {:?}", other),
-        }
+        assert!(matches!(cli.cmd, Cmd::Update { .. }));
+        assert_eq!(cli.output.format(), OutputFormat::Json);
+        assert_eq!(
+            cli.until,
+            Some(crate::selectors::InclusiveSelector::Group(
+                crate::selectors::GroupSelector::LocalPr(1)
+            ))
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,39 +34,24 @@ mod summary_output;
 mod test_support;
 mod update_output;
 
-fn resolve_update_pr_limit(
+fn resolve_update_until_limit(
     groups: &[crate::parsing::Group],
-    to: Option<crate::selectors::GroupSelector>,
-    n: Option<usize>,
-    legacy_n: Option<usize>,
-) -> Result<crate::limit::Limit> {
-    let provided_limit_count =
-        usize::from(to.is_some()) + usize::from(n.is_some()) + usize::from(legacy_n.is_some());
-    if provided_limit_count > 1 {
-        Err(anyhow::anyhow!(
-            "`spr update pr` accepts only one limit selector: `--to <N|label|pr:<label>>`, `--n <N>`, or the positional `N`."
-        ))
-    } else if let Some(to) = to {
-        let count = crate::selectors::resolve_group_ordinal(groups, &to)?;
-        Ok(crate::limit::Limit::ByPr(count))
-    } else if let Some(n) = n {
-        if n == 0 {
-            Err(anyhow::anyhow!("`spr update pr --n` must be 1 or greater."))
-        } else {
-            Ok(crate::limit::Limit::ByPr(n))
+    until: Option<&crate::selectors::InclusiveSelector>,
+) -> Result<(
+    Option<crate::limit::Limit>,
+    crate::update_output::ResolvedUpdateLimit,
+)> {
+    match until {
+        None | Some(crate::selectors::InclusiveSelector::All) => {
+            Ok((None, crate::update_output::ResolvedUpdateLimit::All))
         }
-    } else if let Some(n) = legacy_n {
-        if n == 0 {
-            Err(anyhow::anyhow!(
-                "`spr update pr` positional limit must be 1 or greater."
+        Some(selector) => {
+            let count = crate::selectors::resolve_inclusive_count(groups, selector)?;
+            Ok((
+                Some(crate::limit::Limit::ByPr(count)),
+                crate::update_output::ResolvedUpdateLimit::ByPr { count },
             ))
-        } else {
-            Ok(crate::limit::Limit::ByPr(n))
         }
-    } else {
-        Err(anyhow::anyhow!(
-            "`spr update pr` requires either `--to <N|label|pr:<label>>` or `--n <N>`."
-        ))
     }
 }
 
@@ -463,7 +448,6 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
             pr_description_mode: pr_description_mode_override,
             allow_branch_reuse,
             dry_run,
-            extent,
         } => {
             let execution_mode = ExecutionMode::from(dry_run);
             set_dry_run_env(execution_mode, assume_existing_prs);
@@ -485,20 +469,8 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 let (groups, skipped_handles) =
                     crate::parsing::split_groups_for_update(&leading_ignored, all_groups);
                 crate::branch_names::group_branch_identities(&groups, &prefix)?;
-                let (limit, resolved_extent) = if let Some(extent) = extent {
-                    match extent {
-                        crate::cli::Extent::Pr { to, n, legacy_n } => {
-                            let limit = resolve_update_pr_limit(&groups, to, n, legacy_n)?;
-                            let crate::limit::Limit::ByPr(count) = limit;
-                            (
-                                Some(limit),
-                                crate::update_output::ResolvedUpdateLimit::ByPr { count },
-                            )
-                        }
-                    }
-                } else {
-                    (None, crate::update_output::ResolvedUpdateLimit::All)
-                };
+                let (limit, resolved_extent) =
+                    resolve_update_until_limit(&groups, cli.until.as_ref())?;
                 if output_format == crate::cli::OutputFormat::Json {
                     let execution = crate::commands::build_from_groups_with_summary(
                         &base,
@@ -1257,8 +1229,8 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
 mod tests {
     use super::{
         apply_working_directory_override, command_requires_gh, ensure_rewrite_completed,
-        json_command_for_raw_args, parse_failure_as_json_output, resolve_update_pr_limit, run_cli,
-        CommandOutput,
+        json_command_for_raw_args, parse_failure_as_json_output, resolve_update_until_limit,
+        run_cli, CommandOutput,
     };
     use crate::cli::{DryRunArgs, OutputFormat};
     use crate::json_output::{ErrorPayload, JsonCommand, JsonError, EXIT_FAILURE};
@@ -1267,7 +1239,7 @@ mod tests {
     };
     use crate::parsing::{derive_local_groups_with_ignored, Group};
     use crate::read_only_output::ReadOnlyPayload;
-    use crate::selectors::{ExplicitGroupSelector, GroupSelector};
+    use crate::selectors::{ExplicitGroupSelector, GroupSelector, InclusiveSelector};
     use crate::test_support::{
         commit_file, git, init_case_conflicting_stack_repo, init_repo as init_stack_repo, lock_cwd,
         write_file, DirGuard,
@@ -1373,38 +1345,26 @@ mod tests {
     }
 
     #[test]
-    fn resolve_update_pr_limit_rejects_conflicting_selectors() {
+    fn resolve_update_until_limit_preserves_full_prefix() {
         let groups = vec![group("alpha")];
-        let result = resolve_update_pr_limit(
-            &groups,
-            Some(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
-                "alpha".to_string(),
-            ))),
-            Some(1),
-            None,
-        );
-        let err = match result {
-            Ok(_) => panic!("expected conflicting selector inputs to fail"),
-            Err(err) => err,
-        };
+        let all = InclusiveSelector::All;
 
-        assert!(
-            err.to_string().contains("accepts only one limit selector"),
-            "unexpected error: {err}"
-        );
+        for until in [None, Some(&all)] {
+            let (limit, resolved_extent) =
+                resolve_update_until_limit(&groups, until).expect("full prefix should resolve");
+
+            assert!(limit.is_none());
+            assert_eq!(resolved_extent, ResolvedUpdateLimit::All);
+        }
     }
 
     #[test]
-    fn resolve_update_pr_limit_rejects_local_only_group_selector() {
+    fn resolve_update_until_limit_rejects_local_only_group_selector() {
         let groups = vec![group("alpha")];
-        let result = resolve_update_pr_limit(
-            &groups,
-            Some(GroupSelector::Explicit(ExplicitGroupSelector::PrLabel(
-                "beta".to_string(),
-            ))),
-            None,
-            None,
-        );
+        let selector = InclusiveSelector::Group(GroupSelector::Explicit(
+            ExplicitGroupSelector::PrLabel("beta".to_string()),
+        ));
+        let result = resolve_update_until_limit(&groups, Some(&selector));
         let err = match result {
             Ok(_) => panic!("expected local-only selector to fail"),
             Err(err) => err,
@@ -1471,7 +1431,6 @@ mod tests {
             pr_description_mode: None,
             allow_branch_reuse: false,
             dry_run: DryRunArgs::default(),
-            extent: None,
         }));
     }
 
@@ -1485,7 +1444,6 @@ mod tests {
             pr_description_mode: None,
             allow_branch_reuse: false,
             dry_run: DryRunArgs::default(),
-            extent: None,
         }));
     }
 
@@ -3604,7 +3562,7 @@ mod tests {
     }
 
     #[test]
-    fn update_json_pr_selector_reports_resolved_pr_extent() {
+    fn update_json_until_selector_reports_resolved_pr_extent() {
         let _lock = lock_cwd();
         let dir = init_update_stack_repo();
         let repo = dir.path().join("repo");
@@ -3623,9 +3581,8 @@ mod tests {
             "--dry-run",
             "--json",
             "--no-pr",
-            "pr",
-            "--to",
-            "beta",
+            "--until",
+            "pr:beta",
         ])
         .unwrap();
 
@@ -3641,7 +3598,7 @@ mod tests {
     }
 
     #[test]
-    fn update_json_legacy_pr_limit_reports_resolved_pr_extent() {
+    fn update_json_until_zero_reports_full_extent() {
         let _lock = lock_cwd();
         let dir = init_update_stack_repo();
         let repo = dir.path().join("repo");
@@ -3660,8 +3617,8 @@ mod tests {
             "--dry-run",
             "--json",
             "--no-pr",
-            "pr",
-            "1",
+            "--until",
+            "0",
         ])
         .unwrap();
 
@@ -3669,9 +3626,10 @@ mod tests {
 
         match output {
             CommandOutput::Update(output) => {
-                assert_eq!(output.data.extent, ResolvedUpdateLimit::ByPr { count: 1 });
-                assert_eq!(output.data.groups.len(), 1);
+                assert_eq!(output.data.extent, ResolvedUpdateLimit::All);
+                assert_eq!(output.data.groups.len(), 2);
                 assert_eq!(output.data.groups[0].stable_handle, "pr:alpha");
+                assert_eq!(output.data.groups[1].stable_handle, "pr:beta");
             }
             other => panic!("unexpected command output: {:?}", other),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2041,6 +2041,9 @@ mod tests {
         let dir = init_update_stack_repo();
         let repo = dir.path().join("repo");
         let _guard = DirGuard::change_to(&repo);
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 0; fi\nexit 1\n",
+        );
         let cases = [
             vec![
                 "spr", "--base", "main", "--until", "1", "--exact", "1", "prep",
@@ -3395,6 +3398,11 @@ mod tests {
                     .unwrap();
             groups[0].commits.last().unwrap().clone()
         };
+        let expected_alpha_action = if alpha_tail == rewritten_alpha_tip {
+            crate::local_pr_branches::LocalPrBranchActionKind::Skipped
+        } else {
+            crate::local_pr_branches::LocalPrBranchActionKind::Blocked
+        };
         match output {
             CommandOutput::Machine(output) => match output.payload {
                 crate::machine_output::MachinePayload::Completed {
@@ -3403,10 +3411,7 @@ mod tests {
                 } => {
                     assert_eq!(destination_branch.as_deref(), Some("stack"));
                     assert_eq!(local_pr_branch_actions.len(), 2);
-                    assert_eq!(
-                        local_pr_branch_actions[0].action,
-                        crate::local_pr_branches::LocalPrBranchActionKind::Blocked
-                    );
+                    assert_eq!(local_pr_branch_actions[0].action, expected_alpha_action);
                     assert_eq!(
                         local_pr_branch_actions[1].action,
                         crate::local_pr_branches::LocalPrBranchActionKind::Updated
@@ -3417,7 +3422,6 @@ mod tests {
             other => panic!("unexpected command output: {:?}", other),
         }
         assert_eq!(rev_parse(&repo, "dank-spr/alpha"), alpha_tail);
-        assert_ne!(rev_parse(&repo, "dank-spr/alpha"), rewritten_alpha_tip);
         assert_eq!(rev_parse(&repo, "dank-spr/beta"), rev_parse(&repo, "stack"));
     }
 


### PR DESCRIPTION
Problem:
`spr update` accepts global `--until`, but silently ignores it. Prefix updates
instead require a separate `spr update pr ...` subcommand with redundant
legacy forms.

Solution:
Resolve update prefixes from global `--until` and remove the old extent
subcommand so publish, validate, prep, and land use one selector interface.

<!-- spr-stack:start -->
**Stack**:
-   #155
- ➡ #156

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->