### PR TITLE
update: protect rewritten PR head/base transitions

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -13,14 +13,16 @@ use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
 use crate::execution::ExecutionMode;
 use crate::git::{get_remote_branches_sha, gh_rw, git_is_ancestor, git_rw, sanitize_gh_base_ref};
 use crate::github::{
-    fetch_pr_bodies_graphql, get_repo_owner_name, graphql_escape, is_resource_limit_error,
-    list_recent_terminal_prs_for_heads, upsert_pr_cached, TerminalPrState,
+    convert_pull_requests_to_draft, fetch_pr_bodies_graphql, fetch_pr_stage_info_graphql,
+    get_repo_owner_name, graphql_escape, is_resource_limit_error,
+    list_recent_terminal_prs_for_heads, mark_pull_requests_ready_for_review, upsert_pr_cached,
+    PrStageInfo, TerminalPrState,
 };
 use crate::limit::{apply_limit_groups, Limit};
 use crate::parsing::Group;
 use crate::pr_base_chain::{
     build_desired_pr_base_chain, plan_base_reconciliation, verify_base_edits_converged,
-    BaseReconciliationAction, ObservedPrBaseChain,
+    BaseReconciliationAction, BaseReconciliationDecision, ObservedPrBaseChain,
 };
 use crate::update_output::{
     SkippedUpdateGroupData, UpdateEditAction, UpdateExecutionData, UpdateGroupData, UpdatePrAction,
@@ -208,6 +210,149 @@ struct PlannedPush {
     target_sha: String,
     remote_exists: bool,
     kind: PushKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DraftProtectedBaseTransition {
+    group_idx: usize,
+    remote_pr_number: u64,
+    head_branch: String,
+    target_head_sha: String,
+    current_base_ref: String,
+    desired_base_ref: String,
+}
+
+fn draft_protected_base_transitions(
+    base_reconciliation: &[BaseReconciliationDecision],
+    planned_pushes: &[PlannedPush],
+) -> Result<Vec<DraftProtectedBaseTransition>> {
+    base_reconciliation
+        .iter()
+        .filter(|decision| decision.action == BaseReconciliationAction::NeedsEdit)
+        .map(|decision| {
+            let planned_push = planned_pushes
+                .iter()
+                .find(|planned_push| planned_push.branch == decision.desired.head_branch)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Missing planned branch publication for {}",
+                        decision.desired.head_branch
+                    )
+                })?;
+            if planned_push.kind == PushKind::Skip {
+                Ok(None)
+            } else {
+                let current_base_ref = decision.current_base_ref.clone().ok_or_else(|| {
+                    anyhow!(
+                        "Missing current GitHub base ref for {}",
+                        decision.desired.head_branch
+                    )
+                })?;
+                Ok(decision
+                    .remote_pr_number
+                    .map(|remote_pr_number| DraftProtectedBaseTransition {
+                        group_idx: decision.desired.local_pr_number - 1,
+                        remote_pr_number,
+                        head_branch: decision.desired.head_branch.clone(),
+                        target_head_sha: planned_push.target_sha.clone(),
+                        current_base_ref: sanitize_gh_base_ref(&current_base_ref),
+                        desired_base_ref: decision.desired.expected_base_ref.clone(),
+                    }))
+            }
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|transitions| transitions.into_iter().flatten().collect())
+}
+
+fn base_ref_sha_after_branch_publication(
+    transition: &DraftProtectedBaseTransition,
+    planned_pushes: &[PlannedPush],
+    remote_map: &HashMap<String, String>,
+) -> Result<String> {
+    if let Some(planned_base_push) = planned_pushes
+        .iter()
+        .find(|planned_push| planned_push.branch == transition.current_base_ref)
+    {
+        Ok(planned_base_push.target_sha.clone())
+    } else {
+        remote_map
+            .get(&transition.current_base_ref)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!(
+                    "Missing remote branch SHA for current GitHub base {} on PR #{} ({})",
+                    transition.current_base_ref,
+                    transition.remote_pr_number,
+                    transition.head_branch
+                )
+            })
+    }
+}
+
+fn ancestry_collapse_risk_transitions(
+    transitions: &[DraftProtectedBaseTransition],
+    planned_pushes: &[PlannedPush],
+    remote_map: &HashMap<String, String>,
+) -> Result<Vec<DraftProtectedBaseTransition>> {
+    transitions
+        .iter()
+        .map(|transition| {
+            let future_old_base_sha =
+                base_ref_sha_after_branch_publication(transition, planned_pushes, remote_map)?;
+            Ok(
+                git_is_ancestor(&transition.target_head_sha, &future_old_base_sha)?
+                    .then(|| transition.clone()),
+            )
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|transitions| transitions.into_iter().flatten().collect())
+}
+
+fn pr_stage_info_for_transition<'a>(
+    stage_info_by_number: &'a HashMap<u64, PrStageInfo>,
+    transition: &DraftProtectedBaseTransition,
+) -> Result<&'a PrStageInfo> {
+    stage_info_by_number
+        .get(&transition.remote_pr_number)
+        .ok_or_else(|| {
+            anyhow!(
+                "Missing GitHub draft-stage metadata for PR #{} ({})",
+                transition.remote_pr_number,
+                transition.head_branch
+            )
+        })
+}
+
+fn ready_pull_request_ids_requiring_temporary_draft(
+    transitions: &[DraftProtectedBaseTransition],
+    stage_info_by_number: &HashMap<u64, PrStageInfo>,
+) -> Result<Vec<String>> {
+    transitions
+        .iter()
+        .map(|transition| {
+            let stage_info = pr_stage_info_for_transition(stage_info_by_number, transition)?;
+            Ok((!stage_info.is_draft).then(|| stage_info.id.clone()))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|pull_request_ids| pull_request_ids.into_iter().flatten().collect())
+}
+
+fn draft_protected_base_update_inputs(
+    transitions: &[DraftProtectedBaseTransition],
+    stage_info_by_number: &HashMap<u64, PrStageInfo>,
+) -> Result<Vec<String>> {
+    transitions
+        .iter()
+        .map(|transition| {
+            let stage_info = pr_stage_info_for_transition(stage_info_by_number, transition)?;
+            let desired_base_ref = sanitize_gh_base_ref(&transition.desired_base_ref);
+            let fields = [
+                format!("pullRequestId:\"{}\"", stage_info.id),
+                format!("baseRefName:\"{}\"", graphql_escape(&desired_base_ref)),
+            ];
+            Ok(fields.join(", "))
+        })
+        .collect()
 }
 
 impl UpdatePushAction {
@@ -482,10 +627,24 @@ fn build_from_groups_internal(
         &prs_by_head,
     )?;
 
+    let initial_base_reconciliation = if no_pr {
+        Vec::new()
+    } else {
+        plan_base_reconciliation(&desired_chain, &observed_pr_bases)
+    };
     let mut branch_names = heads.clone();
     let base_ref_for_remote = sanitize_gh_base_ref(base);
     if !branch_names.contains(&base_ref_for_remote) {
         branch_names.push(base_ref_for_remote);
+    }
+    for current_base_ref in initial_base_reconciliation
+        .iter()
+        .filter_map(|decision| decision.current_base_ref.as_deref())
+        .map(sanitize_gh_base_ref)
+    {
+        if !branch_names.contains(&current_base_ref) {
+            branch_names.push(current_base_ref);
+        }
     }
     let remote_map = get_remote_branches_sha(&branch_names)?;
 
@@ -527,6 +686,66 @@ fn build_from_groups_internal(
             kind,
         });
     }
