### PR TITLE
list: add fast local and batched remote modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ spr update
 spr list pr
 spr list commit
 
+# Inspect only local Git history, without invoking GitHub
+spr ls p --local
+spr ls c -l
+
 # Discover which stack branch owns a canonical PR branch
 spr resolve-stack dank-spr/alpha
 
@@ -509,6 +513,21 @@ Operator rules:
 
 Lists PRs in the current stack for the configured prefix. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers remain bottom → top, and the human output shows both the current `LPR #N` and each group's explicit selector. The derived concrete head branch is omitted because it is redundant with the selector.
 
+The default mode performs one batched exact-head GitHub GraphQL request for up
+to 20 groups. It loads open PR identity, merged fallback identity, CI, and
+review state together. Read-only listing does not perform the slower
+case-insensitive remote branch audit; update, land, branch reuse, and other
+mutating paths retain that exhaustive safety check. If the rich status query
+is unavailable, listing retries identity-only and displays unknown status.
+
+Use `spr list pr --local` (or `spr ls p -l`) for a strictly local view. Local
+mode does not invoke `gh`, even for an availability check, and therefore omits
+the status legend, status icons, GitHub PR numbers, and open/merged state:
+
+```text
+LPR #3 / pr:updateUntil - fc01086e - 1 commit
+```
+
 Aliases:
 
 - `p`
@@ -534,6 +553,9 @@ The payload always uses canonical bottom-up group order, includes remote PR meta
 CI/review state when available, retains both `stable_handle` and `head_branch`, and reports
 case-colliding concrete branch failures as a typed
 `synthetic_branch_name_collision` error payload.
+With `--local`, each group reports `remote.kind` as `not_queried`. This differs
+from `no_remote`, which means GitHub was queried and no exact matching PR was
+found.
 
 ### spr status
 
@@ -542,6 +564,8 @@ Aliases:
 - `stat`
 
 Alias for `spr list pr`.
+
+`spr status --local` and `spr stat -l` use the same zero-network local mode.
 
 `spr status` runs the same early concrete branch-collision validation as
 `spr list pr` before printing anything.
@@ -553,6 +577,12 @@ top-level command identity as `status`.
 
 Lists commits in the current stack, grouped by local PR. Display order is controlled by `list_order` (default `recent_on_bottom`); local PR numbers and commit indices remain bottom → top, and each human group header shows its explicit selector without repeating the derived concrete head branch.
 
+The default mode makes one lightweight exact-open-head GitHub query for up to
+20 groups. It fetches only the PR identity and number needed by commit group
+headers; it does not request merged history, CI, or review state. Use
+`spr list commit --local` (or `spr ls c -l`) to skip GitHub entirely. Local
+commit formatting is unchanged except that GitHub PR numbers are unavailable.
+
 Before listing, `spr list commit` validates that no two live PR groups derive
 concrete branch names that collide under case-insensitive comparison. If they
 do, it halts before loading GitHub PR state.
@@ -561,10 +591,16 @@ do, it halts before loading GitHub PR state.
 The payload uses the same canonical bottom-up group order as `spr list --json pr`, keeps canonical
 global commit indices, retains both `stable_handle` and `head_branch`, and ignores `list_order` in
 JSON mode.
+With `--local`, remote state is `not_queried` for every group.
 
 Aliases:
 
 - `c`
