### PR TITLE
fix: recover stale absorb metadata in same context

### DIFF
--- a/src/commands/owning_stack.rs
+++ b/src/commands/owning_stack.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail, Result};
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::commands::{common, rewrite_resume};
-use crate::git::git_rev_parse;
+use crate::git::{git_ref_exists_at, git_rev_parse};
 use crate::parsing::{derive_groups_between_with_ignored, Group};
 use crate::stack_metadata::{
     load_metadata_for_repo_path, verify_stack_branch_for_stack_id, PrBranchRecord,
@@ -33,17 +33,11 @@ pub fn load_recorded_owning_stack_for_candidate_groups(
     let Some(metadata) = load_metadata_for_repo_path(&repo_path)? else {
         return Ok(None);
     };
-    let stack_id = resolve_owning_stack_id(
+    let (stack_id, stack_branch) = resolve_owning_stack_target(
         &repo_path,
         &metadata,
         metadata_context,
         &selector_sequence(candidate_groups),
-    )?;
-    let stack_branch = verified_owning_stack_branch(
-        &repo_path,
-        &metadata,
-        &stack_id,
-        &metadata_context.ignore_tag,
     )?;
     let stack_head = git_rev_parse(&format!("refs/heads/{stack_branch}"))?;
     Ok(Some(ResolvedOwningStack {
@@ -112,17 +106,49 @@ fn verified_stack_branches(
         .map(|branches| branches.into_iter().flatten().collect())
 }
 
-fn resolve_owning_stack_id(
+fn recorded_stack_branch_aliases(
+    metadata: &StackMetadataFile,
+    stack_id: &StackId,
+) -> Result<BTreeSet<String>> {
+    let stack_record = metadata
+        .stacks
+        .get(stack_id)
+        .ok_or_else(|| anyhow!("recorded stack_id {} is missing stack metadata", stack_id.0))?;
+    Ok(std::iter::once(&stack_record.preferred_branch)
+        .chain(stack_record.known_branches.iter())
+        .map(|branch| branch.0.clone())
+        .collect())
+}
+
+fn ensure_stack_context_matches(
+    metadata: &StackMetadataFile,
+    stack_id: &StackId,
+    metadata_context: &RefreshMetadataContext,
+) -> Result<()> {
+    let stack_record = metadata
+        .stacks
+        .get(stack_id)
+        .ok_or_else(|| anyhow!("recorded stack_id {} is missing stack metadata", stack_id.0))?;
+    if stack_record.base != metadata_context.base || stack_record.prefix != metadata_context.prefix
+    {
+        bail!(
+            "recorded live stack {} uses base `{}` and prefix `{}`, but absorb was invoked with base `{}` and prefix `{}`; refusing to recover stack ownership across contexts",
+            stack_id.0,
+            stack_record.base,
+            stack_record.prefix,
+            metadata_context.base,
+            metadata_context.prefix
+        );
+    }
+    Ok(())
+}
+
+fn matching_verified_stack_ids(
     repo_path: &str,
     metadata: &StackMetadataFile,
     metadata_context: &RefreshMetadataContext,
     candidate_selectors: &[String],
-) -> Result<StackId> {
-    if candidate_selectors.is_empty() {
-        bail!("candidate history contains no explicit selectors to identify an owning stack");
-    }
-    live_selector_owners(metadata)?;
-
+) -> Result<BTreeSet<StackId>> {
     let mut matching_stack_ids = BTreeSet::new();
     for stack_id in metadata.stacks.keys() {
         for branch in
@@ -140,12 +166,20 @@ fn resolve_owning_stack_id(
             }
         }
     }
+    Ok(matching_stack_ids)
+}
+
+fn resolve_verified_owning_stack_target(
+    repo_path: &str,
+    metadata: &StackMetadataFile,
+    metadata_context: &RefreshMetadataContext,
+    candidate_selectors: &[String],
+) -> Result<Option<(StackId, String)>> {
+    let matching_stack_ids =
+        matching_verified_stack_ids(repo_path, metadata, metadata_context, candidate_selectors)?;
 
     if matching_stack_ids.is_empty() {
-        bail!(
-            "candidate selector prefix [{}] does not match any verified stack history",
-            candidate_selectors.join(", ")
-        );
+        return Ok(None);
     }
     if matching_stack_ids.len() > 1 {
         bail!(
@@ -158,7 +192,112 @@ fn resolve_owning_stack_id(
                 .join(", ")
         );
     }
-    Ok(matching_stack_ids.into_iter().next().unwrap())
+    let stack_id = matching_stack_ids.into_iter().next().unwrap();
+    let stack_branch =
+        verified_owning_stack_branch(repo_path, metadata, &stack_id, &metadata_context.ignore_tag)?;
+    Ok(Some((stack_id, stack_branch)))
+}
+
+fn recorded_owning_stack_id(
+    owners: &BTreeMap<String, StackId>,
+    candidate_selectors: &[String],
+) -> Result<Option<StackId>> {
+    let mut matching_stack_ids = BTreeSet::new();
+    for selector in candidate_selectors {
+        let Some(stack_id) = owners.get(selector) else {
+            return Ok(None);
+        };
+        matching_stack_ids.insert(stack_id.clone());
+    }
+
+    if matching_stack_ids.len() > 1 {
+        bail!(
+            "candidate selector prefix [{}] belongs to more than one recorded live stack: {}",
+            candidate_selectors.join(", "),
+            matching_stack_ids
+                .iter()
+                .map(|stack_id| stack_id.0.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    Ok(matching_stack_ids.into_iter().next())
+}
+
+fn resolve_stale_compatible_owning_stack_target(
+    repo_path: &str,
+    metadata: &StackMetadataFile,
+    metadata_context: &RefreshMetadataContext,
+    selector_owners: &BTreeMap<String, StackId>,
+    candidate_selectors: &[String],
+) -> Result<(StackId, String)> {
+    let Some(stack_id) = recorded_owning_stack_id(selector_owners, candidate_selectors)? else {
+        bail!(
+            "candidate selector prefix [{}] does not match any verified stack history",
+            candidate_selectors.join(", ")
+        );
+    };
+    ensure_stack_context_matches(metadata, &stack_id, metadata_context)?;
+
+    let mut matching_branches = BTreeSet::new();
+    for branch in recorded_stack_branch_aliases(metadata, &stack_id)? {
+        let branch_ref = format!("refs/heads/{branch}");
+        if !git_ref_exists_at(repo_path, &branch_ref)? {
+            continue;
+        }
+        let (_merge_base, _leading_ignored, groups) = derive_groups_between_with_ignored(
+            &metadata_context.base,
+            &branch_ref,
+            &metadata_context.ignore_tag,
+        )?;
+        if selector_sequence(&groups).starts_with(candidate_selectors) {
+            matching_branches.insert(branch);
+        }
+    }
+
+    if matching_branches.is_empty() {
+        bail!(
+            "recorded live stack {} has no stale-compatible full-stack branch for candidate selector prefix [{}]",
+            stack_id.0,
+            candidate_selectors.join(", ")
+        );
+    }
+    if matching_branches.len() > 1 {
+        bail!(
+            "recorded live stack {} has multiple stale-compatible full-stack branch aliases for candidate selector prefix [{}]: {}",
+            stack_id.0,
+            candidate_selectors.join(", "),
+            matching_branches.into_iter().collect::<Vec<_>>().join(", ")
+        );
+    }
+    Ok((stack_id, matching_branches.into_iter().next().unwrap()))
+}
+
+fn resolve_owning_stack_target(
+    repo_path: &str,
+    metadata: &StackMetadataFile,
+    metadata_context: &RefreshMetadataContext,
+    candidate_selectors: &[String],
+) -> Result<(StackId, String)> {
+    if candidate_selectors.is_empty() {
+        bail!("candidate history contains no explicit selectors to identify an owning stack");
+    }
+    let selector_owners = live_selector_owners(metadata)?;
+    if let Some(target) = resolve_verified_owning_stack_target(
+        repo_path,
+        metadata,
+        metadata_context,
+        candidate_selectors,
+    )? {
+        return Ok(target);
+    }
+    resolve_stale_compatible_owning_stack_target(
+        repo_path,
+        metadata,
+        metadata_context,
+        &selector_owners,
+        candidate_selectors,
+    )
 }
 
 fn verified_owning_stack_branch(

--- a/tests/global_json.rs
+++ b/tests/global_json.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -83,6 +83,177 @@ fn assert_alpha_remote_exists(repo: &Path) {
     )
     .trim()
     .is_empty());
+}
+
+fn commit_file(repo: &Path, file: &str, contents: &str, message: &str) {
+    fs::write(repo.join(file), contents).unwrap();
+    git(repo, ["add", file].as_slice());
+    git(repo, ["commit", "-m", message].as_slice());
+}
+
+fn stack_metadata_path(repo: &Path) -> PathBuf {
+    let git_common_dir = git(repo, ["rev-parse", "--git-common-dir"].as_slice());
+    let git_common_dir = git_common_dir.trim();
+    let git_common_path = Path::new(git_common_dir);
+    let git_common_path = if git_common_path.is_absolute() {
+        git_common_path.to_path_buf()
+    } else {
+        repo.join(git_common_path)
+    };
+    git_common_path.join("spr").join("stack_metadata_v1.json")
+}
+
+fn read_stack_metadata(repo: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(stack_metadata_path(repo)).unwrap()).unwrap()
+}
+
+fn write_stack_metadata(repo: &Path, metadata: &Value) {
+    fs::write(
+        stack_metadata_path(repo),
+        serde_json::to_string_pretty(metadata).unwrap(),
+    )
+    .unwrap();
+}
+
+fn mutate_first_stack_record(
+    repo: &Path,
+    mutate: impl FnOnce(&mut serde_json::Map<String, Value>),
+) {
+    let mut metadata = read_stack_metadata(repo);
+    let stacks = metadata
+        .get_mut("stacks")
+        .and_then(Value::as_object_mut)
+        .unwrap();
+    let stack_id = stacks.keys().next().unwrap().clone();
+    let stack_record = stacks
+        .get_mut(&stack_id)
+        .and_then(Value::as_object_mut)
+        .unwrap();
+    mutate(stack_record);
+    write_stack_metadata(repo, &metadata);
+}
+
+fn init_stale_absorb_metadata_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, ["init", "-b", "main"].as_slice());
+    git(
+        &repo,
+        ["config", "user.email", "spr@example.com"].as_slice(),
+    );
+    git(&repo, ["config", "user.name", "SPR Tests"].as_slice());
+    fs::write(repo.join("README.md"), "init\n").unwrap();
+    git(&repo, ["add", "README.md"].as_slice());
+    git(&repo, ["commit", "-m", "init"].as_slice());
+    let origin = dir.path().join("origin.git");
+    git(
+        &repo,
+        ["init", "--bare", origin.to_str().unwrap()].as_slice(),
+    );
+    git(
+        &repo,
+        ["remote", "add", "origin", origin.to_str().unwrap()].as_slice(),
+    );
+    git(&repo, ["push", "-u", "origin", "main"].as_slice());
+
+    git(&repo, ["checkout", "-b", "stack"].as_slice());
+    commit_file(
+        &repo,
+        "alpha.txt",
+        "alpha-1\n",
+        "feat: alpha start pr:alpha",
+    );
+    commit_file(
+        &repo,
+        "alpha.txt",
+        "alpha-1\nalpha-2\n",
+        "feat: alpha follow-up",
+    );
+    commit_file(&repo, "beta.txt", "beta-1\n", "feat: beta start pr:beta");
+
+    let update = run_spr(&[
+        "--cd",
+        repo.to_str().unwrap(),
+        "--base",
+        "main",
+        "--prefix",
+        "dank-spr/",
+        "--local-pr-branches",
+        "create-or-update",
+        "update",
+        "--no-pr",
+        "--json",
+    ]);
+    assert!(
+        update.status.success(),
+        "spr update --no-pr failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&update.stdout),
+        String::from_utf8_lossy(&update.stderr)
+    );
+
+    git(&repo, ["checkout", "stack"].as_slice());
+    commit_file(
+        &repo,
+        "beta.txt",
+        "beta-1\nbeta-stack-drift\n",
+        "feat: beta stack drift",
+    );
+    git(&repo, ["checkout", "dank-spr/alpha"].as_slice());
+    commit_file(
+        &repo,
+        "alpha.txt",
+        "alpha-1\nalpha-2\nalpha-branch-tail\n",
+        "feat: alpha branch tail",
+    );
+    (dir, repo)
+}
+
+fn assert_absorb_changed_branches(output: std::process::Output, changed_branches: &[&str]) {
+    assert!(
+        output.status.success(),
+        "spr absorb query failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let json = stdout_json(&output);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "absorb");
+    assert_eq!(json["result"], "query");
+    assert_eq!(
+        json["data"]["changed_branches"],
+        serde_json::json!(changed_branches)
+    );
+}
+
+fn assert_absorb_completed(output: std::process::Output, destination_branch: &str) {
+    assert!(
+        output.status.success(),
+        "spr absorb failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let json = stdout_json(&output);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "absorb");
+    assert_eq!(json["result"], "completed");
+    assert_eq!(json["destination_branch"], destination_branch);
+}
+
+fn assert_absorb_json_error_contains(output: std::process::Output, expected_message: &str) {
+    assert!(!output.status.success());
+    assert!(output.stderr.is_empty());
+    let json = stdout_json(&output);
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "absorb");
+    assert_eq!(json["result"], "error");
+    assert_eq!(json["error_kind"], "internal");
+    assert!(
+        json["message"].as_str().unwrap().contains(expected_message),
+        "{json}"
+    );
 }
 
 #[test]
@@ -194,4 +365,128 @@ fn detached_update_json_reports_warning_after_pushing_branch() {
             .as_str()
             .unwrap()
             .contains("Skipping stack metadata refresh because HEAD is detached")));
+}
+
+#[test]
+fn absorb_apply_json_recovers_same_context_stale_metadata() {
+    let (_dir, repo) = init_stale_absorb_metadata_repo();
+
+    let output = run_spr(&[
+        "--cd",
+        repo.to_str().unwrap(),
+        "--base",
+        "main",
+        "--prefix",
+        "dank-spr/",
+        "absorb",
+        "--from",
+        "pr:alpha",
+        "--json",
+    ]);
+    assert_absorb_completed(output, "stack");
+    let stack_subjects = git(&repo, ["log", "--format=%s", "-5", "stack"].as_slice());
+    assert!(stack_subjects.contains("feat: alpha branch tail"));
+}
+
+#[test]
+fn absorb_query_json_recovers_same_context_stale_metadata() {
+    let (_dir, repo) = init_stale_absorb_metadata_repo();
+
+    let from_pr_branch = run_spr(&[
+        "--cd",
+        repo.to_str().unwrap(),
+        "--base",
+        "main",
+        "--prefix",
+        "dank-spr/",
+        "absorb",
+        "--from",
+        "pr:alpha",
+        "--query-changed-branches",
+        "--json",
+    ]);
+    assert_absorb_changed_branches(
+        from_pr_branch,
+        &["stack", "dank-spr/alpha", "dank-spr/beta"],
+    );
+
+    git(&repo, ["checkout", "stack"].as_slice());
+    let from_stack_branch = run_spr(&[
+        "--cd",
+        repo.to_str().unwrap(),
+        "--base",
+        "main",
+        "--prefix",
+        "dank-spr/",
+        "absorb",
+        "--from",
+        "pr:alpha",
+        "--query-changed-branches",
+        "--json",
+    ]);
+    assert_absorb_changed_branches(
+        from_stack_branch,
+        &["stack", "dank-spr/alpha", "dank-spr/beta"],
+    );
+}
+
+#[test]
+fn absorb_query_json_rejects_stale_metadata_context_mismatch() {
+    let (_dir, repo) = init_stale_absorb_metadata_repo();
+    mutate_first_stack_record(&repo, |stack_record| {
+        stack_record.insert(
+            "prefix".to_string(),
+            Value::String("other-spr/".to_string()),
+        );
+    });
+
+    let output = run_spr(&[
+        "--cd",
+        repo.to_str().unwrap(),
+        "--base",
+        "main",
+        "--prefix",
+        "dank-spr/",
+        "absorb",
+        "--from",
+        "pr:alpha",
+        "--query-changed-branches",
+        "--json",
+    ]);
+
+    assert_absorb_json_error_contains(
+        output,
+        "uses base `main` and prefix `other-spr/`, but absorb was invoked with base `main` and prefix `dank-spr/`",
+    );
+}
+
+#[test]
+fn absorb_query_json_rejects_ambiguous_stale_stack_branch_aliases() {
+    let (_dir, repo) = init_stale_absorb_metadata_repo();
+    git(&repo, ["branch", "stack-copy", "stack"].as_slice());
+    mutate_first_stack_record(&repo, |stack_record| {
+        stack_record.insert(
+            "known_branches".to_string(),
+            serde_json::json!(["stack", "stack-copy"]),
+        );
+    });
+
+    let output = run_spr(&[
+        "--cd",
+        repo.to_str().unwrap(),
+        "--base",
+        "main",
+        "--prefix",
+        "dank-spr/",
+        "absorb",
+        "--from",
+        "pr:alpha",
+        "--query-changed-branches",
+        "--json",
+    ]);
+
+    assert_absorb_json_error_contains(
+        output,
+        "multiple stale-compatible full-stack branch aliases for candidate selector prefix [pr:alpha]",
+    );
 }


### PR DESCRIPTION
## Summary

- `spr absorb --from pr:<group>` can now recover when stack metadata is stale but still points to exactly one compatible live stack in the same base and prefix context.
- The recovery path re-checks recorded stack branch aliases against live Git refs before choosing an owning stack branch.
- Context mismatch and ambiguous branch aliases remain hard errors, so absorb still halts instead of guessing when ownership is unsafe.
- Adds JSON command coverage for absorb apply/query recovery and for the rejected stale-metadata cases.

## Simplified example

Consider a stack with two groups:

```text
main
  stack: pr:alpha -> pr:beta
```

After publication, SPR records that `pr:alpha` and `pr:beta` belong to the `stack` branch. Later, local history changes enough that the recorded `stack` metadata no longer verifies as an exact full-stack match, but the live branch still exists and still starts with the same selector sequence:

```text
stack still starts with: pr:alpha -> pr:beta
dank-spr/alpha has a new tail commit that should be absorbed
```

Before this change, running:

```text
spr --base main --prefix dank-spr/ absorb --from pr:alpha --json
```

could fail before planning with an ownership error like:

```text
candidate selector prefix [pr:alpha] does not match any verified stack history
```

The failure happened because absorb only accepted stack ownership proven by currently verified full-stack metadata. In this case, the strict verification had gone stale even though the recorded selector ownership, command context, and live branch refs still identified one compatible stack.

## How this fixes it

Absorb still tries the strict verified-stack path first. If that does not find a match, it now falls back to recorded live selector ownership only when all of these are true:

- the recorded stack uses the same base and prefix as the current command;
- the recorded branch alias still exists as a live Git ref;
- re-parsing that branch from the current base shows a selector sequence that starts with the requested absorb selector prefix;
- exactly one branch alias matches.

That lets the same-context stale-metadata case recover and absorb the per-PR branch tail into the owning stack. If the metadata belongs to a different base or prefix, or if multiple branch aliases could be the owning stack, the command still returns an error.

<!-- spr-stack:start -->
**Stack**:
- ➡ #160

⚠️ *Part of a stack created by [spr-multicommit](https://github.com/mattskl-openai/spr-multicommit). Do not merge manually using the UI - doing so may have unexpected results.*
<!-- spr-stack:end -->