+
+    let draft_protected_transitions = if no_pr {
+        Vec::new()
+    } else {
+        draft_protected_base_transitions(&initial_base_reconciliation, &planned)?
+    };
+    let prepublish_base_transitions =
+        ancestry_collapse_risk_transitions(&draft_protected_transitions, &planned, &remote_map)?;
+    let ancestry_collapse_risk_pr_numbers = prepublish_base_transitions
+        .iter()
+        .map(|transition| transition.remote_pr_number)
+        .collect::<HashSet<_>>();
+    let ancestry_collapse_risk_head_branches = prepublish_base_transitions
+        .iter()
+        .map(|transition| transition.head_branch.clone())
+        .collect::<Vec<_>>();
+    let draft_protected_head_branches = draft_protected_transitions
+        .iter()
+        .map(|transition| transition.head_branch.clone())
+        .collect::<Vec<_>>();
+    let temporarily_drafted_pull_request_ids = if draft_protected_transitions.is_empty() {
+        Vec::new()
+    } else {
+        let protected_pr_numbers = draft_protected_transitions
+            .iter()
+            .map(|transition| transition.remote_pr_number)
+            .collect::<Vec<_>>();
+        let stage_info_by_number = fetch_pr_stage_info_graphql(&protected_pr_numbers)?;
+        let ready_pull_request_ids = ready_pull_request_ids_requiring_temporary_draft(
+            &draft_protected_transitions,
+            &stage_info_by_number,
+        )?;
+        info!(
+            "Guarding {} PR base/head transition(s) before branch publication",
+            draft_protected_transitions.len()
+        );
+        convert_pull_requests_to_draft(&ready_pull_request_ids, execution_mode)?;
+        let protected_base_updates = draft_protected_base_update_inputs(
+            &prepublish_base_transitions,
+            &stage_info_by_number,
+        )?;
+        run_update_mutations(
+            execution_mode,
+            protected_base_updates,
+            "Protecting PR bases before branch publication",
+            MAX_BASE_UPDATES_PER_MUTATION,
+            MAX_BASE_MUTATION_CHARS,
+            true,
+            render_progress,
+        )?;
+        if execution_mode == ExecutionMode::Apply {
+            let refreshed_pr_bases = ObservedPrBaseChain::observe_for_heads(&heads)?;
+            let refreshed_decisions = plan_base_reconciliation(&desired_chain, &refreshed_pr_bases);
+            verify_base_edits_converged(
+                &ancestry_collapse_risk_head_branches,
+                &refreshed_decisions,
+            )?;
+        }
+        ready_pull_request_ids
+    };
 
     let ff_refspecs: Vec<String> = planned
         .iter()