+
+As a rough benchmark guide, the prior serialized remote path took about
+1.6–3 seconds in a representative stack. The batched remote path is expected
+to take roughly 0.6–0.9 seconds, while local mode is expected to take roughly
+0.1–0.4 seconds. These are operational estimates, not timing guarantees.
 
 ### spr move
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,10 +73,26 @@ impl From<DryRunArgs> for ExecutionMode {
 pub enum ListWhat {
     /// List PRs in the stack (halts early if live groups derive case-colliding concrete branch names)
     #[command(alias = "p")]
-    Pr,
+    Pr {
+        /// Read only local Git state and skip all GitHub queries
+        #[arg(short = 'l', long)]
+        local: bool,
+    },
     /// List commits in the stack (halts early if live groups derive case-colliding concrete branch names)
     #[command(alias = "c")]
-    Commit,
+    Commit {
+        /// Read only local Git state and skip all GitHub queries
+        #[arg(short = 'l', long)]
+        local: bool,
+    },
+}
+
+impl ListWhat {
+    pub fn local(self) -> bool {
+        match self {
+            Self::Pr { local } | Self::Commit { local } => local,
+        }
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -206,7 +222,11 @@ pub enum Cmd {
 
     /// Status overview (alias for `list pr`) with the same early concrete branch-collision guard
     #[command(alias = "stat")]
-    Status,
+    Status {
+        /// Read only local Git state and skip all GitHub queries
+        #[arg(short = 'l', long)]
+        local: bool,
+    },
 
     /// Reconcile local per-PR branches with the current stack using the configured sync policy
     SyncLocalBranches,
@@ -502,9 +522,9 @@ mod tests {
             assert!(scan.requested, "case did not request JSON: {case:?}");
             assert!(matches!(
                 cli.cmd,
-                Cmd::Status
+                Cmd::Status { .. }
                     | Cmd::List {
-                        what: super::ListWhat::Commit
+                        what: super::ListWhat::Commit { .. }
                     }
             ));
         }
@@ -630,7 +650,7 @@ mod tests {
 
         match cli.cmd {
             Cmd::List {
-                what: super::ListWhat::Pr,
+                what: super::ListWhat::Pr { local: false },
             } => {
                 assert_eq!(cli.output.format(), OutputFormat::Json);
             }
@@ -644,7 +664,7 @@ mod tests {
 
         match cli.cmd {
             Cmd::List {
-                what: super::ListWhat::Commit,
+                what: super::ListWhat::Commit { local: false },
             } => {
                 assert_eq!(cli.output.format(), OutputFormat::Json);
             }
@@ -659,7 +679,7 @@ mod tests {
         assert!(matches!(
             cli.cmd,
             Cmd::List {
-                what: super::ListWhat::Pr
+                what: super::ListWhat::Pr { local: false }
             }
         ));
         assert_eq!(cli.output.format(), OutputFormat::Json);
@@ -670,8 +690,44 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "status", "--json"]).unwrap();
 
         match cli.cmd {
-            Cmd::Status => assert_eq!(cli.output.format(), OutputFormat::Json),
+            Cmd::Status { local: false } => {
+                assert_eq!(cli.output.format(), OutputFormat::Json)
+            }
             other => panic!("unexpected command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn local_list_flags_parse_on_commands_and_aliases() {
+        let cases = [
+            (["spr", "list", "pr", "--local"], "pr"),
+            (["spr", "ls", "p", "-l"], "pr"),
+            (["spr", "list", "commit", "--local"], "commit"),
+            (["spr", "ls", "c", "-l"], "commit"),
+        ];
+
+        for (args, expected) in cases {
+            let cli = Cli::try_parse_from(args).unwrap();
+            match (cli.cmd, expected) {
+                (
+                    Cmd::List {
+                        what: super::ListWhat::Pr { local: true },
+                    },
+                    "pr",
+                )
+                | (
+                    Cmd::List {
+                        what: super::ListWhat::Commit { local: true },
+                    },
+                    "commit",
+                ) => {}
+                other => panic!("unexpected local list parse: {other:?}"),
+            }
+        }
+
+        for args in [["spr", "status", "--local"], ["spr", "stat", "-l"]] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert!(matches!(cli.cmd, Cmd::Status { local: true }));
         }
     }
 
@@ -709,7 +765,7 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "status", "--cd", "/tmp/example"]).unwrap();
 
         assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
-        assert!(matches!(cli.cmd, Cmd::Status));
+        assert!(matches!(cli.cmd, Cmd::Status { local: false }));
         assert_eq!(cli.output.format(), OutputFormat::Human);
     }
 
@@ -718,7 +774,7 @@ mod tests {
         let cli = Cli::try_parse_from(["spr", "--cd", "/tmp/example", "status"]).unwrap();
 
         assert_eq!(cli.cd, Some(PathBuf::from("/tmp/example")));
-        assert!(matches!(cli.cmd, Cmd::Status));
+        assert!(matches!(cli.cmd, Cmd::Status { local: false }));
         assert_eq!(cli.output.format(), OutputFormat::Human);
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -19,9 +19,11 @@ use crate::branch_names::{
     CanonicalBranchConflictKey, GroupBranchIdentity, GroupBranchNameCollision,
 };
 use crate::config::{ListOrder, LocalPrBranchSyncPolicy};
+#[cfg(test)]
+use crate::github::PrInfoWithState;
 use crate::github::{
-    fetch_pr_ci_review_status, list_open_or_merged_prs_for_heads, PrCiReviewStatus, PrCiState,
-    PrInfoWithState, PrReviewDecision, PrState,
+    fetch_read_only_open_prs, fetch_read_only_pr_status, PrCiReviewStatus, PrCiState,
+    PrReviewDecision, PrState,
 };
 use crate::parsing::{derive_local_groups, Group};
 
@@ -57,6 +59,7 @@ pub struct RemotePrMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RemotePrState {
+    NotQueried,
     NoRemote,
     RemoteWithoutCiReview {
         pr_number: u64,
@@ -120,7 +123,7 @@ pub struct CommitListData {
 /// else would incorrectly imply CI/review information was fetched.
 fn status_icons(remote: &RemotePrMetadata) -> (&'static str, &'static str) {
     match &remote.state {
-        RemotePrState::NoRemote => ("?", "?"),
+        RemotePrState::NotQueried | RemotePrState::NoRemote => ("?", "?"),
         RemotePrState::RemoteWithoutCiReview {
             state: PrState::Merged,
             ..
@@ -215,6 +218,14 @@ fn format_pr_summary_line(line: PrSummaryLine<'_>) -> String {
     )
 }
 
+fn format_local_pr_summary_line(line: PrSummaryLine<'_>) -> String {
+    let plural = if line.count == 1 { "commit" } else { "commits" };
+    format!(
+        "LPR #{} / {} - {} - {} {}",
+        line.local_pr_num, line.stable_handle, line.short, line.count, plural
+    )
+}
+
 fn format_commit_group_header(
     local_pr_num: usize,
     stable_handle: &str,
@@ -251,21 +262,38 @@ fn fetch_remote_pr_metadata(
         .iter()
         .map(|identity| identity.exact.clone())
         .collect();
-    let prs = list_open_or_merged_prs_for_heads(&heads)?;
-    let open_numbers: Vec<u64> = prs
-        .iter()
-        .filter(|pr| pr.state == PrState::Open)
-        .map(|pr| pr.number)
-        .collect();
-    let status_map = if open_numbers.is_empty() {
-        Some(HashMap::new())
-    } else {
-        fetch_pr_ci_review_status(&open_numbers).ok()
-    };
-
-    Ok(build_remote_pr_metadata(prs, status_map.as_ref()))
+    let prs = fetch_read_only_pr_status(&heads)?;
+    Ok(prs
+        .into_values()
+        .map(|info| {
+            let pr = info.pr;
+            (
+                canonical_branch_conflict_key(&pr.head),
+                remote_pr_metadata(pr.number, pr.url, pr.base, pr.state, info.ci_review_status),
+            )
+        })
+        .collect())
 }
 
+fn fetch_open_remote_pr_metadata(
+    branch_identities: &[GroupBranchIdentity],
+) -> Result<HashMap<CanonicalBranchConflictKey, RemotePrMetadata>> {
+    let heads = branch_identities
+        .iter()
+        .map(|identity| identity.exact.clone())
+        .collect::<Vec<_>>();
+    Ok(fetch_read_only_open_prs(&heads)?
+        .into_values()
+        .map(|pr| {
+            (
+                canonical_branch_conflict_key(&pr.head),
+                remote_pr_metadata(pr.number, pr.url, pr.base, pr.state, None),
+            )
+        })
+        .collect())
+}
+
+#[cfg(test)]
 fn build_remote_pr_metadata(
     prs: Vec<PrInfoWithState>,
     status_map: Option<&HashMap<u64, PrCiReviewStatus>>,
@@ -290,6 +318,7 @@ fn build_pr_list_data(
     branch_identities: &[GroupBranchIdentity],
     remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
     local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
+    missing_remote_state: RemotePrState,
 ) -> PrListData {
     let groups = groups
         .iter()
@@ -307,7 +336,7 @@ fn build_pr_list_data(
                     .get(&identity.conflict_key)
                     .cloned()
                     .unwrap_or(RemotePrMetadata {
-                        state: RemotePrState::NoRemote,
+                        state: missing_remote_state.clone(),
                     }),
             }
         })
@@ -324,6 +353,7 @@ fn build_commit_list_data(
     branch_identities: &[GroupBranchIdentity],
     remote_by_head: &HashMap<CanonicalBranchConflictKey, RemotePrMetadata>,
     local_pr_branch_drift: Vec<crate::local_pr_branches::LocalPrBranchAction>,
+    missing_remote_state: RemotePrState,
 ) -> CommitListData {
     let group_start_indices: Vec<usize> = groups
         .iter()
@@ -358,7 +388,7 @@ fn build_commit_list_data(
                     .get(&identity.conflict_key)
                     .cloned()
                     .unwrap_or(RemotePrMetadata {
-                        state: RemotePrState::NoRemote,
+                        state: missing_remote_state.clone(),
                     }),
                 commits,
             }
@@ -376,10 +406,14 @@ pub fn collect_pr_list_data_for_json(
     prefix: &str,
     ignore_tag: &str,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> std::result::Result<PrListData, ReadOnlyQueryError> {
     let (groups, branch_identities) = derive_groups_and_identities(base, prefix, ignore_tag)?;
-    let remote_by_head =
-        fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?;
+    let remote_by_head = if local {
+        HashMap::new()
+    } else {
+        fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?
+    };
     let targets = crate::local_pr_branches::targets_from_groups(prefix, &groups)
         .map_err(ReadOnlyQueryError::Internal)?;
     let local_pr_branch_drift =
@@ -390,6 +424,11 @@ pub fn collect_pr_list_data_for_json(
         &branch_identities,
         &remote_by_head,
         local_pr_branch_drift,
+        if local {
+            RemotePrState::NotQueried
+        } else {
+            RemotePrState::NoRemote
+        },
     ))
 }
 
@@ -398,8 +437,9 @@ pub fn collect_pr_list_data(
     prefix: &str,
     ignore_tag: &str,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> Result<PrListData> {
-    collect_pr_list_data_for_json(base, prefix, ignore_tag, local_pr_branch_policy)
+    collect_pr_list_data_for_json(base, prefix, ignore_tag, local_pr_branch_policy, local)
         .map_err(anyhow::Error::from)
 }
 
@@ -408,10 +448,14 @@ pub fn collect_commit_list_data_for_json(
     prefix: &str,
     ignore_tag: &str,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> std::result::Result<CommitListData, ReadOnlyQueryError> {
     let (groups, branch_identities) = derive_groups_and_identities(base, prefix, ignore_tag)?;
-    let remote_by_head =
-        fetch_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?;
+    let remote_by_head = if local {
+        HashMap::new()
+    } else {
+        fetch_open_remote_pr_metadata(&branch_identities).map_err(ReadOnlyQueryError::Internal)?
+    };
     let targets = crate::local_pr_branches::targets_from_groups(prefix, &groups)
         .map_err(ReadOnlyQueryError::Internal)?;
     let local_pr_branch_drift =
@@ -422,6 +466,11 @@ pub fn collect_commit_list_data_for_json(
         &branch_identities,
         &remote_by_head,
         local_pr_branch_drift,
+        if local {
+            RemotePrState::NotQueried
+        } else {
+            RemotePrState::NoRemote
+        },
     ))
 }
 
@@ -430,28 +479,33 @@ pub fn collect_commit_list_data(
     prefix: &str,
     ignore_tag: &str,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> Result<CommitListData> {
-    collect_commit_list_data_for_json(base, prefix, ignore_tag, local_pr_branch_policy)
+    collect_commit_list_data_for_json(base, prefix, ignore_tag, local_pr_branch_policy, local)
         .map_err(anyhow::Error::from)
 }
 
-fn render_pr_list(data: &PrListData, list_order: ListOrder) -> Vec<String> {
+fn render_pr_list(data: &PrListData, list_order: ListOrder, local: bool) -> Vec<String> {
     if data.groups.is_empty() {
         vec!["No groups discovered; nothing to list.".to_string()]
     } else {
-        let mut lines = vec![
-            format!("┏━━{}CI status", crate::format::EM_SPACE),
-            format!("┃┏━{}review status", crate::format::EM_SPACE),
-        ];
+        let mut lines = if local {
+            Vec::new()
+        } else {
+            vec![
+                format!("┏━━{}CI status", crate::format::EM_SPACE),
+                format!("┃┏━{}review status", crate::format::EM_SPACE),
+            ]
+        };
         for group_idx in list_order.display_indices(data.groups.len()) {
             let group = &data.groups[group_idx];
             let (ci_icon, rv_icon) = status_icons(&group.remote);
             let pr_number = match &group.remote.state {
-                RemotePrState::NoRemote => None,
+                RemotePrState::NotQueried | RemotePrState::NoRemote => None,
                 RemotePrState::RemoteWithoutCiReview { pr_number, .. }
                 | RemotePrState::RemoteWithCiReview { pr_number, .. } => Some(*pr_number),
             };
-            lines.push(format_pr_summary_line(PrSummaryLine {
+            let summary = PrSummaryLine {
                 ci_icon,
                 rv_icon,
                 local_pr_num: group.local_pr_number,
@@ -459,7 +513,12 @@ fn render_pr_list(data: &PrListData, list_order: ListOrder) -> Vec<String> {
                 short: short_sha(&group.first_commit_sha),
                 pr_number,
                 count: group.commit_count,
-            }));
+            };
+            lines.push(if local {
+                format_local_pr_summary_line(summary)
+            } else {
+                format_pr_summary_line(summary)
+            });
             lines.push(format!(
                 "{s}{s}{s}{s}{s}{subject}",
                 s = crate::format::EM_SPACE,
@@ -552,9 +611,10 @@ pub fn list_prs_display(
     ignore_tag: &str,
     list_order: ListOrder,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> Result<()> {
-    let data = collect_pr_list_data(base, prefix, ignore_tag, local_pr_branch_policy)?;
-    for line in render_pr_list(&data, list_order) {
+    let data = collect_pr_list_data(base, prefix, ignore_tag, local_pr_branch_policy, local)?;
+    for line in render_pr_list(&data, list_order, local) {
         info!("{line}");
     }
     for line in render_local_pr_branch_drift(&data.local_pr_branch_drift) {
@@ -575,8 +635,9 @@ pub fn list_commits_display(
     ignore_tag: &str,
     list_order: ListOrder,
     local_pr_branch_policy: LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> Result<()> {
-    let data = collect_commit_list_data(base, prefix, ignore_tag, local_pr_branch_policy)?;
+    let data = collect_commit_list_data(base, prefix, ignore_tag, local_pr_branch_policy, local)?;
     for line in render_commit_list(&data, list_order) {
         info!("{line}");
     }
@@ -656,6 +717,21 @@ mod tests {
         });
 
         assert_eq!(line, "✓✓ LPR #2 / pr:beta - abcdef12 (#17) - 3 commits");
+    }
+
+    #[test]
+    fn local_pr_summary_omits_remote_status_and_number() {
+        let line = format_local_pr_summary_line(PrSummaryLine {
+            ci_icon: "✓",
+            rv_icon: "✓",
+            local_pr_num: 3,
+            stable_handle: "pr:updateUntil",
+            short: "fc01086e",
+            pr_number: Some(151),
+            count: 1,
+        });
+
+        assert_eq!(line, "LPR #3 / pr:updateUntil - fc01086e - 1 commit");
     }
 
     #[test]
@@ -742,7 +818,13 @@ mod tests {
             ),
         )]);
 
-        let data = build_pr_list_data(&groups, &branch_identities, &remote_by_head, Vec::new());
+        let data = build_pr_list_data(
+            &groups,
+            &branch_identities,
+            &remote_by_head,
+            Vec::new(),
+            RemotePrState::NoRemote,
+        );
         assert_eq!(data.groups[0].local_pr_number, 1);
         assert_eq!(data.groups[0].stable_handle, "pr:alpha");
         assert_eq!(data.groups[1].local_pr_number, 2);
@@ -769,7 +851,13 @@ mod tests {
             GroupBranchIdentity::new("dank-spr/beta".to_string()),
         ];
 
-        let data = build_pr_list_data(&groups, &branch_identities, &HashMap::new(), Vec::new());
+        let data = build_pr_list_data(
+            &groups,
+            &branch_identities,
+            &HashMap::new(),
+            Vec::new(),
+            RemotePrState::NoRemote,
+        );
 
         assert_eq!(data.groups[0].stable_handle, "branch:feature/login");
         assert_eq!(data.groups[0].head_branch, "feature/login");
@@ -849,7 +937,13 @@ mod tests {
             ),
         )]);
 
-        let data = build_commit_list_data(&groups, &branch_identities, &remote_by_head, Vec::new());
+        let data = build_commit_list_data(
+            &groups,
+            &branch_identities,
+            &remote_by_head,
+            Vec::new(),
+            RemotePrState::NoRemote,
+        );
 
         assert_eq!(data.groups[0].stable_handle, "pr:alpha");
         assert_eq!(
@@ -894,7 +988,7 @@ mod tests {
             local_pr_branch_drift: Vec::new(),
         };
 
-        let lines = render_pr_list(&data, ListOrder::RecentOnTop);
+        let lines = render_pr_list(&data, ListOrder::RecentOnTop, false);
 
         assert_eq!(lines[2], "?? LPR #2 / pr:beta - bbbbbbbb - 1 commit");
         assert_eq!(
@@ -902,6 +996,30 @@ mod tests {
             format!("{s}{s}{s}{s}{s}feat: beta", s = crate::format::EM_SPACE)
         );
         assert_eq!(lines[4], "?? LPR #1 / pr:alpha - aaaaaaaa - 1 commit");
+    }
+
+    #[test]
+    fn render_local_pr_list_omits_legend_icons_and_pr_numbers() {
+        let data = PrListData {
+            groups: vec![PrGroupData {
+                local_pr_number: 1,
+                stable_handle: "pr:alpha".to_string(),
+                head_branch: "dank-spr/alpha".to_string(),
+                first_commit_sha: "aaaaaaaa1".to_string(),
+                commit_count: 1,
+                first_subject: "feat: alpha".to_string(),
+                remote: RemotePrMetadata {
+                    state: RemotePrState::NotQueried,
+                },
+            }],
+            local_pr_branch_drift: Vec::new(),
+        };
+
+        let lines = render_pr_list(&data, ListOrder::RecentOnBottom, true);
+
+        assert_eq!(lines[0], "LPR #1 / pr:alpha - aaaaaaaa - 1 commit");
+        assert!(!lines.join("\n").contains("CI status"));
+        assert!(!lines.join("\n").contains("#17"));
     }
 
     #[test]
@@ -997,6 +1115,7 @@ mod tests {
             "dank-spr/",
             "ignore",
             LocalPrBranchSyncPolicy::Off,
+            false,
         )
         .expect_err("collision");
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,12 +3,12 @@
 //! This module centralizes read/write calls to GitHub so command modules can operate on
 //! typed results instead of raw JSON. The status-list path relies on branch-name lookups:
 //! for each local stack head, we resolve either the currently open PR or (if none is open)
-//! the latest merged PR for that exact synthetic branch name, while still treating case-only
-//! remote head variants as explicit conflicts. The update preflight separately looks up the
-//! latest terminal PR event for a canonical head ref so branch-name reuse can be blocked after
-//! recent merges or closes.
+//! the latest merged PR for that exact synthetic branch name. Read-only list queries intentionally
+//! avoid case-insensitive conflict searches; mutating commands retain those exhaustive guards. The
+//! update preflight separately looks up the latest terminal PR event for a canonical head ref so
+//! branch-name reuse can be blocked after recent merges or closes.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -97,11 +97,14 @@ const MAX_CONFLICT_HEADS_PER_QUERY: usize = 10;
 const MAX_TERMINAL_HEADS_PER_QUERY: usize = 10;
 const MAX_PR_BODIES_PER_QUERY: usize = 10;
 const MAX_PR_STATUS_PER_QUERY: usize = 20;
+const MAX_LIST_HEADS_PER_QUERY: usize = 20;
 const HEAD_SEARCH_FIELDS: &str =
     "number,headRefName,baseRefName,state,mergedAt,closedAt,url,autoMergeRequest";
 const EXACT_HEAD_QUERY_LIMIT: usize = 10;
 const EXACT_PR_GRAPHQL_FIELDS: &str =
     "number headRefName baseRefName state mergedAt closedAt url autoMergeRequest { enabledAt }";
+const LIST_PR_IDENTITY_FIELDS: &str = "number headRefName baseRefName state mergedAt url";
+const LIST_PR_STATUS_FIELDS: &str = "reviewDecision reviews(last:50, states:[APPROVED,CHANGES_REQUESTED]) { nodes { state } } commits(last:1) { nodes { commit { statusCheckRollup { state } } } }";
 const TERMINAL_PR_SEARCH_GRAPHQL_FIELDS: &str = "number headRefName state mergedAt closedAt url";
 
 #[derive(Debug, Deserialize, Clone)]
@@ -933,6 +936,261 @@ pub struct PrCiReviewStatus {
     pub review_decision: PrReviewDecision,
 }
 
+#[derive(Debug, Clone)]
+pub struct ReadOnlyListPrInfo {
+    pub pr: PrInfoWithState,
+    pub ci_review_status: Option<PrCiReviewStatus>,
+}
+
+fn parse_pr_ci_review_status(node: &serde_json::Value) -> PrCiReviewStatus {
+    let mut review = node["reviewDecision"]
+        .as_str()
+        .map(PrReviewDecision::from_graphql_state)
+        .unwrap_or(PrReviewDecision::Unknown);
+    let mut ci = PrCiState::Success;
+    if let Some(commit) = node["commits"]["nodes"]
+        .as_array()
+        .and_then(|nodes| nodes.first())
+    {
+        if let Some(state) = commit["commit"]["statusCheckRollup"]["state"].as_str() {
+            ci = PrCiState::from_graphql_state(state);
+        }
+    }
+    if review == PrReviewDecision::Unknown {
+        let mut has_changes_requested = false;
+        let mut has_approved = false;
+        if let Some(nodes) = node["reviews"]["nodes"].as_array() {
+            for review_node in nodes {
+                match review_node["state"].as_str().unwrap_or("") {
+                    "CHANGES_REQUESTED" => has_changes_requested = true,
+                    "APPROVED" => has_approved = true,
+                    _ => {}
+                }
+            }
+        }
+        review = if has_changes_requested {
+            PrReviewDecision::ChangesRequested
+        } else if has_approved {
+            PrReviewDecision::Approved
+        } else {
+            PrReviewDecision::ReviewRequired
+        };
+    }
+
+    PrCiReviewStatus {
+        ci_state: ci,
+        review_decision: review,
+    }
+}
+
+fn read_only_list_pr_from_head_search(
+    pr: HeadSearchPr,
+    requested_head: &str,
+    state: PrState,
+    ci_review_status: Option<PrCiReviewStatus>,
+) -> Result<ReadOnlyListPrInfo> {
+    let base = pr.base.ok_or_else(|| {
+        anyhow!(
+            "PR #{} missing baseRefName for requested head {}",
+            pr.number,
+            requested_head
+        )
+    })?;
+    let url = pr.url.ok_or_else(|| {
+        anyhow!(
+            "PR #{} missing url for requested head {}",
+            pr.number,
+            requested_head
+        )
+    })?;
+    Ok(ReadOnlyListPrInfo {
+        pr: PrInfoWithState {
+            number: pr.number,
+            head: pr.head,
+            base,
+            state,
+            url,
+        },
+        ci_review_status,
+    })
+}
+
+fn fetch_read_only_pr_status_chunk(
+    heads: &[String],
+    include_status: bool,
+) -> Result<HashMap<String, ReadOnlyListPrInfo>> {
+    let mut out = HashMap::new();
+    if heads.is_empty() {
+        return Ok(out);
+    }
+    let (owner, name) = get_repo_owner_name()?;
+    let open_fields = if include_status {
+        format!("{LIST_PR_IDENTITY_FIELDS} {LIST_PR_STATUS_FIELDS}")
+    } else {
+        LIST_PR_IDENTITY_FIELDS.to_string()
+    };
+    let mut query =
+        String::from("query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ ");
+    for (index, head) in heads.iter().enumerate() {
+        let escaped_head = graphql_escape(head);
+        query.push_str(&format!(
+            "open{index}: pullRequests(headRefName:\"{escaped_head}\", states:[OPEN], first:{EXACT_HEAD_QUERY_LIMIT}, orderBy:{{field:UPDATED_AT,direction:DESC}}) {{ nodes {{ {open_fields} }} }} "
+        ));
+        query.push_str(&format!(
+            "merged{index}: pullRequests(headRefName:\"{escaped_head}\", states:[MERGED], first:{EXACT_HEAD_QUERY_LIMIT}, orderBy:{{field:UPDATED_AT,direction:DESC}}) {{ nodes {{ {LIST_PR_IDENTITY_FIELDS} }} }} "
+        ));
+    }
+    query.push_str("} }");
+    let json = gh_ro(
+        [
+            "api",
+            "graphql",
+            "-f",
+            &format!("query={query}"),
+            "-F",
+            &format!("owner={owner}"),
+            "-F",
+            &format!("name={name}"),
+        ]
+        .as_slice(),
+    )?;
+    let value: serde_json::Value = serde_json::from_str(&json)?;
+    let repo = &value["data"]["repository"];
+    for (index, head) in heads.iter().enumerate() {
+        let open_nodes = repo[format!("open{index}")]["nodes"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let open_matches = open_nodes
+            .iter()
+            .cloned()
+            .map(serde_json::from_value)
+            .collect::<std::result::Result<Vec<HeadSearchPr>, _>>()?;
+        if let Some(pr) = select_single_open_pr_match(head, open_matches)? {
+            let status = if include_status {
+                open_nodes
+                    .iter()
+                    .find(|node| node["number"].as_u64() == Some(pr.number))
+                    .map(parse_pr_ci_review_status)
+            } else {
+                None
+            };
+            out.insert(
+                head.clone(),
+                read_only_list_pr_from_head_search(pr, head, PrState::Open, status)?,
+            );
+            continue;
+        }
+
+        let merged_matches = repo[format!("merged{index}")]["nodes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .cloned()
+            .map(serde_json::from_value)
+            .collect::<std::result::Result<Vec<HeadSearchPr>, _>>()?;
+        if let Some(pr) = select_latest_merged_pr_match(head, &merged_matches)? {
+            out.insert(
+                head.clone(),
+                read_only_list_pr_from_head_search(pr, head, PrState::Merged, None)?,
+            );
+        }
+    }
+    Ok(out)
+}
+
+pub fn fetch_read_only_pr_status(heads: &[String]) -> Result<HashMap<String, ReadOnlyListPrInfo>> {
+    let mut out = HashMap::new();
+    for chunk in heads.chunks(MAX_LIST_HEADS_PER_QUERY) {
+        let rich = run_read_chunk_with_retry(
+            chunk,
+            &|subset| fetch_read_only_pr_status_chunk(subset, true),
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        );
+        let chunk_out = match rich {
+            Ok(chunk_out) => chunk_out,
+            Err(rich_err) => run_read_chunk_with_retry(
+                chunk,
+                &|subset| fetch_read_only_pr_status_chunk(subset, false),
+                &|mut left, right| {
+                    left.extend(right);
+                    left
+                },
+            )
+            .with_context(|| format!("status query failed: {rich_err:#}"))?,
+        };
+        out.extend(chunk_out);
+    }
+    Ok(out)
+}
+
+fn fetch_read_only_open_prs_chunk(heads: &[String]) -> Result<HashMap<String, PrInfoWithState>> {
+    let mut out = HashMap::new();
+    if heads.is_empty() {
+        return Ok(out);
+    }
+    let (owner, name) = get_repo_owner_name()?;
+    let mut query =
+        String::from("query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ ");
+    for (index, head) in heads.iter().enumerate() {
+        query.push_str(&format!(
+            "open{index}: pullRequests(headRefName:\"{}\", states:[OPEN], first:{EXACT_HEAD_QUERY_LIMIT}, orderBy:{{field:UPDATED_AT,direction:DESC}}) {{ nodes {{ {LIST_PR_IDENTITY_FIELDS} }} }} ",
+            graphql_escape(head)
+        ));
+    }
+    query.push_str("} }");
+    let json = gh_ro(
+        [
+            "api",
+            "graphql",
+            "-f",
+            &format!("query={query}"),
+            "-F",
+            &format!("owner={owner}"),
+            "-F",
+            &format!("name={name}"),
+        ]
+        .as_slice(),
+    )?;
+    let value: serde_json::Value = serde_json::from_str(&json)?;
+    let repo = &value["data"]["repository"];
+    for (index, head) in heads.iter().enumerate() {
+        let matches = repo[format!("open{index}")]["nodes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .cloned()
+            .map(serde_json::from_value)
+            .collect::<std::result::Result<Vec<HeadSearchPr>, _>>()?;
+        if let Some(pr) = select_single_open_pr_match(head, matches)? {
+            out.insert(
+                head.clone(),
+                read_only_list_pr_from_head_search(pr, head, PrState::Open, None)?.pr,
+            );
+        }
+    }
+    Ok(out)
+}
+
+pub fn fetch_read_only_open_prs(heads: &[String]) -> Result<HashMap<String, PrInfoWithState>> {
+    let mut out = HashMap::new();
+    for chunk in heads.chunks(MAX_LIST_HEADS_PER_QUERY) {
+        let chunk_out = run_read_chunk_with_retry(
+            chunk,
+            &fetch_read_only_open_prs_chunk,
+            &|mut left, right| {
+                left.extend(right);
+                left
+            },
+        )?;
+        out.extend(chunk_out);
+    }
+    Ok(out)
+}
+
 pub fn fetch_pr_ci_review_status(numbers: &[u64]) -> Result<HashMap<u64, PrCiReviewStatus>> {
     let mut out = HashMap::new();
     for chunk in numbers.chunks(MAX_PR_STATUS_PER_QUERY) {
@@ -959,8 +1217,8 @@ fn fetch_pr_ci_review_status_chunk(numbers: &[u64]) -> Result<HashMap<u64, PrCiR
         String::from("query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ ");
     for (i, n) in numbers.iter().enumerate() {
         q.push_str(&format!(
-            "pr{}: pullRequest(number: {}) {{ reviewDecision isDraft reviewRequests(first:1){{ totalCount }} reviews(last:50, states:[APPROVED,CHANGES_REQUESTED]){{ nodes {{ state }} }} commits(last:1) {{ nodes {{ commit {{ statusCheckRollup {{ state }} }} }} }} }} ",
-            i, n
+            "pr{}: pullRequest(number: {}) {{ {} }} ",
+            i, n, LIST_PR_STATUS_FIELDS
         ));
     }
     q.push_str("} }");
@@ -981,48 +1239,7 @@ fn fetch_pr_ci_review_status_chunk(numbers: &[u64]) -> Result<HashMap<u64, PrCiR
     let repo = &v["data"]["repository"];
     for (i, n) in numbers.iter().enumerate() {
         let key = format!("pr{}", i);
-        let mut review = repo[&key]["reviewDecision"]
-            .as_str()
-            .map(PrReviewDecision::from_graphql_state)
-            .unwrap_or(PrReviewDecision::Unknown);
-        // Default when missing (no CI configured) → treat as passing
-        let mut ci = PrCiState::Success;
-        if let Some(nodes) = repo[&key]["commits"]["nodes"].as_array() {
-            if let Some(node) = nodes.first() {
-                if let Some(state) = node["commit"]["statusCheckRollup"]["state"].as_str() {
-                    ci = PrCiState::from_graphql_state(state);
-                }
-            }
-        }
-        if review == PrReviewDecision::Unknown {
-            // Fallback heuristic when reviewDecision is not available (e.g., no protected branch rules)
-            let mut has_changes_requested = false;
-            let mut has_approved = false;
-            if let Some(nodes) = repo[&key]["reviews"]["nodes"].as_array() {
-                for node in nodes {
-                    match node["state"].as_str().unwrap_or("") {
-                        "CHANGES_REQUESTED" => has_changes_requested = true,
-                        "APPROVED" => has_approved = true,
-                        _ => {}
-                    }
-                }
-            }
-            if has_changes_requested {
-                review = PrReviewDecision::ChangesRequested;
-            } else if has_approved {
-                review = PrReviewDecision::Approved;
-            } else {
-                review = PrReviewDecision::ReviewRequired;
-            }
-        }
-
-        out.insert(
-            *n,
-            PrCiReviewStatus {
-                ci_state: ci,
-                review_decision: review,
-            },
-        );
+        out.insert(*n, parse_pr_ci_review_status(&repo[&key]));
     }
     Ok(out)
 }
@@ -1516,10 +1733,10 @@ pub fn append_warning_to_pr(
 mod tests {
     use super::{
         fetch_merged_pr_merge_commit_oids, fetch_pr_bodies_graphql,
-        fetch_pr_issue_comment_bodies_graphql, filter_case_variant_head_search_matches,
-        filter_head_search_matches, is_resource_limit_error,
-        list_conflicting_prs_for_heads_search_exhaustive, list_exact_prs_for_heads,
-        list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
+        fetch_pr_issue_comment_bodies_graphql, fetch_read_only_pr_status,
+        filter_case_variant_head_search_matches, filter_head_search_matches,
+        is_resource_limit_error, list_conflicting_prs_for_heads_search_exhaustive,
+        list_exact_prs_for_heads, list_open_or_merged_prs_for_heads, list_open_prs_for_heads,
         list_recent_terminal_prs_for_heads, parse_open_pr_automerge_node, resolve_pr_url_head_ref,
         run_read_chunk_with_retry, select_latest_merged_pr_match, select_single_open_pr_match,
         HeadSearchPr, PrState, TerminalPrState, EXACT_HEAD_QUERY_LIMIT,
@@ -1606,6 +1823,21 @@ mod tests {
             "Resource limits for this query exceeded"
         )));
         assert!(!is_resource_limit_error(&anyhow!("different failure")));
+    }
+
+    fn init_github_query_repo() -> TempDir {
+        let repo = init_repo();
+        crate::test_support::git(
+            repo.path(),
+            [
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/spr-test.git",
+            ]
+            .as_slice(),
+        );
+        repo
     }
 
     fn install_gh_wrapper(script_body: &str) -> (TempDir, EnvVarGuard) {
@@ -1705,6 +1937,136 @@ mod tests {
             path_guard,
             log_path.display().to_string(),
         )
+    }
+
+    #[test]
+    fn read_only_status_prefers_open_and_falls_back_to_latest_merged() {
+        let _lock = lock_cwd();
+        let repo = init_github_query_repo();
+        let _guard = DirGuard::change_to(repo.path());
+        let response = json!({
+            "data": { "repository": {
+                "open0": { "nodes": [{
+                    "number": 17,
+                    "headRefName": "dank-spr/alpha",
+                    "baseRefName": "main",
+                    "state": "OPEN",
+                    "mergedAt": null,
+                    "url": "https://github.com/o/r/pull/17",
+                    "reviewDecision": "APPROVED",
+                    "reviews": { "nodes": [{ "state": "APPROVED" }] },
+                    "commits": { "nodes": [{ "commit": {
+                        "statusCheckRollup": { "state": "SUCCESS" }
+                    }}] }
+                }] },
+                "merged0": { "nodes": [{
+                    "number": 16,
+                    "headRefName": "dank-spr/alpha",
+                    "baseRefName": "main",
+                    "state": "MERGED",
+                    "mergedAt": "2026-01-01T00:00:00Z",
+                    "url": "https://github.com/o/r/pull/16"
+                }] },
+                "open1": { "nodes": [] },
+                "merged1": { "nodes": [
+                    {
+                        "number": 18,
+                        "headRefName": "dank-spr/beta",
+                        "baseRefName": "main",
+                        "state": "MERGED",
+                        "mergedAt": "2026-01-01T00:00:00Z",
+                        "url": "https://github.com/o/r/pull/18"
+                    },
+                    {
+                        "number": 19,
+                        "headRefName": "dank-spr/beta",
+                        "baseRefName": "main",
+                        "state": "MERGED",
+                        "mergedAt": "2026-02-01T00:00:00Z",
+                        "url": "https://github.com/o/r/pull/19"
+                    }
+                ] }
+            }}
+        })
+        .to_string();
+        let (_wrapper_dir, _data_dir, _path_guard, log_path) =
+            install_gh_number_query_wrapper(&response);
+
+        let result =
+            fetch_read_only_pr_status(&["dank-spr/alpha".to_string(), "dank-spr/beta".to_string()])
+                .unwrap();
+
+        assert_eq!(result["dank-spr/alpha"].pr.number, 17);
+        assert_eq!(result["dank-spr/alpha"].pr.state, PrState::Open);
+        assert!(result["dank-spr/alpha"].ci_review_status.is_some());
+        assert_eq!(result["dank-spr/beta"].pr.number, 19);
+        assert_eq!(result["dank-spr/beta"].pr.state, PrState::Merged);
+        assert_eq!(fs::read_to_string(log_path).unwrap().lines().count(), 1);
+    }
+
+    #[test]
+    fn read_only_status_batches_twenty_heads_in_one_request() {
+        let _lock = lock_cwd();
+        let repo = init_github_query_repo();
+        let _guard = DirGuard::change_to(repo.path());
+        let mut repository = serde_json::Map::new();
+        for index in 0..20 {
+            repository.insert(format!("open{index}"), json!({ "nodes": [] }));
+            repository.insert(format!("merged{index}"), json!({ "nodes": [] }));
+        }
+        let response = json!({ "data": { "repository": repository } }).to_string();
+        let (_wrapper_dir, _data_dir, _path_guard, log_path) =
+            install_gh_number_query_wrapper(&response);
+        let heads = (0..20)
+            .map(|index| format!("dank-spr/group-{index}"))
+            .collect::<Vec<_>>();
+
+        let result = fetch_read_only_pr_status(&heads).unwrap();
+
+        assert!(result.is_empty());
+        let requests = fs::read_to_string(log_path).unwrap();
+        assert_eq!(requests.lines().count(), 1);
+        assert!(requests.contains("open19:"));
+        assert!(requests.contains("merged19:"));
+        assert!(!requests.contains("search(query:"));
+    }
+
+    #[test]
+    fn read_only_status_degrades_to_identity_when_rich_query_fails() {
+        let _lock = lock_cwd();
+        let repo = init_github_query_repo();
+        let _guard = DirGuard::change_to(repo.path());
+        let data_dir = tempfile::tempdir().unwrap();
+        let log_path = data_dir.path().join("gh.log");
+        let response_path = data_dir.path().join("response.json");
+        fs::write(
+            &response_path,
+            json!({ "data": { "repository": {
+                "open0": { "nodes": [{
+                    "number": 17,
+                    "headRefName": "dank-spr/alpha",
+                    "baseRefName": "main",
+                    "state": "OPEN",
+                    "mergedAt": null,
+                    "url": "https://github.com/o/r/pull/17"
+                }] },
+                "merged0": { "nodes": [] }
+            }}})
+            .to_string(),
+        )
+        .unwrap();
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$*\" in\n  *reviewDecision*) echo 'rich status unavailable' >&2; exit 1 ;;\nesac\ncat \"{}\"\n",
+            log_path.display(),
+            response_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+
+        let result = fetch_read_only_pr_status(&["dank-spr/alpha".to_string()]).unwrap();
+
+        assert_eq!(result["dank-spr/alpha"].pr.number, 17);
+        assert!(result["dank-spr/alpha"].ci_review_status.is_none());
+        assert_eq!(fs::read_to_string(log_path).unwrap().lines().count(), 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,9 +81,9 @@ fn command_requires_gh(cmd: &crate::cli::Cmd) -> bool {
             .map(crate::commands::looks_like_pr_url)
             .unwrap_or(false),
         crate::cli::Cmd::Update { no_pr, .. } => !*no_pr,
-        crate::cli::Cmd::List { .. }
-        | crate::cli::Cmd::Status
-        | crate::cli::Cmd::Prep { .. }
+        crate::cli::Cmd::List { what } => !what.local(),
+        crate::cli::Cmd::Status { local } => !*local,
+        crate::cli::Cmd::Prep { .. }
         | crate::cli::Cmd::DropMergedPrefix { .. }
         | crate::cli::Cmd::Land { .. }
         | crate::cli::Cmd::RelinkPrs { .. }
@@ -310,12 +310,14 @@ fn read_only_pr_list_output(
     prefix: &str,
     ignore_tag: &str,
     local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> std::result::Result<crate::read_only_output::ReadOnlyOutput, crate::json_output::ErrorOutput> {
     match crate::commands::collect_pr_list_data_for_json(
         base,
         prefix,
         ignore_tag,
         local_pr_branch_policy,
+        local,
     ) {
         Ok(data) => Ok(crate::read_only_output::pr_list(command, data)),
         Err(crate::commands::ReadOnlyQueryError::SyntheticBranchNameCollision(collision)) => Err(
@@ -333,12 +335,14 @@ fn read_only_commit_list_output(
     prefix: &str,
     ignore_tag: &str,
     local_pr_branch_policy: crate::config::LocalPrBranchSyncPolicy,
+    local: bool,
 ) -> std::result::Result<crate::read_only_output::ReadOnlyOutput, crate::json_output::ErrorOutput> {
     match crate::commands::collect_commit_list_data_for_json(
         base,
         prefix,
         ignore_tag,
         local_pr_branch_policy,
+        local,
     ) {
         Ok(data) => Ok(crate::read_only_output::commit_list(command, data)),
         Err(crate::commands::ReadOnlyQueryError::SyntheticBranchNameCollision(collision)) => Err(
@@ -736,25 +740,28 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 Ok(CommandOutput::None)
             }
         }
-        crate::cli::Cmd::List { what, .. } => {
+        crate::cli::Cmd::List { what } => {
+            let local = what.local();
             if output_format == crate::cli::OutputFormat::Json {
                 match what {
-                    crate::cli::ListWhat::Pr => match read_only_pr_list_output(
+                    crate::cli::ListWhat::Pr { .. } => match read_only_pr_list_output(
                         crate::json_output::JsonCommand::ListPr,
                         &base,
                         &prefix,
                         &ignore_tag,
                         local_pr_branch_policy,
+                        local,
                     ) {
                         Ok(output) => Ok(CommandOutput::ReadOnly(output)),
                         Err(output) => Ok(CommandOutput::Error(output)),
                     },
-                    crate::cli::ListWhat::Commit => match read_only_commit_list_output(
+                    crate::cli::ListWhat::Commit { .. } => match read_only_commit_list_output(
                         crate::json_output::JsonCommand::ListCommit,
                         &base,
                         &prefix,
                         &ignore_tag,
                         local_pr_branch_policy,
+                        local,
                     ) {
                         Ok(output) => Ok(CommandOutput::ReadOnly(output)),
                         Err(output) => Ok(CommandOutput::Error(output)),
@@ -762,25 +769,27 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                 }
             } else {
                 match what {
-                    crate::cli::ListWhat::Pr => crate::commands::list_prs_display(
+                    crate::cli::ListWhat::Pr { .. } => crate::commands::list_prs_display(
                         &base,
                         &prefix,
                         &ignore_tag,
                         list_order,
                         local_pr_branch_policy,
+                        local,
                     )?,
-                    crate::cli::ListWhat::Commit => crate::commands::list_commits_display(
+                    crate::cli::ListWhat::Commit { .. } => crate::commands::list_commits_display(
                         &base,
                         &prefix,
                         &ignore_tag,
                         list_order,
                         local_pr_branch_policy,
+                        local,
                     )?,
                 }
                 Ok(CommandOutput::None)
             }
         }
-        crate::cli::Cmd::Status => {
+        crate::cli::Cmd::Status { local } => {
             if output_format == crate::cli::OutputFormat::Json {
                 match read_only_pr_list_output(
                     crate::json_output::JsonCommand::Status,
@@ -788,6 +797,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &prefix,
                     &ignore_tag,
                     local_pr_branch_policy,
+                    local,
                 ) {
                     Ok(output) => Ok(CommandOutput::ReadOnly(output)),
                     Err(output) => Ok(CommandOutput::Error(output)),
@@ -799,6 +809,7 @@ fn run_cli(cli: crate::cli::Cli, output_format: crate::cli::OutputFormat) -> Res
                     &ignore_tag,
                     list_order,
                     local_pr_branch_policy,
+                    local,
                 )?;
                 Ok(CommandOutput::None)
             }
@@ -1178,11 +1189,13 @@ fn json_command_for_cli(cmd: &crate::cli::Cmd) -> crate::json_output::JsonComman
         crate::cli::Cmd::Move { .. } => crate::machine_output::MachineCommand::Move,
         crate::cli::Cmd::Update { .. } => crate::machine_output::MachineCommand::Update,
         crate::cli::Cmd::Prep { .. } => crate::machine_output::MachineCommand::Prep,
-        crate::cli::Cmd::List { what, .. } => match what {
-            crate::cli::ListWhat::Pr => crate::machine_output::MachineCommand::ListPr,
-            crate::cli::ListWhat::Commit => crate::machine_output::MachineCommand::ListCommit,
+        crate::cli::Cmd::List { what } => match what {
+            crate::cli::ListWhat::Pr { .. } => crate::machine_output::MachineCommand::ListPr,
+            crate::cli::ListWhat::Commit { .. } => {
+                crate::machine_output::MachineCommand::ListCommit
+            }
         },
-        crate::cli::Cmd::Status => crate::machine_output::MachineCommand::Status,
+        crate::cli::Cmd::Status { .. } => crate::machine_output::MachineCommand::Status,
         crate::cli::Cmd::SyncLocalBranches => {
             crate::machine_output::MachineCommand::SyncLocalBranches
         }
@@ -1357,7 +1370,22 @@ mod tests {
 
     #[test]
     fn status_requires_github_cli() {
-        assert!(command_requires_gh(&crate::cli::Cmd::Status));
+        assert!(command_requires_gh(&crate::cli::Cmd::Status {
+            local: false,
+        }));
+    }
+
+    #[test]
+    fn local_list_and_status_skip_github_cli_checks() {
+        assert!(!command_requires_gh(&crate::cli::Cmd::List {
+            what: crate::cli::ListWhat::Pr { local: true },
+        }));
+        assert!(!command_requires_gh(&crate::cli::Cmd::List {
+            what: crate::cli::ListWhat::Commit { local: true },
+        }));
+        assert!(!command_requires_gh(&crate::cli::Cmd::Status {
+            local: true,
+        }));
     }
 
     #[test]
@@ -1792,15 +1820,55 @@ mod tests {
 
     fn list_json_gh_script(
         log_path: &std::path::Path,
-        open_json_path: &std::path::Path,
-        status_json_path: &std::path::Path,
+        response_json_path: &std::path::Path,
     ) -> String {
         format!(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  query_arg=\"\"\n  while [ \"$#\" -gt 0 ]; do\n    if [ \"$1\" = \"-f\" ]; then\n      query_arg=\"$2\"\n      break\n    fi\n    shift\n  done\n  case \"$query_arg\" in\n    *\"states:[OPEN]\"*)\n      cat \"{}\" ;;\n    *\"is:pr is:open head:dank-spr/alpha\"*)\n      echo '{{\"data\":{{\"pr0\":{{\"nodes\":[]}},\"pr1\":{{\"nodes\":[]}}}}}}' ;;\n    *\"pullRequest(number: 17)\"*\"pullRequest(number: 18)\"*)\n      cat \"{}\" ;;\n    *)\n      echo '{{\"data\":{{}}}}' ;;\n  esac\n  exit 0\nfi\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n  echo '[]'\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh test wrapper'\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n  cat \"{}\"\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1\n",
             log_path.display(),
-            open_json_path.display(),
-            status_json_path.display()
+            response_json_path.display()
         )
+    }
+
+    fn list_json_response() -> String {
+        serde_json::to_string(&serde_json::json!({
+            "data": {
+                "repository": {
+                    "open0": {
+                        "nodes": [{
+                            "number": 17,
+                            "headRefName": "dank-spr/alpha",
+                            "baseRefName": "main",
+                            "state": "OPEN",
+                            "mergedAt": serde_json::Value::Null,
+                            "url": "https://github.com/o/r/pull/17",
+                            "reviewDecision": "APPROVED",
+                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
+                            "commits": { "nodes": [{ "commit": {
+                                "statusCheckRollup": { "state": "SUCCESS" }
+                            }}] }
+                        }]
+                    },
+                    "merged0": { "nodes": [] },
+                    "open1": {
+                        "nodes": [{
+                            "number": 18,
+                            "headRefName": "dank-spr/beta",
+                            "baseRefName": "dank-spr/alpha",
+                            "state": "OPEN",
+                            "mergedAt": serde_json::Value::Null,
+                            "url": "https://github.com/o/r/pull/18",
+                            "reviewDecision": "REVIEW_REQUIRED",
+                            "reviews": { "nodes": [] },
+                            "commits": { "nodes": [{ "commit": {
+                                "statusCheckRollup": { "state": "PENDING" }
+                            }}] }
+                        }]
+                    },
+                    "merged1": { "nodes": [] }
+                }
+            }
+        }))
+        .unwrap()
     }
 
     #[test]
@@ -2061,81 +2129,9 @@ mod tests {
         let _restore = CurrentDirGuard::capture();
         let repo = init_local_stack_repo();
         let log_path = repo.path().join("gh.log");
-        let open_json_path = repo.path().join("gh-open.json");
-        let status_json_path = repo.path().join("gh-status.json");
-        fs::write(
-            &open_json_path,
-            serde_json::to_string(&serde_json::json!({
-                "data": {
-                    "repository": {
-                        "pr0": {
-                            "nodes": [{
-                                "number": 17,
-                                "headRefName": "dank-spr/alpha",
-                                "baseRefName": "main",
-                                "state": "OPEN",
-                                "mergedAt": serde_json::Value::Null,
-                                "closedAt": serde_json::Value::Null,
-                                "url": "https://github.com/o/r/pull/17",
-                                "autoMergeRequest": serde_json::Value::Null
-                            }]
-                        },
-                        "pr1": {
-                            "nodes": [{
-                                "number": 18,
-                                "headRefName": "dank-spr/beta",
-                                "baseRefName": "main",
-                                "state": "OPEN",
-                                "mergedAt": serde_json::Value::Null,
-                                "closedAt": serde_json::Value::Null,
-                                "url": "https://github.com/o/r/pull/18",
-                                "autoMergeRequest": serde_json::Value::Null
-                            }]
-                        }
-                    }
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        fs::write(
-            &status_json_path,
-            serde_json::to_string(&serde_json::json!({
-                "data": {
-                    "repository": {
-                        "pr0": {
-                            "reviewDecision": "APPROVED",
-                            "isDraft": false,
-                            "reviewRequests": { "totalCount": 0 },
-                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
-                            "commits": {
-                                "nodes": [{
-                                    "commit": {
-                                        "statusCheckRollup": { "state": "SUCCESS" }
-                                    }
-                                }]
-                            }
-                        },
-                        "pr1": {
-                            "reviewDecision": "REVIEW_REQUIRED",
-                            "isDraft": false,
-                            "reviewRequests": { "totalCount": 0 },
-                            "reviews": { "nodes": [] },
-                            "commits": {
-                                "nodes": [{
-                                    "commit": {
-                                        "statusCheckRollup": { "state": "PENDING" }
-                                    }
-                                }]
-                            }
-                        }
-                    }
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let response_json_path = repo.path().join("gh-list.json");
+        fs::write(&response_json_path, list_json_response()).unwrap();
+        let script = list_json_gh_script(&log_path, &response_json_path);
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
         let cli = crate::cli::Cli::try_parse_from([
             "spr",
@@ -2183,6 +2179,59 @@ mod tests {
             }
             other => panic!("unexpected command output: {:?}", other),
         }
+        let gh_log = fs::read_to_string(log_path).unwrap();
+        assert_eq!(gh_log.lines().count(), 1, "{gh_log}");
+        assert!(!gh_log.contains("search(query:"), "{gh_log}");
+    }
+
+    #[test]
+    fn run_cli_local_pr_json_never_invokes_github() {
+        let _lock = lock_cwd();
+        let _restore = CurrentDirGuard::capture();
+        let repo = init_local_stack_repo();
+        let log_path = repo.path().join("gh.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\necho 'gh must not run in local mode' >&2\nexit 1\n",
+            log_path.display()
+        );
+        let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
+        let cli = crate::cli::Cli::try_parse_from([
+            "spr",
+            "--cd",
+            repo.path().to_str().unwrap(),
+            "--base",
+            "main",
+            "--prefix",
+            "dank-spr/",
+            "list",
+            "--json",
+            "pr",
+            "--local",
+        ])
+        .unwrap();
+
+        let output = run_cli(cli, OutputFormat::Json).unwrap();
+
+        match output {
+            CommandOutput::ReadOnly(output) => match output.data {
+                ReadOnlyPayload::PrList { data } => {
+                    assert_eq!(data.groups.len(), 2);
+                    assert!(data.groups.iter().all(|group| matches!(
+                        group.remote.state,
+                        crate::commands::RemotePrState::NotQueried
+                    )));
+                    let json = serde_json::to_value(crate::read_only_output::pr_list(
+                        JsonCommand::ListPr,
+                        data,
+                    ))
+                    .unwrap();
+                    assert_eq!(json["data"]["groups"][0]["remote"]["kind"], "not_queried");
+                }
+                other => panic!("unexpected read-only payload: {other:?}"),
+            },
+            other => panic!("unexpected command output: {other:?}"),
+        }
+        assert!(!log_path.exists(), "local mode invoked gh");
     }
 
     #[test]
@@ -2196,15 +2245,13 @@ mod tests {
             ["branch", "dank-spr/alpha", &alpha_tip].as_slice(),
         );
         let log_path = repo.path().join("gh.log");
-        let open_json_path = repo.path().join("gh-open.json");
-        let status_json_path = repo.path().join("gh-status.json");
+        let response_json_path = repo.path().join("gh-list.json");
         fs::write(
-            &open_json_path,
-            "{\"data\":{\"repository\":{\"pr0\":{\"nodes\":[]},\"pr1\":{\"nodes\":[]}}}}",
+            &response_json_path,
+            "{\"data\":{\"repository\":{\"open0\":{\"nodes\":[]},\"merged0\":{\"nodes\":[]},\"open1\":{\"nodes\":[]},\"merged1\":{\"nodes\":[]}}}}",
         )
         .unwrap();
-        fs::write(&status_json_path, "{\"data\":{\"repository\":{}}}").unwrap();
-        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let script = list_json_gh_script(&log_path, &response_json_path);
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
         let cli = crate::cli::Cli::try_parse_from([
             "spr",
@@ -2316,81 +2363,9 @@ mod tests {
         let _restore = CurrentDirGuard::capture();
         let repo = init_local_stack_repo();
         let log_path = repo.path().join("gh.log");
-        let open_json_path = repo.path().join("gh-open.json");
-        let status_json_path = repo.path().join("gh-status.json");
-        fs::write(
-            &open_json_path,
-            serde_json::to_string(&serde_json::json!({
-                "data": {
-                    "repository": {
-                        "pr0": {
-                            "nodes": [{
-                                "number": 17,
-                                "headRefName": "dank-spr/alpha",
-                                "baseRefName": "main",
-                                "state": "OPEN",
-                                "mergedAt": serde_json::Value::Null,
-                                "closedAt": serde_json::Value::Null,
-                                "url": "https://github.com/o/r/pull/17",
-                                "autoMergeRequest": serde_json::Value::Null
-                            }]
-                        },
-                        "pr1": {
-                            "nodes": [{
-                                "number": 18,
-                                "headRefName": "dank-spr/beta",
-                                "baseRefName": "main",
-                                "state": "OPEN",
-                                "mergedAt": serde_json::Value::Null,
-                                "closedAt": serde_json::Value::Null,
-                                "url": "https://github.com/o/r/pull/18",
-                                "autoMergeRequest": serde_json::Value::Null
-                            }]
-                        }
-                    }
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        fs::write(
-            &status_json_path,
-            serde_json::to_string(&serde_json::json!({
-                "data": {
-                    "repository": {
-                        "pr0": {
-                            "reviewDecision": "APPROVED",
-                            "isDraft": false,
-                            "reviewRequests": { "totalCount": 0 },
-                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
-                            "commits": {
-                                "nodes": [{
-                                    "commit": {
-                                        "statusCheckRollup": { "state": "SUCCESS" }
-                                    }
-                                }]
-                            }
-                        },
-                        "pr1": {
-                            "reviewDecision": "REVIEW_REQUIRED",
-                            "isDraft": false,
-                            "reviewRequests": { "totalCount": 0 },
-                            "reviews": { "nodes": [] },
-                            "commits": {
-                                "nodes": [{
-                                    "commit": {
-                                        "statusCheckRollup": { "state": "PENDING" }
-                                    }
-                                }]
-                            }
-                        }
-                    }
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let response_json_path = repo.path().join("gh-list.json");
+        fs::write(&response_json_path, list_json_response()).unwrap();
+        let script = list_json_gh_script(&log_path, &response_json_path);
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
         let list_cli = crate::cli::Cli::try_parse_from([
             "spr",
@@ -2437,35 +2412,30 @@ mod tests {
         let _restore = CurrentDirGuard::capture();
         let repo = init_local_stack_repo();
         let log_path = repo.path().join("gh.log");
-        let open_json_path = repo.path().join("gh-open.json");
-        let status_json_path = repo.path().join("gh-status.json");
+        let response_json_path = repo.path().join("gh-list.json");
         fs::write(
-            &open_json_path,
+            &response_json_path,
             serde_json::to_string(&serde_json::json!({
                 "data": {
                     "repository": {
-                        "pr0": {
+                        "open0": {
                             "nodes": [{
                                 "number": 17,
                                 "headRefName": "dank-spr/alpha",
                                 "baseRefName": "main",
                                 "state": "OPEN",
                                 "mergedAt": serde_json::Value::Null,
-                                "closedAt": serde_json::Value::Null,
-                                "url": "https://github.com/o/r/pull/17",
-                                "autoMergeRequest": serde_json::Value::Null
+                                "url": "https://github.com/o/r/pull/17"
                             }]
                         },
-                        "pr1": {
+                        "open1": {
                             "nodes": [{
                                 "number": 18,
                                 "headRefName": "dank-spr/beta",
                                 "baseRefName": "main",
                                 "state": "OPEN",
                                 "mergedAt": serde_json::Value::Null,
-                                "closedAt": serde_json::Value::Null,
-                                "url": "https://github.com/o/r/pull/18",
-                                "autoMergeRequest": serde_json::Value::Null
+                                "url": "https://github.com/o/r/pull/18"
                             }]
                         }
                     }
@@ -2474,44 +2444,7 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        fs::write(
-            &status_json_path,
-            serde_json::to_string(&serde_json::json!({
-                "data": {
-                    "repository": {
-                        "pr0": {
-                            "reviewDecision": "APPROVED",
-                            "isDraft": false,
-                            "reviewRequests": { "totalCount": 0 },
-                            "reviews": { "nodes": [{ "state": "APPROVED" }] },
-                            "commits": {
-                                "nodes": [{
-                                    "commit": {
-                                        "statusCheckRollup": { "state": "SUCCESS" }
-                                    }
-                                }]
-                            }
-                        },
-                        "pr1": {
-                            "reviewDecision": "REVIEW_REQUIRED",
-                            "isDraft": false,
-                            "reviewRequests": { "totalCount": 0 },
-                            "reviews": { "nodes": [] },
-                            "commits": {
-                                "nodes": [{
-                                    "commit": {
-                                        "statusCheckRollup": { "state": "PENDING" }
-                                    }
-                                }]
-                            }
-                        }
-                    }
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        let script = list_json_gh_script(&log_path, &open_json_path, &status_json_path);
+        let script = list_json_gh_script(&log_path, &response_json_path);
         let (_wrapper_dir, _path_guard) = install_gh_wrapper(&script);
         let cli = crate::cli::Cli::try_parse_from([
             "spr",
@@ -2543,11 +2476,23 @@ mod tests {
                     );
                     assert_eq!(data.groups[1].stable_handle, "pr:beta");
                     assert_eq!(data.groups[1].commits[0].global_commit_index, 3);
+                    assert!(matches!(
+                        &data.groups[0].remote.state,
+                        crate::commands::RemotePrState::RemoteWithoutCiReview { url, .. }
+                            if url == "https://github.com/o/r/pull/17"
+                    ));
                 }
                 other => panic!("unexpected read-only payload: {:?}", other),
             },
             other => panic!("unexpected command output: {:?}", other),
         }
+
+        let requests = fs::read_to_string(log_path).unwrap();
+        assert_eq!(requests.lines().count(), 1);
+        assert!(requests.contains("states:[OPEN]"));
+        assert!(!requests.contains("merged0:"));
+        assert!(!requests.contains("reviewDecision"));
+        assert!(!requests.contains("search(query:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make stack inspection responsive in both offline/local workflows and normal GitHub-backed use.

## Problem

`spr list pr`, `spr list commit`, and `spr status` perform serialized GitHub lookups before showing results. Even though the local stack is already available from Git history, users who only need group boundaries or commit placement still wait for remote availability checks and API round trips.

### Motivating example

On an 18-PR stack, `spr list pr` can take roughly 1.6–3 seconds before printing anything. The command separately resolves PR identity, searches for case-variant conflicts, and loads CI/review status. Most of that delay is network latency, and the local stack remains unavailable if GitHub is slow or unreachable.

## Solution

- Add `--local` / `-l` to PR, commit, and status listings. This mode performs no GitHub CLI or API calls and clearly reports remote state as `not_queried` in JSON.
- Batch exact-head PR identity, merged fallback, CI, and review state into one GraphQL request for up to 20 groups in the default PR/status path.
- Use a lighter exact-open-head query for commit listings, which do not need merged history or status details.
- Keep exhaustive case-variant conflict detection on mutating commands, where it is a safety requirement, instead of paying that cost on every read-only listing.
- If the richer status request fails, retry identity-only and render status as unknown rather than failing the entire listing.

This reduces the expected remote path to roughly 0.6–0.9 seconds and makes local-only listing roughly 0.1–0.4 seconds, without adding stale caches.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Focused CLI, local-mode, batching, merged-fallback, and status-degradation tests
- Full suite reached 386 passing tests. One unrelated absorb integration failure reproduces on the unchanged parent snapshot; another parallel-only absorb failure passes in isolation.