@@ -620,6 +839,9 @@ fn build_from_groups_internal(
         };
         groups.len()
     ];
+    for transition in &draft_protected_transitions {
+        base_actions_by_group[transition.group_idx] = UpdateEditAction::Updated;
+    }
     let mut description_actions_by_group: Vec<UpdateEditAction> = vec![
         if no_pr {
             UpdateEditAction::NotRequested
@@ -761,6 +983,7 @@ fn build_from_groups_internal(
                     .then_some(decision.remote_pr_number)
                     .flatten()
             })
+            .filter(|number| !ancestry_collapse_risk_pr_numbers.contains(number))
             .collect::<HashSet<_>>();
         for (&number, want_base) in &desired_base_by_number {
             if let Some(info) = bodies_by_number.get(&number) {
@@ -814,6 +1037,12 @@ fn build_from_groups_internal(
         } else {
             info!("All PR descriptions/base refs up-to-date; no edits needed");
         }
+        if !draft_protected_head_branches.is_empty() && execution_mode == ExecutionMode::Apply {
+            let refreshed_pr_bases = ObservedPrBaseChain::observe_for_heads(&heads)?;
+            let refreshed_decisions = plan_base_reconciliation(&desired_chain, &refreshed_pr_bases);
+            verify_base_edits_converged(&draft_protected_head_branches, &refreshed_decisions)?;
+        }
+        mark_pull_requests_ready_for_review(&temporarily_drafted_pull_request_ids, execution_mode)?;
     }
 
     if !no_pr {
@@ -995,17 +1224,24 @@ pub fn build_from_tags(
 #[cfg(test)]
 mod tests {
     use super::{
-        branch_reuse_guard_window, build_from_groups, build_from_tags, head_key,
-        heads_without_open_prs, ignored_boundary_warning, parse_github_timestamp_rfc3339,
-        pr_number_for_head, recent_pr_age, recent_pr_age_blocks_recreation,
-        should_use_single_update_mutation, terminal_pr_action,
+        ancestry_collapse_risk_transitions, branch_reuse_guard_window, build_from_groups,
+        build_from_tags, draft_protected_base_transitions, head_key, heads_without_open_prs,
+        ignored_boundary_warning, parse_github_timestamp_rfc3339, pr_number_for_head,
+        ready_pull_request_ids_requiring_temporary_draft, recent_pr_age,
+        recent_pr_age_blocks_recreation, should_use_single_update_mutation, terminal_pr_action,
+        DraftProtectedBaseTransition, PlannedPush, PushKind,
     };
     use crate::branch_names::group_branch_identities;
     use crate::config::{ListOrder, LocalPrBranchSyncPolicy, PrDescriptionMode};
     use crate::execution::ExecutionMode;
-    use crate::github::TerminalPrState;
+    use crate::github::{PrStageInfo, TerminalPrState};
     use crate::parsing::{split_groups_for_update, Group};
-    use crate::test_support::{init_case_conflicting_stack_repo, lock_cwd, DirGuard};
+    use crate::pr_base_chain::{
+        BaseReconciliationAction, BaseReconciliationDecision, DesiredPrBase,
+    };
+    use crate::test_support::{
+        commit_file, init_case_conflicting_stack_repo, init_repo, lock_cwd, DirGuard,
+    };
     use std::collections::HashMap;
     use time::{Duration as TimeDuration, OffsetDateTime};
 
@@ -1105,6 +1341,171 @@ mod tests {
     fn terminal_pr_action_describes_terminal_state() {
         assert_eq!(terminal_pr_action(TerminalPrState::Merged), "merged");
         assert_eq!(terminal_pr_action(TerminalPrState::Closed), "closed");
+    }
+
+    fn desired_base(head_branch: &str) -> DesiredPrBase {
+        DesiredPrBase {
+            local_pr_number: 1,
+            stable_handle: "pr:gamma".to_string(),
+            head_branch: head_branch.to_string(),
+            expected_base_ref: "main".to_string(),
+        }
+    }
+
+    fn planned_push(head_branch: &str, kind: PushKind) -> PlannedPush {
+        PlannedPush {
+            branch: head_branch.to_string(),
+            target_sha: "next".to_string(),
+            remote_exists: true,
+            kind,
+        }
+    }
+
+    #[test]
+    fn draft_protection_detects_base_retarget_plus_head_move() {
+        let head_branch = "dank-spr/gamma";
+        let decisions = vec![BaseReconciliationDecision {
+            desired: desired_base(head_branch),
+            current_base_ref: Some("dank-spr/beta".to_string()),
+            remote_pr_number: Some(3),
+            action: BaseReconciliationAction::NeedsEdit,
+        }];
+
+        let transitions = draft_protected_base_transitions(
+            &decisions,
+            &[planned_push(head_branch, PushKind::Force)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            transitions,
+            vec![DraftProtectedBaseTransition {
+                group_idx: 0,
+                remote_pr_number: 3,
+                head_branch: head_branch.to_string(),
+                target_head_sha: "next".to_string(),
+                current_base_ref: "dank-spr/beta".to_string(),
+                desired_base_ref: "main".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn draft_protection_ignores_base_retargets_without_head_moves() {
+        let head_branch = "dank-spr/gamma";
+        let decisions = vec![BaseReconciliationDecision {
+            desired: desired_base(head_branch),
+            current_base_ref: Some("dank-spr/beta".to_string()),
+            remote_pr_number: Some(3),
+            action: BaseReconciliationAction::NeedsEdit,
+        }];
+
+        let transitions = draft_protected_base_transitions(
+            &decisions,
+            &[planned_push(head_branch, PushKind::Skip)],
+        )
+        .unwrap();
+
+        assert!(transitions.is_empty());
+    }
+
+    #[test]
+    fn ready_pull_request_ids_only_restore_prs_that_spr_temporarily_drafts() {
+        let transitions = vec![
+            DraftProtectedBaseTransition {
+                group_idx: 0,
+                remote_pr_number: 3,
+                head_branch: "dank-spr/gamma".to_string(),
+                target_head_sha: "gamma-next".to_string(),
+                current_base_ref: "dank-spr/beta".to_string(),
+                desired_base_ref: "main".to_string(),
+            },
+            DraftProtectedBaseTransition {
+                group_idx: 1,
+                remote_pr_number: 4,
+                head_branch: "dank-spr/delta".to_string(),
+                target_head_sha: "delta-next".to_string(),
+                current_base_ref: "dank-spr/gamma".to_string(),
+                desired_base_ref: "dank-spr/gamma".to_string(),
+            },
+        ];
+        let stage_info_by_number = HashMap::from([
+            (
+                3,
+                PrStageInfo {
+                    id: "ready-pr".to_string(),
+                    is_draft: false,
+                },
+            ),
+            (
+                4,
+                PrStageInfo {
+                    id: "already-draft-pr".to_string(),
+                    is_draft: true,
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            ready_pull_request_ids_requiring_temporary_draft(&transitions, &stage_info_by_number)
+                .unwrap(),
+            vec!["ready-pr".to_string()]
+        );
+    }
+
+    #[test]
+    fn ancestry_collapse_risk_tracks_the_old_base_branch_after_publication() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let target_head_sha = commit_file(&repo, "gamma.txt", "gamma\n", "feat: gamma pr:gamma");
+        let future_old_base_sha = commit_file(&repo, "beta.txt", "beta\n", "feat: beta pr:beta");
+        let transitions = vec![DraftProtectedBaseTransition {
+            group_idx: 0,
+            remote_pr_number: 3,
+            head_branch: "dank-spr/gamma".to_string(),
+            target_head_sha: target_head_sha.clone(),
+            current_base_ref: "dank-spr/beta".to_string(),
+            desired_base_ref: "main".to_string(),
+        }];
+        let planned_pushes = vec![PlannedPush {
+            branch: "dank-spr/beta".to_string(),
+            target_sha: future_old_base_sha,
+            remote_exists: true,
+            kind: PushKind::Force,
+        }];
+
+        assert_eq!(
+            ancestry_collapse_risk_transitions(&transitions, &planned_pushes, &HashMap::new())
+                .unwrap(),
+            transitions
+        );
+    }
+
+    #[test]
+    fn ancestry_collapse_risk_rejects_unavailable_old_base_objects() {
+        let _lock = lock_cwd();
+        let dir = init_repo();
+        let repo = dir.path().to_path_buf();
+        let _guard = DirGuard::change_to(&repo);
+        let target_head_sha = commit_file(&repo, "gamma.txt", "gamma\n", "feat: gamma pr:gamma");
+        let transitions = vec![DraftProtectedBaseTransition {
+            group_idx: 0,
+            remote_pr_number: 3,
+            head_branch: "dank-spr/gamma".to_string(),
+            target_head_sha,
+            current_base_ref: "main".to_string(),
+            desired_base_ref: "dank-spr/alpha".to_string(),
+        }];
+        let remote_map = HashMap::from([(
+            "main".to_string(),
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+        )]);
+
+        let error = ancestry_collapse_risk_transitions(&transitions, &[], &remote_map).unwrap_err();
+
+        assert!(error.to_string().contains("git merge-base --is-ancestor"));
     }
 
     fn group(tag: &str) -> Group {

--- a/src/git.rs
+++ b/src/git.rs
@@ -396,11 +396,23 @@ pub fn get_remote_branches_sha(branches: &[String]) -> Result<HashMap<String, St
 }
 
 pub fn git_is_ancestor(ancestor: &str, descendant: &str) -> Result<bool> {
-    let status = Command::new("git")
+    let out = Command::new("git")
         .args(["merge-base", "--is-ancestor", ancestor, descendant])
-        .status()
+        .output()
         .with_context(|| "failed to run git merge-base --is-ancestor")?;
-    Ok(status.success())
+    if out.status.success() {
+        Ok(true)
+    } else if out.status.code() == Some(1) {
+        Ok(false)
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        bail!(
+            "git merge-base --is-ancestor {} {} failed: {}",
+            ancestor,
+            descendant,
+            stderr
+        )
+    }
 }
 
 /// Resolves a revision to its full object id.

--- a/src/github.rs
+++ b/src/github.rs
@@ -767,6 +767,122 @@ fn fetch_pr_bodies_graphql_chunk(numbers: &[u64]) -> Result<HashMap<u64, PrBodyI
     Ok(out)
 }
 
+/// Existing pull request state needed while temporarily protecting reorder publication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrStageInfo {
+    pub id: String,
+    pub is_draft: bool,
+}
+
+/// Fetch the mutation identity plus current ready-vs-draft stage for existing pull requests.
+pub fn fetch_pr_stage_info_graphql(numbers: &[u64]) -> Result<HashMap<u64, PrStageInfo>> {
+    if numbers.is_empty() {
+        Ok(HashMap::new())
+    } else {
+        let (owner, name) = get_repo_owner_name()?;
+        let mut q = String::from(
+            "query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ ",
+        );
+        for (i, n) in numbers.iter().enumerate() {
+            q.push_str(&format!(
+                "pr{}: pullRequest(number: {}) {{ id isDraft }} ",
+                i, n
+            ));
+        }
+        q.push_str("} }");
+        let json = gh_ro(
+            [
+                "api",
+                "graphql",
+                "-f",
+                &format!("query={}", q),
+                "-F",
+                &format!("owner={}", owner),
+                "-F",
+                &format!("name={}", name),
+            ]
+            .as_slice(),
+        )?;
+        let v: serde_json::Value = serde_json::from_str(&json)?;
+        let repo = &v["data"]["repository"];
+        let mut out = HashMap::new();
+        for (i, number) in numbers.iter().enumerate() {
+            let key = format!("pr{}", i);
+            let node = &repo[&key];
+            if node.is_null() {
+                bail!(
+                    "GitHub PR #{} was not found while reading draft stage",
+                    number
+                );
+            }
+            let id = node["id"]
+                .as_str()
+                .ok_or_else(|| anyhow!("GitHub PR #{} result missing GraphQL id", number))?;
+            let is_draft = node["isDraft"]
+                .as_bool()
+                .ok_or_else(|| anyhow!("GitHub PR #{} result missing isDraft", number))?;
+            out.insert(
+                *number,
+                PrStageInfo {
+                    id: id.to_string(),
+                    is_draft,
+                },
+            );
+        }
+        Ok(out)
+    }
+}
+
+const MAX_PR_STAGE_MUTATIONS_PER_REQUEST: usize = 50;
+
+fn mutate_pull_request_stage(
+    mutation_name: &str,
+    pull_request_ids: &[String],
+    execution_mode: ExecutionMode,
+) -> Result<()> {
+    for chunk in pull_request_ids.chunks(MAX_PR_STAGE_MUTATIONS_PER_REQUEST) {
+        let mut mutation = String::from("mutation {");
+        for (i, pull_request_id) in chunk.iter().enumerate() {
+            mutation.push_str(&format!(
+                "m{}: {}(input:{{pullRequestId:\"{}\"}}){{ clientMutationId }} ",
+                i,
+                mutation_name,
+                graphql_escape(pull_request_id)
+            ));
+        }
+        mutation.push('}');
+        gh_rw(
+            execution_mode,
+            ["api", "graphql", "-f", &format!("query={}", mutation)].as_slice(),
+        )?;
+    }
+    Ok(())
+}
+
+/// Temporarily draft existing pull requests before a protected reorder publication.
+pub fn convert_pull_requests_to_draft(
+    pull_request_ids: &[String],
+    execution_mode: ExecutionMode,
+) -> Result<()> {
+    mutate_pull_request_stage(
+        "convertPullRequestToDraft",
+        pull_request_ids,
+        execution_mode,
+    )
+}
+
+/// Restore existing pull requests to ready-for-review after a protected reorder publication.
+pub fn mark_pull_requests_ready_for_review(
+    pull_request_ids: &[String],
+    execution_mode: ExecutionMode,
+) -> Result<()> {
+    mutate_pull_request_stage(
+        "markPullRequestReadyForReview",
+        pull_request_ids,
+        execution_mode,
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PrCiState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1510,10 +1510,28 @@ mod tests {
         body_json_path: &std::path::Path,
     ) -> String {
         format!(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*) cat \"{}\" ;;\n    *\"is:pr is:open head:dank-spr/alpha\"*|*\"is:pr is:open head:dank-spr/beta\"*)\n      echo '{{\"data\":{{\"pr0\":{{\"nodes\":[]}},\"pr1\":{{\"nodes\":[]}}}}}}' ;;\n    *\"pullRequest(number: 17)\"*\"pullRequest(number: 18)\"*) cat \"{}\" ;;\n    *\"mutation {{\"*) echo '{{\"data\":{{}}}}' ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*) cat \"{}\" ;;\n    *\"is:pr is:open head:dank-spr/alpha\"*|*\"is:pr is:open head:dank-spr/beta\"*)\n      echo '{{\"data\":{{\"pr0\":{{\"nodes\":[]}},\"pr1\":{{\"nodes\":[]}}}}}}' ;;\n    *\"pullRequest(number: 18) {{ id isDraft }}\"*)\n      echo '{{\"data\":{{\"repository\":{{\"pr0\":{{\"id\":\"PR_18\",\"isDraft\":false}}}}}}}}' ;;\n    *\"pullRequest(number: 17)\"*\"pullRequest(number: 18)\"*) cat \"{}\" ;;\n    *\"mutation {{\"*) echo '{{\"data\":{{}}}}' ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
             log_path.display(),
             open_prs_path.display(),
             body_json_path.display(),
+        )
+    }
+
+    fn protected_update_gh_script(
+        log_path: &std::path::Path,
+        stale_open_prs_path: &std::path::Path,
+        updated_open_prs_path: &std::path::Path,
+        body_json_path: &std::path::Path,
+        base_updated_path: &std::path::Path,
+    ) -> String {
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*)\n      if [ -f \"{}\" ]; then cat \"{}\"; else cat \"{}\"; fi ;;\n    *\"pullRequest(number: 18) {{ id isDraft }}\"*)\n      echo '{{\"data\":{{\"repository\":{{\"pr0\":{{\"id\":\"PR_18\",\"isDraft\":false}}}}}}}}' ;;\n    *\"pullRequest(number: 17)\"*\"pullRequest(number: 18)\"*) cat \"{}\" ;;\n    *\"updatePullRequest\"*\"baseRefName\"*) touch \"{}\"; echo '{{\"data\":{{}}}}' ;;\n    *\"mutation {{\"*) echo '{{\"data\":{{}}}}' ;;\n    *) echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            log_path.display(),
+            base_updated_path.display(),
+            updated_open_prs_path.display(),
+            stale_open_prs_path.display(),
+            body_json_path.display(),
+            base_updated_path.display(),
         )
     }
 
@@ -2789,6 +2807,135 @@ mod tests {
         );
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("baseRefName:\"dank-spr/alpha\""), "{log}");
+    }
+
+    #[test]
+    fn update_draft_protection_wraps_head_push_and_base_reconciliation() {
+        let _lock = lock_cwd();
+        let dir = init_update_stack_repo();
+        let repo = dir.path().join("repo");
+        let _guard = DirGuard::change_to(&repo);
+        let _home_guard = EnvVarGuard::set("HOME", dir.path().display().to_string());
+        let origin_url = format!("file://{}", dir.path().join("origin.git").display());
+        git(
+            &repo,
+            ["remote", "set-url", "origin", origin_url.as_str()].as_slice(),
+        );
+        let log_path = repo.join("events.log");
+        let stale_open_prs_path = repo.join("gh-open-stale.json");
+        let updated_open_prs_path = repo.join("gh-open-updated.json");
+        let body_json_path = repo.join("gh-bodies.json");
+        let base_updated_path = repo.join("base-updated");
+        let open_prs = |beta_base: &str| {
+            serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": {
+                            "nodes": [{
+                                "number": 17,
+                                "headRefName": "dank-spr/alpha",
+                                "baseRefName": "main",
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/17",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        },
+                        "pr1": {
+                            "nodes": [{
+                                "number": 18,
+                                "headRefName": "dank-spr/beta",
+                                "baseRefName": beta_base,
+                                "state": "OPEN",
+                                "mergedAt": serde_json::Value::Null,
+                                "closedAt": serde_json::Value::Null,
+                                "url": "https://github.com/o/r/pull/18",
+                                "autoMergeRequest": serde_json::Value::Null
+                            }]
+                        }
+                    }
+                }
+            })
+        };
+        fs::write(
+            &stale_open_prs_path,
+            serde_json::to_string(&open_prs("main")).unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &updated_open_prs_path,
+            serde_json::to_string(&open_prs("dank-spr/alpha")).unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &body_json_path,
+            serde_json::to_string(&serde_json::json!({
+                "data": {
+                    "repository": {
+                        "pr0": { "id": "PR_17", "body": "alpha body" },
+                        "pr1": { "id": "PR_18", "body": "beta body" }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let hook_path = repo.join(".git/hooks/pre-push");
+        fs::write(
+            &hook_path,
+            format!(
+                "#!/bin/sh\nprintf 'git-push\\n' >> \"{}\"\n",
+                log_path.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&hook_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook_path, permissions).unwrap();
+        let script = protected_update_gh_script(
+            &log_path,
+            &stale_open_prs_path,
+            &updated_open_prs_path,
+            &body_json_path,
+            &base_updated_path,
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "update",
+        ])
+        .unwrap();
+
+        run_cli(cli, OutputFormat::Human).unwrap();
+
+        let events = fs::read_to_string(log_path).unwrap();
+        let event_lines = events.lines().collect::<Vec<_>>();
+        let draft_idx = event_lines
+            .iter()
+            .position(|line| line.contains("convertPullRequestToDraft"))
+            .unwrap();
+        let push_idx = event_lines
+            .iter()
+            .position(|line| *line == "git-push")
+            .unwrap();
+        let base_idx = event_lines
+            .iter()
+            .position(|line| line.contains("updatePullRequest") && line.contains("baseRefName"))
+            .unwrap();
+        let ready_idx = event_lines
+            .iter()
+            .position(|line| line.contains("markPullRequestReadyForReview"))
+            .unwrap();
+        assert!(draft_idx < push_idx, "{events}");
+        assert!(push_idx < base_idx, "{events}");
+        assert!(base_idx < ready_idx, "{events}");
     }
 
     #[test]


### PR DESCRIPTION
Ports the draft-protected publication flow from [#151](https://github.com/mattskl-openai/spr-multicommit/pull/151) directly onto `main`, without its stacked parent [#140](https://github.com/mattskl-openai/spr-multicommit/pull/140).

`spr update` can rewrite an existing PR head and retarget its base as two separate GitHub-visible operations. During that gap, GitHub can compute the new head against the old base.

This was confirmed on <a different repo>: GitHub briefly saw 356 commits and 300+ unrelated files, requested nine unrelated CODEOWNERS, and received the corrected base four seconds later. The settled PR changed only 16 files, but the stale review requests remained.

A smaller form of the same race can make a reordered open PR appear already contained in its stale base and collapse it as merged. That was the original failure addressed by #151.

The update flow now temporarily converts affected ready PRs to draft, performs the protected base/head transition, verifies that the final base chain converged, and restores only the PRs it temporarily drafted. GitHub therefore assigns CODEOWNERS only after the final stable diff is visible.

Example:

```text
Before: push rewritten head -> compare against stale base -> unrelated CODEOWNERS
After:  draft -> update head/base -> verify stable diff -> ready
```

Validation:
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (feature coverage passes; current `origin/main` has known Git 2.43 and absorb-policy baseline failures)